### PR TITLE
making the manytomany fields not required again for source-create

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -192,17 +192,17 @@ class SourceCreateForm(forms.ModelForm):
     full_source.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     century = forms.ModelMultipleChoiceField(
-        queryset=Century.objects.all().order_by("name")
+        queryset=Century.objects.all().order_by("name"), required=False
     )
     century.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     current_editors = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("last_name")
+        queryset=get_user_model().objects.all().order_by("last_name"), required=False
     )
     current_editors.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     melodies_entered_by = forms.ModelMultipleChoiceField(
-        queryset=Indexer.objects.all().order_by("family_name")
+        queryset=Indexer.objects.all().order_by("family_name"), required=False
     )
     melodies_entered_by.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 


### PR DESCRIPTION
reverting my mistake where I made the ManyToMany fields required, when they don't need to be.