### PR TITLE
added the my-sources page + fixed a bug with chant-edit

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -26,7 +26,9 @@ MEDIA_ROOT = os.getenv("CANTUSDB_MEDIA_ROOT")
 SECRET_KEY = os.getenv("CANTUSDB_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(strtobool(os.getenv("CANTUSDB_DEBUG", "False")))
+DEBUG = False
+# need to set this to false so that we can display the custom 404 page
+# default: DEBUG = bool(strtobool(os.getenv("CANTUSDB_DEBUG", "False")))
 
 ALLOWED_HOSTS = [os.getenv("CANTUSDB_HOSTS")]
 

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -26,9 +26,8 @@ MEDIA_ROOT = os.getenv("CANTUSDB_MEDIA_ROOT")
 SECRET_KEY = os.getenv("CANTUSDB_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = bool(strtobool(os.getenv("CANTUSDB_DEBUG", "False")))
 # need to set this to false so that we can display the custom 404 page
-# default: DEBUG = bool(strtobool(os.getenv("CANTUSDB_DEBUG", "False")))
 
 ALLOWED_HOSTS = [os.getenv("CANTUSDB_HOSTS")]
 

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from .models import Chant, Office, Genre, Feast, Source, RismSiglum, Provenance, Century, Indexer
 from .widgets import *
+from django.contrib.auth import get_user_model
 
 # ModelForm allows to build a form directly from a model
 # see https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/
@@ -196,7 +197,7 @@ class SourceCreateForm(forms.ModelForm):
     century.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     current_editors = forms.ModelMultipleChoiceField(
-        queryset=Indexer.objects.all().order_by("family_name"), required=False
+        queryset=get_user_model().objects.all().order_by("last_name"), required=False
     )
     current_editors.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -1,6 +1,6 @@
 from django.db import models
 from main_app.models import BaseModel
-from users.models import User
+from django.contrib.auth import get_user_model
 
 
 class Source(BaseModel):
@@ -60,7 +60,7 @@ class Source(BaseModel):
         blank=True, null=True, choices=cursus_choices, max_length=63
     )
     # TODO: Fill this field up with JSON info when I have access to the Users
-    current_editors = models.ManyToManyField(User, related_name="sources_edited")
+    current_editors = models.ManyToManyField(get_user_model(), related_name="sources_edited")
     inventoried_by = models.ManyToManyField(
         "Indexer", related_name="sources_inventoried"
     )

--- a/django/cantusdb_project/main_app/templates/404.html
+++ b/django/cantusdb_project/main_app/templates/404.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="mr-3 p-3 col-md-8 bg-white rounded">
+            <h3>404</h3>
+            <h5>Page not found</h5>
+            <br>
+            <dl>
+                <dd>{{ exception }}</dd>
+            </dl> 
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% load helper_tags %}
+{% block content %}
+<title>My Sources | Cantus Manuscript Database</title>
+<div class="container">
+    <div class="row">
+        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+            <h3>My Sources</h3>
+            <a href="{% url "source-create" %}">+ Add new source</a>
+            {% if sources %}
+                <table class="table table-sm small table-bordered">
+                    <tbody>
+                        {% for source in sources %}
+                            <tr>
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{% url "source-detail" source.pk %}">
+                                        {{ source.title }}
+                                    </a>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{% url "source-edit-volpiano" source.pk %}">
+                                        Full text &amp; volpiano editor
+                                    </a>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{% url "source-detail" source.pk %}">
+                                        Proofreading form
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}        
+        </div>
+        <div class="col p-0">
+            <!-- global search bar-->
+            {% include "global_search_bar.html" %}
+            <div class="card mb-3 w-100">
+                <div class="card-header">
+                    <h4>Sources created by user</h4>
+                </div>
+                <div class="card-body">
+                    <a href="{% url "source-create" %}">+ Add new source</a>
+                </div>    
+            </div>    
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -4,7 +4,7 @@ from main_app.views import views
 from main_app.views.source import SourceCreateView
 from main_app.views.chant import ChantEditVolpianoView
 from django.contrib.auth import views as auth_views
-from main_app.views.user import UserDetailView
+from main_app.views.user import UserDetailView, UserSourceListView
 
 urlpatterns = [
     path("indexers/", IndexerListView.as_view(), name="indexer-list"),
@@ -71,6 +71,9 @@ urlpatterns = [
         name="source-edit-volpiano"
     ),
     path("users/<int:user_id>", UserDetailView.as_view(), name="user-detail"),
+    path("my-sources/", UserSourceListView.as_view(), name="my-sources"),
     path('login/', auth_views.LoginView.as_view(redirect_authenticated_user=True), name="login"),
     path('logout/', views.CustomLogoutView.as_view(), name="logout")
 ]
+
+handler404 = 'main_app.views.views.handle404'

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -19,6 +19,7 @@ from main_app.forms import ChantCreateForm, ChantEditForm
 from main_app.models import Chant, Feast, Genre, Source, Sequence
 from align_text_mel import *
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
 
 
 def keyword_search(queryset: QuerySet, keywords: str) -> QuerySet:
@@ -858,6 +859,8 @@ class ChantEditVolpianoView(LoginRequiredMixin, UpdateView):
     
     def get_object(self):
         queryset = self.get_queryset()
+        if len(queryset) == 0:
+            raise Http404("There are no chants associated with this source to edit")
         pk = self.request.GET.get("pk")
         # if a pk is not specified, we will not render the update form, rather we will render the instructions page
         if not pk:

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -68,7 +68,7 @@ class SourceDetailView(DetailView):
         source = self.get_object()
         context = super().get_context_data(**kwargs)
 
-        if source.segment.id == 4064:
+        if source.segment and source.segment.id == 4064:
             # if this is a sequence source
             context["sequences"] = source.sequence_set.all().order_by("sequence")
             context["folios"] = (

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -1,5 +1,10 @@
+from urllib import request
 from django.views.generic import DetailView
 from django.contrib.auth import get_user_model
+from main_app.models import Source
+from django.views.generic import ListView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Q
 
 class UserDetailView(DetailView):
     """Detail view for User model
@@ -11,3 +16,19 @@ class UserDetailView(DetailView):
     context_object_name = "user"
     template_name = "user_detail.html"
     pk_url_kwarg = 'user_id'	
+
+class UserSourceListView(LoginRequiredMixin, ListView):
+    model = Source
+    context_object_name = "sources"
+    template_name = "user_source_list.html"
+
+    def get_queryset(self):
+        return Source.objects.filter(
+            Q(current_editors=self.request.user) 
+            # |
+            # Q(inventoried_by=self.request.user) |
+            # Q(full_text_entered_by=self.request.user) |
+            # Q(melodies_entered_by=self.request.user) |
+            # Q(proofreaders=self.request.user) |
+            # Q(other_editors=self.request.user) 
+        ).order_by("title")

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -516,3 +516,6 @@ class CustomLogoutView(LogoutView):
             'You have successfully logged out!'
         )
         return next_page
+
+def handle404(request, exception):
+    return render(request, "404.html")


### PR DESCRIPTION
Fixes #100

The "Proofreading form" hyperlink currently redirects the user to the source detail page, as we don't know how to implement the "Proofreading form" yet.

Also fixed a bug in chant-edit where if the `get_queryset` method of the view returned an empty set (aka if the source does not have any chants associated with it), the page would crash. Now, we return a 404 error with an exception stating that there are no chants to edit.

UPDATE: 
Added another commit to revert back to the original setting of `DEBUG`. To be able to display the custom 404 error page during development, we would have to set `DEBUG=False`. However, this is not ideal, so we can set `DEBUG=False` when it comes time to deploy.