### PR TITLE
Implement JSON export feature

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_input.py
+++ b/django/cantusdb_project/main_app/tests/test_input.py
@@ -13,6 +13,9 @@ from .make_fakes import *
 
 fake = Faker()
 
+# test_input (this file) is out of date and should not be run.
+# Instead, run test_views_general and test_models.
+
 """
 run tests with 'python manage.py test main_app'
 it creates a special database for the purpose of testing

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -17,6 +17,10 @@ from main_app.views import (
 
 from . import make_fakes
 
+
+# test_views (this file) is out of date and should not be run.
+# Instead, run test_views_general and test_models.
+
 fake = Faker()
 
 

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from main_app.views.feast import FeastListView
 from .make_fakes import *
 
-# run with `python -Wa manage.py test main_app.tests.test_views_genral`
+# run with `python -Wa manage.py test main_app.tests.test_views_general`
 # the -Wa flag tells Python to display deprecation warnings
 
 

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -43,6 +43,11 @@ urlpatterns = [
     path("ajax/melody/<str:cantus_id>", views.ajax_melody_list, name="ajax_melody"),
     path("ajax/melody-search/", views.ajax_melody_search, name="ajax_melody_search",),
     path("csv/<str:source_id>", views.csv_export, name="csv-export"),
+    path(
+        "json-melody/<str:cantus_id>",
+        views.json_melody_export,
+        name="json_melody_export",
+    ),
     path("index/", FullIndexView.as_view(), name="chant-index"),
     path("contact/", views.contact_us, name="contact"),
     path(

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -55,4 +55,5 @@ urlpatterns = [
         views.ajax_search_bar,
         name="ajax_search_bar",
     ),
+    path("json-sources/", views.json_sources_export, name="json-sources-export"),
 ]

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -56,4 +56,5 @@ urlpatterns = [
         name="ajax_search_bar",
     ),
     path("json-sources/", views.json_sources_export, name="json-sources-export"),
+    path("json-node/<str:id>", views.json_node_export, name="json-node-export"),
 ]

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -362,6 +362,7 @@ def ajax_melody_search(request):
     for result in results:
         # construct the url for chant detail page and add it to the result
         result["chant_link"] = reverse("chant-detail", args=[result["id"]])
+
     result_count = result_values.count()
     return JsonResponse({"results": results, "result_count": result_count}, safe=True)
 
@@ -464,6 +465,19 @@ def json_melody_export(request, cantus_id):
     
     return JsonResponse(standardized_chants_values, safe=False)
 
+def json_node_export(request, id):
+    """
+    returns all fields of the chant/source with the specified `id`
+    """
+    pass
 
-            
+def json_sources_export(request):
+    """
+    generates a json object of published sources with their IDs and CSV links
+    """
+    sources = Source.objects.all()
+    ids = [source.id for source in sources]
+    csv_links = {id: request.build_absolute_uri(reverse("csv-export", args=[id])) for id in ids}
+
+    return JsonResponse(csv_links)
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1,4 +1,5 @@
 import csv
+from multiprocessing.sharedctypes import Value
 from django.http.response import HttpResponseRedirect, JsonResponse
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -465,11 +466,22 @@ def json_melody_export(request, cantus_id):
     
     return JsonResponse(standardized_chants_values, safe=False)
 
+
 def json_node_export(request, id):
     """
     returns all fields of the chant/source with the specified `id`
     """
-    pass
+    chant = Chant.objects.filter(id=id)
+    source = Source.objects.filter(id=id)
+    if chant and source:
+        raise ValueError("id is associated with both a chant and a source")
+    elif not chant and not source:
+        raise ValueError("id is associated with neither a chant nor a source")
+    chant_or_source = chant if chant else source
+    vals = dict(*chant_or_source.values())
+
+    return JsonResponse(vals)
+
 
 def json_sources_export(request):
     """


### PR DESCRIPTION
Fixes #94 

Wrote three views—`standardize_for_api`, `json_node_export` and `json_sources_export`—implementing API functionality present in old Cantus Database.