### PR TITLE
Update _-detail views to use the singular

### DIFF
--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -8,17 +8,17 @@ from main_app.views.user import UserDetailView, UserSourceListView
 
 urlpatterns = [
     path("indexers/", IndexerListView.as_view(), name="indexer-list"),
-    path("indexers/<int:pk>", IndexerDetailView.as_view(), name="indexer-detail"),
+    path("indexer/<int:pk>", IndexerDetailView.as_view(), name="indexer-detail"),
     path("feasts/", FeastListView.as_view(), name="feast-list"),
-    path("feasts/<int:pk>", FeastDetailView.as_view(), name="feast-detail"),
+    path("feast/<int:pk>", FeastDetailView.as_view(), name="feast-detail"),
     path("genres/", GenreListView.as_view(), name="genre-list"),
-    path("genres/<int:pk>", GenreDetailView.as_view(), name="genre-detail"),
+    path("genre/<int:pk>", GenreDetailView.as_view(), name="genre-detail"),
     path("offices/", OfficeListView.as_view(), name="office-list"),
-    path("offices/<int:pk>", OfficeDetailView.as_view(), name="office-detail"),
+    path("office/<int:pk>", OfficeDetailView.as_view(), name="office-detail"),
     path("sources/", SourceListView.as_view(), name="source-list"),
-    path("sources/<int:pk>", SourceDetailView.as_view(), name="source-detail"),
+    path("source/<int:pk>", SourceDetailView.as_view(), name="source-detail"),
     path("chants/", ChantListView.as_view(), name="chant-list"),
-    path("chants/<int:pk>", ChantDetailView.as_view(), name="chant-detail"),
+    path("chant/<int:pk>", ChantDetailView.as_view(), name="chant-detail"),
     path("chant-search/", ChantSearchView.as_view(), name="chant-search"),
     path("melody/", MelodySearchView.as_view(), name="melody-search"),
     path(
@@ -31,7 +31,7 @@ urlpatterns = [
     ),
     path("chant-update/<int:pk>", ChantUpdateView.as_view(), name="chant-update"),
     path("sequences/", SequenceListView.as_view(), name="sequence-list"),
-    path("sequences/<int:pk>", SequenceDetailView.as_view(), name="sequence-detail",),
+    path("sequence/<int:pk>", SequenceDetailView.as_view(), name="sequence-detail",),
     path(
         "id/<str:cantus_id>", ChantByCantusIDView.as_view(), name="chant-by-cantus-id"
     ),


### PR DESCRIPTION
change indexer, genre, office, source, chant, sequence detail pages to use the singular form of the model in their url