### PR TITLE
truncate fulltexts of suggested chants on chant-create page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -245,7 +245,7 @@
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}
                                     <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid }}()"></input>
-                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext }} (<strong>{{ chant.count }}x</strong>)<br>
+                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext|truncatechars:100 }} (<strong>{{ chant.count }}x</strong>)<br>
                                     <script>
                                         function autoFill{{ chant.cid }}() {
                                             const genreId = Array.prototype.find.call(document.getElementById('id_genre').children, ({ textContent }) => textContent === "{{ chant.genre }}");

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -113,8 +113,19 @@
 
                     <div class="form-group m-1 col-lg-5">
                         <small>{{ form.feast.label_tag }}</small>
-                        {{ form.feast }}
                     </div>
+
+                    <p>
+                        <small>
+                            {% if previous_chant %}
+                                Feasts that follow:
+                                {% for feast in suggested_feasts %}
+                                    <a href="{# something to do with the feast's ID - maybe calls some js to change the feast datalist above? #}">
+                                        {{feast.name}}</a> ({{feast.count}}x) |
+                                {% endfor %}
+                            {% endif %}
+                        </small>
+                    </p>
                     
                 </div>
 
@@ -245,7 +256,7 @@
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}
                                     <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid }}()"></input>
-                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext }} (<strong>{{ chant.count }}x</strong>)<br>
+                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext|truncatechars:100 }} (<strong>{{ chant.count }}x</strong>)<br>
                                     <script>
                                         function autoFill{{ chant.cid }}() {
                                             const genreId = Array.prototype.find.call(document.getElementById('id_genre').children, ({ textContent }) => textContent === "{{ chant.genre }}");

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -113,19 +113,8 @@
 
                     <div class="form-group m-1 col-lg-5">
                         <small>{{ form.feast.label_tag }}</small>
+                        {{ form.feast }}
                     </div>
-
-                    <p>
-                        <small>
-                            {% if previous_chant %}
-                                Feasts that follow:
-                                {% for feast in suggested_feasts %}
-                                    <a href="{# something to do with the feast's ID - maybe calls some js to change the feast datalist above? #}">
-                                        {{feast.name}}</a> ({{feast.count}}x) |
-                                {% endfor %}
-                            {% endif %}
-                        </small>
-                    </p>
                     
                 </div>
 
@@ -256,7 +245,7 @@
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}
                                     <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid }}()"></input>
-                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext|truncatechars:100 }} (<strong>{{ chant.count }}x</strong>)<br>
+                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext }} (<strong>{{ chant.count }}x</strong>)<br>
                                     <script>
                                         function autoFill{{ chant.cid }}() {
                                             const genreId = Array.prototype.find.call(document.getElementById('id_genre').children, ({ textContent }) => textContent === "{{ chant.genre }}");


### PR DESCRIPTION
If full texts of the chants suggested in the sidebar of the chant-create page are long, trim them to only 100 characters.