### PR TITLE
Hotfix

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -103,6 +103,15 @@
                         </div>
                     {% endif %}
 
+                    {% if chant.chant_range %}
+                        <div class="col">
+                            <dt>Range</dt>
+                            <dd>
+                                <p style="font-family: volpiano; font-size:28px">{{ chant.chant_range }}</p>
+                            </dd>
+                        </div>
+                    {% endif %}
+
                     {% if chant.addendum %}
                         <div class="col">
                             <dt>Addendum</dt>
@@ -126,13 +135,6 @@
                 {% if chant.manuscript_full_text %}
                     <dt>Manuscript Reading Full Text (MS spelling)</dt>
                     <dd>{{ chant.manuscript_full_text }}</dd>
-                {% endif %}
-
-                {% if chant.chant_range %}
-                    <dt>Range</dt>
-                    <dd>
-                        <p style="font-family: volpiano; font-size:28px">{{ chant.chant_range }}</p>
-                    </dd>
                 {% endif %}
 
                 {% if chant.volpiano %}
@@ -171,7 +173,7 @@
                 {% if chant.image_link %}
                     <dt>Image link</dt>
                     <dd>
-                        <a href="{{ chant.image_link }}" target="_blank">{{ chant.image_link }}</a>
+                        <a href="{{ chant.image_link }}" target="_blank" style="word-break: break-all">{{ chant.image_link }}</a>
                     </dd>
                 {% endif %}
             </dl>
@@ -250,7 +252,7 @@
                                     <div id="previousDiv" style="display:none">
                                         {% for feast, chants in feasts_previous_folio %}
                                             Folio: <b>{{ previous_folio }}</b> - Feast: <b>{{ feast.name }}</b>
-                                            <table class="table table-responsive table-sm small table-bordered">     
+                                            <table class="table table-sm small table-bordered">     
                                                 {% for chant in chants %}
                                                     <tr>
                                                         <td>{{ chant.sequence_number }}</td>
@@ -268,7 +270,7 @@
 
                                 {% for feast, chants in feasts_current_folio %}
                                     Folio: <b>{{ chant.folio }}</b> - Feast: <b>{{ feast.name }}</b>
-                                    <table class="table table-responsive table-sm small table-bordered">     
+                                    <table class="table table-sm small table-bordered">     
                                         {% for chant in chants %}
                                             <tr>
                                                 <td>{{ chant.sequence_number }}</td>
@@ -286,7 +288,7 @@
                                     <div id="nextDiv" style="display:none">
                                         {% for feast, chants in feasts_next_folio %}
                                             Folio: <b>{{ next_folio }}</b> - Feast: <b>{{ feast.name }}</b>
-                                            <table class="table table-responsive table-sm small table-bordered">     
+                                            <table class="table table-sm small table-bordered">     
                                                 {% for chant in chants %}
                                                     <tr>
                                                         <td>{{ chant.sequence_number }}</td>
@@ -342,7 +344,7 @@
 
                                     {% if source.inventoried_by.all %}
                                         Inventoried by:
-                                        <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                        <ul>
                                             {% for editor in source.inventoried_by.all %}
                                                 <li>
                                                     <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}
@@ -356,7 +358,7 @@
                                     {% if source.proofreaders.all %}
                                         Proofreader{{ source.proofreaders.all|pluralize }}:
                                         <br>
-                                        <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                        <ul>
                                             {% for editor in source.proofreaders.all %}
                                                 <li>
                                                     <a href={{ editor.get_absolute_url }}><b>{{editor.first_name}}

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -15,7 +15,7 @@
                     <div class="form-group m-1 col-lg">
                         <label for="sourceFilter"><small><b>Source</b></small></label>
                         <select id="sourceFilter" name="source" class="form-control custom-select custom-select-sm">
-                            <option value="">- Any -</option>
+                            {% comment %} <option value="">- Any -</option> {% endcomment %}
                             {% for source in sources %}
                                 <option value="{{ source.id }}">{{ source.siglum }}</option>
                             {% endfor %}
@@ -152,6 +152,7 @@
                             {% if next_folio %}
                                 &nbsp;<a href="{% url "chant-list" %}?source={{ source.id }}&folio={{ next_folio }}">> {{ next_folio }}</a>
                             {% endif %}                                
+                            <br>
 
                             <select name="feast" id="feastSelect">
                                 <option value="">Select a feast:</option>

--- a/django/cantusdb_project/main_app/templates/genre_list.html
+++ b/django/cantusdb_project/main_app/templates/genre_list.html
@@ -2,48 +2,38 @@
 {% load helper_tags %}
 {% block content %}
 <title>List of Genres | Cantus Manuscript Database</title>
-<script>
-    // Make sure the select components keep their values across multiple GET requests
-    // so the user can "drill down" on what they want
-    window.onload = function () {
-        choice = "{{ request.GET.mass_office }}"
-        if (choice == "Mass") {
-            $("#mass_choice").prop("checked", true);
-        } else if (choice == "Office") {
-            $("#office_choice").prop("checked", true);
-        } else {
-            $("#any_choice").prop("checked", true);
-        }
-    }
-</script>
+<script src="/static/js/genre_list.js"></script>
+
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <!-- global search bar-->
     <object align="right">
         {% include "global_search_bar.html" %}
     </object>
     <h3>List of Genres</h3>
-    <small>Displaying {{page_obj.start_index}}-{{page_obj.end_index}} of <b>{{page_obj.paginator.count}}</b></small>
+    <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}</b></small>
+    
     <form method="get">
         <p>Filter Genres:</p>
         <div class="form-row">
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" id="any_choice" name="mass_office" value="">
-                <label class="form-check-label" for="mass_choice">- Any -</label>
+                <input class="form-check-input" type="radio" id="anyChoice" name="mass_office" value="">
+                <label class="form-check-label" for="anyChoice">- Any -</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" id="mass_choice" name="mass_office" value="Mass">
-                <label class="form-check-label" for="mass_choice">Mass</label>
+                <input class="form-check-input" type="radio" id="massChoice" name="mass_office" value="Mass">
+                <label class="form-check-label" for="massChoice">Mass</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" id="office_choice" name="mass_office" value="Office">
-                <label class="form-check-label" for="office_choice">Office</label>
+                <input class="form-check-input" type="radio" id="officeChoice" name="mass_office" value="Office">
+                <label class="form-check-label" for="officeChoice">Office</label>
             </div>
             <div class="form-group m-1 col-lg">
                 <button type="submit" class="btn btn-dark btn-sm" id="btn-submit">Apply</button>
             </div>
         </div>
     </form>
-    <table class="table table-responsive table-sm small">
+
+    <table class="table table-sm small table-bordered">
         <thead>
             <tr>
                 <th scope="col" class="text-wrap">Genre</th>
@@ -53,24 +43,27 @@
         </thead>
         <tbody>
             {% for genre in genres %}
-            <tr>
-                <td class="text-wrap">
-                    <a href="{{ genre.get_absolute_url }}">{{genre.name}}</a>
-                </td>
-                <td class="text-wrap">{{ genre.description|default:""}}</td>
-                <td class="text-wrap">
-                    {{ genre.mass_office }}
-                </td>
-            </tr>
+                <tr>
+                    <td style="text-align:center">
+                        <a href="{{ genre.get_absolute_url }}"><b>{{ genre.name }}</b></a>
+                    </td>
+                    <td style="text-align:center">
+                        {{ genre.description|default:"" }}
+                    </td>
+                    <td style="text-align:center">
+                        {{ genre.mass_office }}
+                    </td>
+                </tr>
             {% endfor %}
         </tbody>
     </table>
+
     <div class="pagination">
         <span class="step-links">
             {% if page_obj.has_previous %}
-            <a href="?page=1&mass_office={{ request.GET.mass_office }}">&laquo;
-                first</a>
-            <a href="?page={{ page_obj.previous_page_number }}&mass_office={{ request.GET.mass_office }}">previous</a>
+                <a href="?page=1&mass_office={{ request.GET.mass_office }}">&laquo;
+                    first</a>
+                <a href="?page={{ page_obj.previous_page_number }}&mass_office={{ request.GET.mass_office }}">previous</a>
             {% endif %}
 
             <span class="current">
@@ -78,9 +71,9 @@
             </span>
 
             {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}&mass_office={{ request.GET.mass_office }}">next</a>
-            <a href="?page={{ page_obj.paginator.num_pages }}&mass_office={{ request.GET.mass_office }}">last
-                &raquo;</a>
+                <a href="?page={{ page_obj.next_page_number }}&mass_office={{ request.GET.mass_office }}">next</a>
+                <a href="?page={{ page_obj.paginator.num_pages }}&mass_office={{ request.GET.mass_office }}">last
+                    &raquo;</a>
             {% endif %}
         </span>
     </div>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -1,98 +1,87 @@
 {% extends "base.html" %}
 {% block content %}
 <title>{{ source.title }} | Cantus Manuscript Database</title>
-<script>
-    // function for the auto-jump of various selectors and input fields on the page
-    // the folio selector and folio-feast selector on the right half do source-wide filtering
-    // the feast selector, genre selector, and text search on the left half do folio-wide filtering
-    function setParam(param) {
-        var url = new URL("{% url 'chant-list' %}", window.location.origin);
-        url.searchParams.set("source", {{ source.id }});
-        var target = document.getElementById(event.srcElement.id).options[document.getElementById(event.srcElement.id).selectedIndex].value;
-        url.searchParams.set(param, target);
-        window.location.assign(url);
-    }
-</script>
+<script src="/static/js/source_detail.js"></script>
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-lg-8 bg-white rounded" id="long-info">
+        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
             <h3>{{ source.title }}</h3>
             <dl>
                 {% if source.siglum %}
-                <dt>Siglum</dt>
-                <dd>{{ source.siglum }}</dd>
+                    <dt>Siglum</dt>
+                    <dd>{{ source.siglum }}</dd>
                 {% endif %}
 
                 {% if source.summary %}
-                <dt>Summary</dt>
-                <dd>{{ source.summary }}</dd>
+                    <dt>Summary</dt>
+                    <dd>{{ source.summary }}</dd>
                 {% endif %}
 
                 {% if source.liturgical_occasions %}
-                <dt>Liturgical Occasions</dt>
-                <dd>{{ source.liturgical_occasions }}</dd>
+                    <dt>Liturgical Occasions</dt>
+                    <dd>{{ source.liturgical_occasions }}</dd>
                 {% endif %}
 
                 {% if source.description %}
-                <dt>Description</dt>
-                <dd>{{ source.description|safe }}</dd>
+                    <dt>Description</dt>
+                    <dd>{{ source.description|safe }}</dd>
                 {% endif %}
 
                 {% if source.selected_bibliography %}
-                <dt>Selected Bibilography</dt>
-                <dd>{{ source.selected_bibliography|safe }}</dd>
+                    <dt>Selected Bibilography</dt>
+                    <dd>{{ source.selected_bibliography|safe }}</dd>
                 {% endif %}
 
                 {% if source.indexing_notes %}
-                <dt>Notes on the Inventory</dt>
-                <dd>{{ source.indexing_notes|safe }}</dd>
+                    <dt>Notes on the Inventory</dt>
+                    <dd>{{ source.indexing_notes|safe }}</dd>
                 {% endif %}
 
                 {% if source.other_editors.all %}
-                <dt>Other Editors</dt>
-                <dd>
-                    {% for editor in source.other_editors.all %}
-                    <a href={{ editor.get_absolute_url }}>{{editor.first_name}} {{editor.family_name}}</a><br>
-                    {% endfor %}
-                </dd>
+                    <dt>Other Editors</dt>
+                    <dd>
+                        {% for editor in source.other_editors.all %}
+                        <a href={{ editor.get_absolute_url }}>{{ editor.first_name }} {{ editor.family_name }}</a><br>
+                        {% endfor %}
+                    </dd>
                 {% endif %}
 
                 {% if source.full_text_entered_by.all %}
-                <dt>Full Text Entered by</dt>
-                <dd>
-                    {% for editor in source.full_text_entered_by.all %}
-                    <a href={{ editor.get_absolute_url }}>{{editor.first_name}} {{editor.family_name}}</a><br>
-                    {% endfor %}
-                </dd>
+                    <dt>Full Text Entered by</dt>
+                    <dd>
+                        {% for editor in source.full_text_entered_by.all %}
+                        <a href={{ editor.get_absolute_url }}>{{ editor.first_name }} {{ editor.family_name }}</a><br>
+                        {% endfor %}
+                    </dd>
                 {% endif %}
 
                 {% if source.melodies_entered_by.all %}
-                <dt>Melodies Entered by</dt>
-                <dd>
-                    {% for editor in source.melodies_entered_by.all %}
-                    <a href={{ editor.get_absolute_url }}>{{editor.first_name}} {{editor.family_name}}</a><br>
-                    {% endfor %}
-                </dd>
+                    <dt>Melodies Entered by</dt>
+                    <dd>
+                        {% for editor in source.melodies_entered_by.all %}
+                        <a href={{ editor.get_absolute_url }}>{{ editor.first_name }} {{ editor.family_name }}</a><br>
+                        {% endfor %}
+                    </dd>
                 {% endif %}
 
                 {% if source.complete_inventory is not None %}
-                <dt>Complete/Partial Inventory</dt>
-                <dd>{{ source.complete_inventory|yesno:"Complete Inventory,Partial Inventory"}}</dd>
+                    <dt>Complete/Partial Inventory</dt>
+                    <dd>{{ source.complete_inventory|yesno:"Complete Inventory,Partial Inventory" }}</dd>
                 {% endif %}
 
                 {% if source.full_source is not None %}
-                <dt>Full Source/Fragment</dt>
-                <dd>{{ source.full_source|yesno:"Full Source,Fragment"}}</dd>
+                    <dt>Full Source/Fragment</dt>
+                    <dd>{{ source.full_source|yesno:"Full Source,Fragment" }}</dd>
                 {% endif %}
 
                 {% if source.fragmentarium_id is not None %}
-                <dt>Fragment ID</dt>
-                <dd>{{ source.fragmentarium_id }}</dd>
+                    <dt>Fragment ID</dt>
+                    <dd>{{ source.fragmentarium_id }}</dd>
                 {% endif %}
 
                 {% if source.dact_id is not None %}
-                <dt>DACT ID</dt>
-                <dd>{{ source.dact_id }}</dd>
+                    <dt>DACT ID</dt>
+                    <dd>{{ source.dact_id }}</dd>
                 {% endif %}
             </dl>
 
@@ -113,12 +102,12 @@
                         {% for sequence in sequences %}
                             <tr>
                                 <td class="text-wrap" style="text-align:center">
-                                    <a href="{{ source.get_absolute_url }}">{{source.siglum}}</a>
+                                    <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a>
                                     <br>
                                     <b>{{ sequence.folio }}</b>  {{ sequence.sequence }}
                                 </td>
                                 <td class="text-wrap" style="text-align:center">
-                                    <a href={{ sequence.get_absolute_url}} >{{ sequence.incipit|default:"" }}</a>
+                                    <a href={{ sequence.get_absolute_url }} >{{ sequence.incipit|default:"" }}</a>
                                 </td>
                                 <td class="text-wrap" style="text-align:center">
                                     {{ sequence.rubrics|default:"" }}
@@ -145,22 +134,20 @@
 
             <div class="row">
                 <div class="card mb-3 w-100">
-
                     <div class="card-header">
                         <h4>{{ source.siglum }}</h4>
                     </div>
-
                     <div class="card-body">
                         <small>
                             <!--a small selector of all folios of this source-->
-                            <select name="folio" id="folio-filter" class="w-30" onchange="setParam('folio')">
+                            <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
                                 <option value="">Select a folio:</option>
                                 {% for folio in folios %}
                                     <option value="{{ folio }}">{{ folio }}</option>
                                 {% endfor %}
                             </select>                              
 
-                            <select name="feast" id="feast-select" onchange="setParam('feast')">
+                            <select id="feastSelect" onchange="jumpToFeast({{ source.id }})">
                                 <option value="">Select a feast:</option>
                                 {% for folio, feast in feasts_with_folios %}
                                     <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
@@ -185,66 +172,66 @@
                             <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" target="_blank">» Analyse this manuscript (Cantus Analysis Tool)</a>
                         </small>
                     </div>    
-
                 </div>
             </div>
 
             <div class="row">
                 <div class="card mb-3 w-100">
                     <div class="card-header">
-                        <small><a href="/sources?segment={{ source.segment.id }}">
-                                {{ source.segment.name }}</a></small>
+                        <small>
+                            <a href="{% url "source-list" %}?segment={{ source.segment.id }}">{{ source.segment.name }}</a>
+                        </small>
                         <br>
                         {{ source.siglum }}
                     </div>
                     <div class=" card-body">
                         <small>
                             {% if source.provenance.name %}
-                            Provenance: <b><a href="#">{{source.provenance.name}}</a></b>
-                            <br>
+                                Provenance: <b><a href="#">{{source.provenance.name}}</a></b>
+                                <br>
                             {% endif %}
                             {% if source.date %}
-                            Date: 
-                            {% for century in source.century.all %}
-                            <b><a href="#">{{ century.name }}</a></b>
-                            {% endfor %}
-                            |
-                            <b>{{source.date|default_if_none:""}}</b>
-                            <br>
+                                Date: 
+                                {% for century in source.century.all %}
+                                    <b><a href="#">{{ century.name }}</a></b>
+                                {% endfor %}
+                                |
+                                <b>{{ source.date|default_if_none:"" }}</b>
+                                <br>
                             {% endif %}
                             {% if source.cursus %}
-                            Cursus: <b>{{source.cursus|default_if_none:""}}</b>
-                            <br>
+                                Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
+                                <br>
                             {% endif %}
                             {% if source.notation.all %}
-                            Notation: <b><a href="#">{{source.notation.all.first.name}}</a></b>
-                            <br>
+                                Notation: <b><a href="#">{{ source.notation.all.first.name }}</a></b>
+                                <br>
                             {% endif %}
                             {% if source.inventoried_by.all %}
-                            Inventoried by:
-                            <ul class="list-unstyled" style="margin-bottom: 0rem;">
-                                {% for editor in source.inventoried_by.all %}
-                                <li>
-                                    <a href={{ editor.get_absolute_url }}><b>{{editor.first_name}}
-                                        {{editor.family_name}}</b></a><br>
-                                    {{ editor.institution|default_if_none:"" }}
-                                </li>
-                                {% endfor %}
-                            </ul>
-                            {% endif %}
-                            {% comment %} {% if source.proofreaders.all %} {% endcomment %}
-                                Proofreader{{source.proofreaders.all|pluralize}}:
-                                <br>
+                                Inventoried by:
                                 <ul class="list-unstyled" style="margin-bottom: 0rem;">
-                                    {% for editor in source.proofreaders.all %}
+                                    {% for editor in source.inventoried_by.all %}
                                     <li>
-                                        <a href={{ editor.get_absolute_url }}><b>{{editor.first_name}}
-                                            {{editor.family_name}}</b></a><br>
+                                        <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}
+                                            {{ editor.family_name }}</b></a><br>
+                                        {{ editor.institution|default_if_none:"" }}
                                     </li>
                                     {% endfor %}
                                 </ul>
-                            {% comment %} {% endif %} {% endcomment %}
-                            {{source.indexing_notes|default_if_none:""}}
+                            {% endif %}
+                            {% if source.proofreaders.all %}
+                                Proofreader{{ source.proofreaders.all|pluralize }}:
+                                <br>
+                                <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                    {% for editor in source.proofreaders.all %}
+                                        <li>
+                                            <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}
+                                                {{ editor.family_name }}</b></a><br>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                            {{ source.indexing_notes|default_if_none:"" }}
                             <br>
                             Contributor: <a href="">CANTUS Database Administrator</a>
                         </small>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -2,6 +2,7 @@
 {% block content %}
 <title>{{ source.title }} | Cantus Manuscript Database</title>
 <script src="/static/js/source_detail.js"></script>
+
 <div class="container">
     <div class="row">
         <div class="mr-3 p-3 col-lg-8 bg-white rounded">
@@ -209,20 +210,20 @@
                             {% endif %}
                             {% if source.inventoried_by.all %}
                                 Inventoried by:
-                                <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                <ul>
                                     {% for editor in source.inventoried_by.all %}
-                                    <li>
-                                        <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}
-                                            {{ editor.family_name }}</b></a><br>
-                                        {{ editor.institution|default_if_none:"" }}
-                                    </li>
+                                        <li>
+                                            <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}
+                                                {{ editor.family_name }}</b></a><br>
+                                            {{ editor.institution|default_if_none:"" }}
+                                        </li>
                                     {% endfor %}
                                 </ul>
                             {% endif %}
                             {% if source.proofreaders.all %}
                                 Proofreader{{ source.proofreaders.all|pluralize }}:
                                 <br>
-                                <ul class="list-unstyled" style="margin-bottom: 0rem;">
+                                <ul>
                                     {% for editor in source.proofreaders.all %}
                                         <li>
                                             <a href={{ editor.get_absolute_url }}><b>{{ editor.first_name }}

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -2,69 +2,60 @@
 {% load helper_tags %}
 {% block content %}
 <title>Browse Sources | Cantus Manuscript Database</title>
-<script>
-    // Make sure the select components keep their values across multiple GET requests
-    // so the user can "drill down" on what they want
-    window.onload = function () {
-        $("#segment-filter").val("{{ request.GET.segment }}")
-        $("#provenance-filter").val("{{ request.GET.provenance }}")
-        $("#century-filter").val("{{ request.GET.century }}")
-        $("#full-source-filter").val("{{ request.GET.fullsource}}")
-    }
-</script>
+<script src="/static/js/source_list.js"></script>
+
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <!-- global search bar-->
     <object align="right">
         {% include "global_search_bar.html" %}
     </object>
     <h3>Browse Sources</h3>
-    <small>Displaying {{page_obj.start_index}}-{{page_obj.end_index}} of <b>{{page_obj.paginator.count}}
-            sources</b></small>
+    <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}</b> sources</small>
 
     <form method="get">
         <div class="form-row align-items-end">
             <div class="form-group m-1 col-lg">
-                <label for="segment-filter"><small>Segment</small></label>
-                <select id="segment-filter" name="segment" class="form-control custom-select custom-select-sm">
+                <label for="segmentFilter"><small>Segment</small></label>
+                <select id="segmentFilter" name="segment" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>
                     <option value="4063">CANTUS Database</option>
                     <option value="4064">Bower Sequence Database</option>
                 </select>
             </div>
             <div class="form-group m-1 col-lg">
-                <label for="general-search"><small>General search (siglum, city, description ..)</small></label>
+                <label for="generalSearch"><small>General search (siglum, city, description ..)</small></label>
                 <input type="text" class="form-control form-control-sm" name="general"
-                    placeholder="Enter any part of a word" value="{{ request.GET.general}}" id="general-search">
+                    placeholder="Enter any part of a word" value="{{ request.GET.general }}" id="generalSearch">
             </div>
             <div class="form-group m-1 col-lg">
-                <label for="indexing-search"><small>Indexing Notes</small></label>
+                <label for="indexingSearch"><small>Indexing Notes</small></label>
                 <input type="text" class="form-control form-control-sm" name="indexing"
-                    placeholder="Search for indexers, proofreaders, editors." value="{{ request.GET.indexing}}"
-                    id="indexing-search">
+                    placeholder="Search for indexers, proofreaders, editors." value="{{ request.GET.indexing }}"
+                    id="indexingSearch">
             </div>
         </div>
         <div class="form-row form-row align-items-end">
             <div class="form-group m-1 col-lg">
-                <label for="provenance-filter"><small>Provenance (origin/history)</small></label>
-                <select id="provenance-filter" name="provenance" class="form-control custom-select custom-select-sm">
+                <label for="provenanceFilter"><small>Provenance (origin/history)</small></label>
+                <select id="provenanceFilter" name="provenance" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>
                     {% for provenance in provenances %}
-                    <option value="{{provenance.id}}">{{provenance.name}}</option>
+                        <option value="{{ provenance.id }}">{{ provenance.name }}</option>
                     {% endfor %}
                 </select>
             </div>
             <div class="form-group m-1 col-lg">
-                <label for="century-filter"><small>Century</small></label>
-                <select id="century-filter" name="century" class="form-control custom-select custom-select-sm">
+                <label for="centuryFilter"><small>Century</small></label>
+                <select id="centuryFilter" name="century" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>
                     {% for century in centuries %}
-                    <option value="{{century.id}}">{{century.name}}</option>
+                        <option value="{{ century.id }}">{{ century.name }}</option>
                     {% endfor %}
                 </select>
             </div>
             <div class="form-group m-1 col-lg">
-                <label for="full-source-filter"><small>Full source/Fragment</small></label>
-                <select class="form-control custom-select custom-select-sm" id="full-source-filter" name="fullsource">
+                <label for="fullSourceFilter"><small>Full source/Fragment</small></label>
+                <select id="fullSourceFilter"  name="fullSource" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>
                     <option value="true">Complete source</option>
                     <option value="false">Fragment</option>
@@ -77,7 +68,7 @@
         </div>
     </form>
 
-    <table class="table table-responsive table-sm small table-bordered">
+    <table class="table table-sm small table-bordered">
         <thead>
             <tr>
                 <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
@@ -89,38 +80,39 @@
         </thead>
         <tbody>
             {% for source in sources %}
-            <tr>
-                <td class="text-wrap" style="text-align:center">
-                    <a href="{{ source.get_absolute_url }}">{{source.siglum}}</a>
-                </td>
-                <td class="text-wrap" style="text-align:center">
-                    {{ source.summary|default:""|truncatechars_html:140 }}
-                </td>
-                <td class="text-wrap" style="text-align:center">
-                    {{ source.century.all.first.name }}<br>
-                    {{ source.provenance.name|default:""}}
-                </td>
-                <td class="text-wrap" style="text-align:center">
-                    {% if source.image_link %}
-                    <a href="{{ source.image_link }}" target="_blank">Images</a>
-                    {% endif %}
-                </td>
-                <td class="text-wrap" style="text-align:center">
-                    <b>{{ source.number_of_chants }}</b>
-                    {% if source.number_of_melodies %}
-                        <br>/ {{ source.number_of_melodies }}
-                    {% endif %}
-                </td>
-            </tr>
+                <tr>
+                    <td class="text-wrap" style="text-align:center">
+                        <a href="{{ source.get_absolute_url }}"><b>{{ source.siglum }}</b></a>
+                    </td>
+                    <td class="text-wrap" style="text-align:center">
+                        {{ source.summary|default:""|truncatechars_html:140 }}
+                    </td>
+                    <td class="text-wrap" style="text-align:center">
+                        {{ source.century.all.first.name }}<br>
+                        {{ source.provenance.name|default:"" }}
+                    </td>
+                    <td class="text-wrap" style="text-align:center">
+                        {% if source.image_link %}
+                            <a href="{{ source.image_link }}" target="_blank">Images</a>
+                        {% endif %}
+                    </td>
+                    <td class="text-wrap" style="text-align:center">
+                        <b>{{ source.number_of_chants }}</b>
+                        {% if source.number_of_melodies %}
+                            <br>/ {{ source.number_of_melodies }}
+                        {% endif %}
+                    </td>
+                </tr>
             {% endfor %}
         </tbody>
     </table>
+
     <div class="pagination">
         <span class="step-links">
             {% if page_obj.has_previous %}
-            <a href="?{% url_add_get_params page=1%}">&laquo;
-                first</a>
-            <a href="?{% url_add_get_params page=page_obj.previous_page_number %}">previous</a>
+                <a href="?{% url_add_get_params page=1 %}">&laquo;
+                    first</a>
+                <a href="?{% url_add_get_params page=page_obj.previous_page_number %}">previous</a>
             {% endif %}
 
             <span class="current">
@@ -128,9 +120,9 @@
             </span>
 
             {% if page_obj.has_next %}
-            <a href="?{% url_add_get_params page=page_obj.next_page_number %}">next</a>
-            <a href="?{% url_add_get_params page=page_obj.paginator.num_pages %}">last
-                &raquo;</a>
+                <a href="?{% url_add_get_params page=page_obj.next_page_number %}">next</a>
+                <a href="?{% url_add_get_params page=page_obj.paginator.num_pages %}">last
+                    &raquo;</a>
             {% endif %}
         </span>
     </div>

--- a/django/cantusdb_project/main_app/views/genre.py
+++ b/django/cantusdb_project/main_app/views/genre.py
@@ -75,15 +75,13 @@ class GenreDetailView(SingleObjectMixin, ListView):
 
 class GenreListView(SearchableListMixin, ListView):
     model = Genre
-    queryset = Genre.objects.all().order_by("name")
-    # search_fields = ["name"]
     paginate_by = 100
     context_object_name = "genres"
     template_name = "genre_list.html"
 
     def get_queryset(self):
+        queryset = super().get_queryset()
         mass_office = self.request.GET.get("mass_office", None)
         if mass_office in ["Mass", "Office", "Old Hispanic"]:
-            queryset = super().get_queryset().filter(mass_office__contains=mass_office)
-            return queryset
-        return super().get_queryset()
+            queryset = queryset.filter(mass_office__contains=mass_office)
+        return queryset.order_by("name")

--- a/django/cantusdb_project/static/js/genre_list.js
+++ b/django/cantusdb_project/static/js/genre_list.js
@@ -1,0 +1,20 @@
+window.onload = function () {
+    // check the correct radio button according to the GET parameter
+    const anyChoice = document.getElementById("anyChoice");
+    const massChoice = document.getElementById("massChoice");
+    const officeChoice = document.getElementById("officeChoice");
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const massOffice = urlParams.get("mass_office");
+
+    switch (massOffice) {
+        case "Mass":
+            massChoice.checked = true;
+            break;
+        case "Office":
+            officeChoice.checked = true;
+            break;
+        default:
+            anyChoice.checked = true;
+    }
+}

--- a/django/cantusdb_project/static/js/source_detail.js
+++ b/django/cantusdb_project/static/js/source_detail.js
@@ -1,0 +1,19 @@
+// on selecting an option in the folio selector or feast selector, 
+// jump to the browse chants page with pre-filled source and folio/feast info
+function jumpToFolio(sourceId) {
+    const folioSelect = document.getElementById("folioSelect");
+    const url = new URL("chants/", window.location.origin);
+    const folio = folioSelect.options[folioSelect.selectedIndex].value;
+    url.searchParams.set("source", sourceId);
+    url.searchParams.set("folio", folio);
+    window.location.assign(url);
+}
+
+function jumpToFeast(sourceId) {
+    const feastSelect = document.getElementById("feastSelect");
+    const url = new URL("chants/", window.location.origin);
+    const feast = feastSelect.options[feastSelect.selectedIndex].value;
+    url.searchParams.set("source", sourceId);
+    url.searchParams.set("feast", feast);
+    window.location.assign(url);
+}

--- a/django/cantusdb_project/static/js/source_list.js
+++ b/django/cantusdb_project/static/js/source_list.js
@@ -1,0 +1,22 @@
+window.onload = function () {
+    // Make sure the select components keep their values across multiple GET requests
+    // so the user can "drill down" on what they want
+    const segmentFilter = document.getElementById("segmentFilter");
+    const provenanceFilter = document.getElementById("provenanceFilter");
+    const centuryFilter = document.getElementById("centuryFilter");
+    const fullSourceFilter = document.getElementById("fullSourceFilter");
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has("segment")) {
+        segmentFilter.value = urlParams.get("segment");
+    }
+    if (urlParams.has("provenance")) {
+        provenanceFilter.value = urlParams.get("provenance");
+    }
+    if (urlParams.has("century")) {
+        centuryFilter.value = urlParams.get("century");
+    }
+    if (urlParams.has("fullSource")) {
+        fullSourceFilter.value = urlParams.get("fullSource");
+    }
+}


### PR DESCRIPTION
Some chants don't have an associated feast. In some sources, none of the chants has a feast. This causes an attribute error when referencing `chant.feast` for the feast selector on the source detail page and chant list page. After this fix, sources that have no feasts will have no options displayed in the feast selector, instead of throwing an attribute error. 