### PR TITLE
Hotfix

### DIFF
--- a/django/cantusdb_project/main_app/models/rism_siglum.py
+++ b/django/cantusdb_project/main_app/models/rism_siglum.py
@@ -1,8 +1,15 @@
 from django.db import models
-
 from main_app.models import BaseModel
 
 
 class RismSiglum(BaseModel):
+    """The `RismSiglum` model, a foreign key to the `Source` model
+    
+    The `name` attribute takes the form of Country code, a dash, an indicator of a city in uppercase, 
+    and an indicator of an institution in lower-case. 
+
+    Example: GB-Lbl stands for Great Britain, London, British Library
+    """
+
     name = models.CharField(max_length=255)
     description = models.TextField(null=True, blank=True)

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -1,7 +1,5 @@
 from django.db import models
 from main_app.models import BaseModel
-from psycopg2.extras import NumericRange
-from django.contrib.postgres.fields import IntegerRangeField
 from django.contrib.postgres.fields import JSONField
 from users.models import User
 
@@ -29,12 +27,12 @@ class Source(BaseModel):
         max_length=255,
         help_text="Full Manuscript Identification (City, Archive, Shelf-mark)",
     )
+    # the siglum field as implemented on the old Cantus is composed of both the RISM siglum and the shelfmark
+    # it is a human-readable ID for a source
     siglum = models.CharField(max_length=63, null=True, blank=True)
+    # the RISM siglum uniquely identifies a library or holding institution
     rism_siglum = models.ForeignKey(
-        "RismSiglum",
-        on_delete=models.PROTECT,
-        null=True,
-        blank=True,
+        "RismSiglum", on_delete=models.PROTECT, null=True, blank=True,
     )
     provenance = models.ForeignKey(
         "Provenance",

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -9,231 +9,170 @@
             <h3>{{ chant.incipit }}</h3>
             <dl>
                 <div class="row">
-                    <div class="col">
-                        <dt>
-                            Source
-                        </dt>
-                        <dd>
-                            <a href="{{ chant.source.get_absolute_url }}">
-                                {{ chant.source.title }}
-                            </a>
-                        </dd>
-                    </div>
+                    {% if chant.source %}
+                        <div class="col">
+                            <dt>Source</dt>
+                            <dd>
+                                <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.title }}</a>
+                            </dd>
+                        </div>
+                    {% endif %}
+
                     {% if chant.marginalia %}
-                    <div class="col">
-                        <dt>
-                            Marginalia
-                        </dt>
-                        <dd>
-                            {{ chant.marginalia }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt> Marginalia</dt>
+                            <dd>{{ chant.marginalia }}</dd>
+                        </div>
                     {% endif %}
                 </div>
 
                 <div class="row">
                     {% if chant.folio %}
-                    <div class="col">
-                        <dt>
-                            Folio
-                        </dt>
-                        <dd>
-                            {{ chant.folio }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Folio</dt>
+                            <dd>{{ chant.folio }}</dd>
+                        </div>
                     {% endif %}
-                    <div class="col">
-                        {% comment %} {% if chant.sequence_number %} {% endcomment %}
-                        <dt>
-                            Sequence
-                        </dt>
-                        <dd>
-                            {{ chant.sequence_number }}
-                        </dd>
-                        {% comment %} {% endif %} {% endcomment %}
-                    </div>
+
+                    {% if chant.sequence_number %}
+                        <div class="col">
+                            <dt>Sequence</dt>
+                            <dd>{{ chant.sequence_number }}</dd>
+                        </div>
+                    {% endif %}
                 </div>
                 
                 <div class="row">
                     {% if chant.feast %}
-                    <div class="col">
-                        <dt>
-                            Feast
-                        </dt>
-                        <dd>
-                            <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name }}</a>
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Feast</dt>
+                            <dd>
+                                <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name }}</a>
+                            </dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.office %}
-                    <div class="col">
-                        <dt>
-                            Office/Mass
-                        </dt>
-                        <dd>
-                            <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name }}</a>
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Office/Mass</dt>
+                            <dd>{{ chant.office.name }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.genre %}
-                    <div class="col">
-                        <dt>
-                            Genre
-                        </dt>
-                        <dd>
-                            <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name }}</a>
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Genre</dt>
+                            <dd>{{ chant.genre.name }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.position %}
-                    <div class="col">
-                        <dt>
-                            Position
-                        </dt>
-                        <dd>
-                            {{ chant.position }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Position</dt>
+                            <dd>{{ chant.position }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.cantus_id %}
-                    <div class="col">
-                        <dt>
-                            Cantus ID
-                        </dt>
-                        <dd>
-                            {{ chant.cantus_id }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Cantus ID</dt>
+                            <dd>{{ chant.cantus_id }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.mode %}
-                    <div class="col">
-                        <dt>
-                            Mode
-                        </dt>
-                        <dd>
-                            {{ chant.mode }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Mode</dt>
+                            <dd>{{ chant.mode }}</dd>
+                        </div>
                     {% endif %}
                 </div>
 
                 <div class="row">
                     {% if chant.finalis %}
-                    <div class="col">
-                        <dt>
-                            Finalis
-                        </dt>
-                        <dd>
-                            {{ chant.finalis }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Finalis</dt>
+                            <dd>{{ chant.finalis }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.differentia %}
-                    <div class="col">
-                        <dt>
-                            Differentia
-                        </dt>
-                        <dd>
-                            {{ chant.differentia }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Differentia</dt>
+                            <dd>{{ chant.differentia }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.addendum %}
-                    <div class="col">
-                        <dt>
-                            Addendum
-                        </dt>
-                        <dd>
-                            {{ chant.addendum }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Addendum</dt>
+                            <dd>{{ chant.addendum }}</dd>
+                        </div>
                     {% endif %}
+
                     {% if chant.extra %}
-                    <div class="col">
-                        <dt>
-                            Extra
-                        </dt>
-                        <dd>
-                            {{ chant.extra }}
-                        </dd>
-                    </div>
+                        <div class="col">
+                            <dt>Extra</dt>
+                            <dd>{{ chant.extra }}</dd>
+                        </div>
                     {% endif %}
                 </div>
 
                 {% if chant.manuscript_full_text_std_spelling %}
-                <dt>
-                    Manuscript Reading Full Text (standardized spelling)
-                </dt>
-                <dd>
-                    {{ chant.manuscript_full_text_std_spelling }}
-                </dd>
+                    <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                    <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
                 {% endif %}
+
                 {% if chant.manuscript_full_text %}
-                <dt>
-                    Manuscript Reading Full Text (MS spelling)
-                </dt>
-                <dd>
-                    {{ chant.manuscript_full_text }}
-                </dd>
+                    <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                    <dd>{{ chant.manuscript_full_text }}</dd>
                 {% endif %}
+
                 {% if chant.chant_range %}
-                <dt>
-                    Range
-                </dt>
-                <dd>
-                    <p style="font-family: volpiano; font-size:28px">
-                        {{ chant.chant_range }}
-                    </p>
-                </dd>
+                    <dt>Range</dt>
+                    <dd>
+                        <p style="font-family: volpiano; font-size:28px">{{ chant.chant_range }}</p>
+                    </dd>
                 {% endif %}
+
                 {% if chant.volpiano %}
-                <dt>
-                    Volpiano
-                </dt>
-                <dd>
-                    <p style="font-family: volpiano; font-size:28px">
-                        {{ chant.volpiano }}
-                    </p>
-                </dd>
+                    <dt>Volpiano</dt>
+                    <dd>
+                        <p style="font-family: volpiano; font-size:28px">{{ chant.volpiano }}</p>
+                    </dd>
                 {% endif %}
+
                 {% if chant.indexing_notes %}
-                <dt>
-                    Indexing Notes
-                </dt>
-                <dd>
-                    {{ chant.indexing_notes }}
-                </dd>
+                    <dt>Indexing Notes</dt>
+                    <dd>{{ chant.indexing_notes }}</dd>
                 {% endif %}
+
                 {% if chant.volpiano %}
-                <div class="row">
-                    <div class="col">
-                        <dt>
-                            Melody with text
-                        </dt>
-                        {% if chant.manuscript_syllabized_full_text %}
-                            <p><small>Syllabification is based on saved syllabized text.</small></p>
-                        {% endif %}
-                        <dd>
-                            {% for zip in syllabized_text_with_melody %}
-                                {% for syl_mel, syl_text in zip %}
-                                    <span style="float: left">
-                                        <div style="font-family: volpiano; font-size: 28px">{{ syl_mel }}</div>
-                                        <div style="font-size: 10px"><pre>{{ syl_text }}</pre></div>
-                                    </span>
+                    <div class="row">
+                        <div class="col">
+                            <dt>Melody with text</dt>
+                            {% if chant.manuscript_syllabized_full_text %}
+                                <p><small>Syllabification is based on saved syllabized text.</small></p>
+                            {% endif %}
+                            <dd>
+                                {% for zip in syllabized_text_with_melody %}
+                                    {% for syl_mel, syl_text in zip %}
+                                        <span style="float: left">
+                                            <div style="font-family: volpiano; font-size: 28px">{{ syl_mel }}</div>
+                                            <div style="font-size: 10px"><pre>{{ syl_text }}</pre></div>
+                                        </span>
+                                    {% endfor %}
                                 {% endfor %}
-                            {% endfor %}
-                        </dd>
+                            </dd>
+                        </div>
                     </div>
-                </div>
                 {% endif %}
 
                 {% if chant.image_link %}
-                <dt>
-                    Image link
-                </dt>
-                <dd>
-                    <a href="{{ chant.image_link }}" target="_blank">{{ chant.image_link }}</a>
-                </dd>
+                    <dt>Image link</dt>
+                    <dd>
+                        <a href="{{ chant.image_link }}" target="_blank">{{ chant.image_link }}</a>
+                    </dd>
                 {% endif %}
             </dl>
 
@@ -249,6 +188,7 @@
                 <a id="melodyButton" href="#" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">» Display the melodies connected with this chant</a>
                 <div id="melodyDiv"></div>        
             {% endif %}
+
             {% comment %} <br>
             <a href="" class="btn btn-primary" id="delete">Delete this Chant</a>
             <script>
@@ -256,7 +196,6 @@
                     document.getElementById("delete").href = window.location.href + '/delete';
                 }
             </script> {% endcomment %}
-
         </div>
 
         <div class="col">
@@ -271,9 +210,14 @@
                         <div class="card-header">
                             <b>Source navigation</b>
                             <br>
-                            <a href="{{ source.get_absolute_url }}"> <b>{{ source.siglum }}</b> </a>
+                            {% if source %}
+                                <a href="{{ source.get_absolute_url }}"> <b>{{ source.siglum }}</b> </a>
+                            {% else %}
+                                This chant is not associated with any source. 
+                            {% endif %}                            
                         </div>
 
+                        {% if source %}
                         <div class="card-body">
                             <small>
                                 <!--a small selector of all folios of this source-->
@@ -357,74 +301,80 @@
                                 {% endif %}
                             </small>
                         </div>
+                        {% endif %}
                     </div>
                 </div>
 
-                <div class="row">
-                    <div class="card mb-3 w-100">
-                        <div class="card-header">
-                            <!-- TODO: add proper segment link here -->
-                            <small><a href="/sources?segment={{ source.segment.id }}">
-                                    {{ source.segment.name }}</a></small>
-                            <br>
-                            {{ source.siglum }}
-                        </div>
-                        <div class=" card-body">
-                            <!-- TODO: add proper links here -->
-                            <small>
-                                {% if source.provenance.name %}
-                                Provenance: <b><a href="#" onclick="return false;">{{source.provenance.name}}</a></b>
+                {% if source %}
+                    <div class="row">
+                        <div class="card mb-3 w-100">
+                            <div class="card-header">
+                                <small><a href="/sources?segment={{ source.segment.id }}">{{ source.segment.name }}</a></small>
                                 <br>
-                                {% endif %}
-                                {% if source.date %}
-                                Date: 
-                                {% for century in source.century.all %}
-                                <b><a href="#" onclick="return false;">{{ century.name }}</a></b>
-                                {% endfor %}
-                                |
-                                <b>{{source.date|default_if_none:""}}</b>
-                                <br>
-                                {% endif %}
-                                {% if source.cursus %}
-                                Cursus: <b>{{source.cursus|default_if_none:""}}</b>
-                                <br>
-                                {% endif %}
-                                {% if source.notation.all %}
-                                Notation: <b><a href="#" onclick="return false;">{{source.notation.all.first.name}}</a></b>
-                                <br>
-                                {% endif %}
-                                {% if source.inventoried_by.all %}
-                                Inventoried by:
-                                <ul class="list-unstyled" style="margin-bottom: 0rem;">
-                                    {% for editor in source.inventoried_by.all %}
-                                    <li>
-                                        <a href={{ editor.get_absolute_url }}><b>{{editor.first_name}}
-                                            {{editor.family_name}}</b></a><br>
-                                        {{ editor.institution|default_if_none:"" }}
-                                    </li>
-                                    {% endfor %}
-                                </ul>
-                                {% endif %}
-                                {% comment %} {% if source.proofreaders.all %} {% endcomment %}
-                                    Proofreader{{source.proofreaders.all|pluralize}}:
-                                    <br>
-                                    <ul class="list-unstyled" style="margin-bottom: 0rem;">
-                                        {% for editor in source.proofreaders.all %}
-                                        <li>
-                                            <a href={{ editor.get_absolute_url }}><b>{{editor.first_name}}
-                                                {{editor.family_name}}</b></a><br>
-                                        </li>
+                                {{ source.siglum }}
+                            </div>
+                            <div class=" card-body">
+                                <small>
+                                    {% if source.provenance.name %}
+                                        Provenance: <b>{{ source.provenance.name }}</b>
+                                        <br>
+                                    {% endif %}
+
+                                    {% if source.date %}
+                                        Date: 
+                                        {% for century in source.century.all %}
+                                            <b>{{ century.name }}</b>
                                         {% endfor %}
-                                    </ul>
-                                {% comment %} {% endif %} {% endcomment %}
-                                {{source.indexing_notes|default_if_none:""}}
-                                <br>
-                                Contributor: <a href="#" onclick="return false;">CANTUS Database Administrator</a>
-                            </small>
-                        </div>
-                    </div>
+                                        |
+                                        <b>{{ source.date|default_if_none:"" }}</b>
+                                        <br>
+                                    {% endif %}
 
-                </div>
+                                    {% if source.cursus %}
+                                        Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
+                                        <br>
+                                    {% endif %}
+
+                                    {% if source.notation.all %}
+                                        Notation: <b>{{ source.notation.all.first.name }}</b>
+                                        <br>
+                                    {% endif %}
+
+                                    {% if source.inventoried_by.all %}
+                                        Inventoried by:
+                                        <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                            {% for editor in source.inventoried_by.all %}
+                                                <li>
+                                                    <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}
+                                                        {{ editor.family_name }}</b></a><br>
+                                                    {{ editor.institution|default_if_none:"" }}
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% endif %}
+
+                                    {% if source.proofreaders.all %}
+                                        Proofreader{{ source.proofreaders.all|pluralize }}:
+                                        <br>
+                                        <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                            {% for editor in source.proofreaders.all %}
+                                                <li>
+                                                    <a href={{ editor.get_absolute_url }}><b>{{editor.first_name}}
+                                                        {{editor.family_name}}</b></a><br>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% endif %}
+
+                                    {{ source.indexing_notes|default_if_none:"" }}
+                                    <br>
+                                    Contributor: <a href="#" onclick="return false;">CANTUS Database Administrator</a>
+                                </small>
+                            </div>
+                        </div>
+
+                    </div>
+                {% endif %}
             {% endwith %}
         </div>
     </div>

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -71,7 +71,10 @@ def ajax_concordance_list(request, cantus_id):
 
     concordances = list(concordance_values)
     for i, concordance in enumerate(concordances):
-        concordance["source_link"] = chants[i].source.get_absolute_url()
+        # some chants do not have a source
+        # for those chants, do not return source link
+        if chants[i].source:
+            concordance["source_link"] = chants[i].source.get_absolute_url()
         if chants[i].search_vector:
             concordance["chant_link"] = chants[i].get_absolute_url()
         else:
@@ -119,7 +122,10 @@ def ajax_melody_list(request, cantus_id):
 
     concordances = list(concordance_values)
     for i, concordance in enumerate(concordances):
-        concordance["source_link"] = chants[i].source.get_absolute_url()
+        # some chants do not have a source
+        # for those chants, do not return source link
+        if chants[i].source:
+            concordance["source_link"] = chants[i].source.get_absolute_url()
         concordance["ci_link"] = chants[i].get_ci_url()
         concordance["chant_link"] = chants[i].get_absolute_url()
         concordance["db"] = "CD"

--- a/django/cantusdb_project/static/js/chant_detail.js
+++ b/django/cantusdb_project/static/js/chant_detail.js
@@ -43,19 +43,19 @@ function loadConcordances(cantusId) {
     xhttp.onload = function () {
         const data = JSON.parse(this.response);
         concordanceDiv.innerHTML = `Displaying <b>${data.concordance_count}</b> concordances from the following databases (Cantus ID <b>${cantusId}</b>)`;
-        concordanceDiv.innerHTML += `<table id="concordanceTable" class="table table-responsive table-sm small">
+        concordanceDiv.innerHTML += `<table id="concordanceTable" class="table table-bordered table-sm small" style="table-layout: fixed; width: 100%;">
                                     <thead>
                                         <tr>
-                                            <th scope="col" class="text-wrap">Siglum</th>
-                                            <th scope="col" class="text-wrap">Folio</th>
-                                            <th scope="col" class="text-wrap">Incipit</th>
-                                            <th scope="col" class="text-wrap">Office </th>
-                                            <th scope="col" class="text-wrap">Genre </th>
-                                            <th scope="col" class="text-wrap">Position</th>
-                                            <th scope="col" class="text-wrap">Feast</th>
-                                            <th scope="col" class="text-wrap">Mode</th>
-                                            <th scope="col" class="text-wrap">Image</th>
-                                            <th scope="col" class="text-wrap">DB</th>
+                                            <th scope="col" class="text-wrap" style="width:15%">Siglum</th>
+                                            <th scope="col" class="text-wrap" style="width:5%">Folio</th>
+                                            <th scope="col" class="text-wrap" style="width:20%">Incipit</th>
+                                            <th scope="col" class="text-wrap" style="width:5%"></th>
+                                            <th scope="col" class="text-wrap" style="width:5%"></th>
+                                            <th scope="col" class="text-wrap" style="width:5%"></th>
+                                            <th scope="col" class="text-wrap" style="width:20%">Feast</th>
+                                            <th scope="col" class="text-wrap" style="width:10%">Mode</th>
+                                            <th scope="col" class="text-wrap" style="width:10%">Image</th>
+                                            <th scope="col" class="text-wrap" style="width:5%">DB</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -65,7 +65,18 @@ function loadConcordances(cantusId) {
 
         data.concordances.map(chant => {
             const newRow = table.insertRow(table.rows.length);
-            if (chant.siglum) { newRow.innerHTML += `<td class="text-wrap"><a href="${chant.source_link}" target="_blank">${chant.siglum}</a></td>` } else { newRow.innerHTML += '<td class="text-wrap"></td>' }
+            if (chant.siglum) {
+                // if the chant has a siglum, display it
+                if (chant.source_link) {
+                    // if the chant has a source, display the siglum as a hyperlink to the source page
+                    newRow.innerHTML += `<td class="text-wrap"><a href="${chant.source_link}" target="_blank">${chant.siglum}</a></td>`;
+                } else {
+                    // if the chant does not have a source, display the siglum as plain text
+                    newRow.innerHTML += `<td class="text-wrap">${chant.siglum}</td>`;
+                }
+            } else {
+                newRow.innerHTML += '<td class="text-wrap"></td>';
+            }
             if (chant.folio) { newRow.innerHTML += `<td class="text-wrap">${chant.folio}</td>` } else { newRow.innerHTML += '<td class="text-wrap"></td>' }
             if (chant.incipit) { newRow.innerHTML += `<td class="text-wrap"><a href="${chant.chant_link}" target="_blank">${chant.incipit}</a></td>` } else { newRow.innerHTML += '<td class="text-wrap"></td>' }
             if (chant.office__name) { newRow.innerHTML += `<td class="text-wrap">${chant.office__name}</td>` } else { newRow.innerHTML += '<td class="text-wrap"></td>' }
@@ -106,10 +117,10 @@ function loadMelodies(cantusId) {
     xhttp.onload = function () {
         const data = JSON.parse(this.response);
         melodyDiv.innerHTML = `Displaying <b>${data.concordance_count}</b> melodies from the following databases: `;
-        melodyDiv.innerHTML += `<table id="melodyTable" class="table table-responsive table-sm small">
+        melodyDiv.innerHTML += `<table id="melodyTable" class="table table-bordered table-sm small" style="table-layout: fixed; width: 100%;">
                                     <thead>
                                         <tr>
-                                            <th scope="col" class="text-wrap">Chant</th>
+                                            <th scope="col" class="text-wrap" style="width:20%">Chant</th>
                                             <th scope="col" class="text-wrap">Melody</th>
                                         </tr>
                                     </thead>
@@ -121,11 +132,21 @@ function loadMelodies(cantusId) {
 
         data.concordances.map(chant => {
             const newRow = table.insertRow(table.rows.length);
+            if (chant.siglum) {
+                // if the chant has a siglum, display it
+                if (chant.source_link) {
+                    // if the chant has a source, display the siglum as a hyperlink to the source page
+                    newRow.innerHTML += `<td class="text-wrap"><a href="${chant.source_link}" target="_blank">${chant.siglum}</a></td>`;
+                } else {
+                    // if the chant does not have a source, display the siglum as plain text
+                    newRow.innerHTML += `<td class="text-wrap">${chant.siglum}</td>`;
+                }
+            } else {
+                newRow.innerHTML += '<td class="text-wrap"></td>';
+            }
 
-            chantCell = newRow.insertCell();
-            melodyCell = newRow.insertCell();
-
-            if (chant.siglum) { chantCell.innerHTML += `<a href="${chant.source_link}" target="_blank"><b>${chant.siglum}</b></a>` } else { chantCell.innerHTML += '' }
+            // the first cell contains chant information
+            const chantCell = newRow.getElementsByTagName("td")[0];
             chantCell.innerHTML += '<br>';
             if (chant.folio) { chantCell.innerHTML += `${chant.folio} | ` } else { chantCell.innerHTML += '' }
             if (chant.office__name) { chantCell.innerHTML += `${chant.office__name} ` } else { chantCell.innerHTML += '' }
@@ -136,10 +157,29 @@ function loadMelodies(cantusId) {
             chantCell.innerHTML += '<br>';
             chantCell.innerHTML += `Cantus ID: <a href="${chant.ci_link}" target="_blank">${chant.cantus_id}</a>`
 
-            melodyCell.innerHTML += `<div style="font-family: volpiano; font-size:20px">${chant.volpiano}</div>`
-            melodyCell.innerHTML += '<br>'
-            if (chant.mode) { melodyCell.innerHTML += `M:<b>${chant.mode} </b>` } else { melodyCell.innerHTML += '' }
-            if (chant.manuscript_full_text_std_spelling) { melodyCell.innerHTML += `<a href="${chant.chant_link}" target="_blank">${chant.manuscript_full_text_std_spelling}</a>` } else { melodyCell.innerHTML += '' }
+            // add the second cell to the row
+            newRow.innerHTML += `<td>
+                                    <div style="font-family: volpiano; font-size: 28px; white-space: nowrap; overflow: hidden; text-overflow: clip;">
+                                        ${chant.volpiano}
+                                    </div>
+                                    <br>
+                                </td>`;
+            // the second cell contains the volpiano and text
+            const melodyCell = newRow.getElementsByTagName("td")[1];
+            if (chant.mode) {
+                melodyCell.innerHTML += `M:<b>${chant.mode} </b>`;
+            } else {
+                melodyCell.innerHTML += "";
+            }
+            if (chant.manuscript_full_text_std_spelling) {
+                melodyCell.innerHTML += `<div style="white-space: nowrap; overflow: hidden; text-overflow: clip;">
+                                            <a href="${chant.chant_link}" target="_blank">
+                                                ${chant.manuscript_full_text_std_spelling}
+                                            </a>
+                                        </div>`;
+            } else {
+                melodyCell.innerHTML += ""
+            }
         });
         // hide the "loading results" prompt after loading the data
         loadingPrompt.style.display = "none";


### PR DESCRIPTION
- Fix the attribute error thrown when loading the concordance/melody list. This error occurs when some chant in the list do not have a source. 
- General improvements to the appearance of the chant detail page and the concordance and melody tables
- Add comments about the difference between the real "RISM siglum" term and the "siglum" field as implemented in the old Cantus 