### PR TITLE
Add name attribute to User class

### DIFF
--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -1,3 +1,4 @@
+from this import d
 from django.contrib.postgres.search import SearchVectorField
 from django.db import models
 from django.db.models.query import QuerySet
@@ -114,6 +115,17 @@ class Chant(BaseModel):
     # # Digital Analysis of Chant Transmission
     # dact = models.CharField(blank=True, null=True, max_length=64)
     # also a second differentia field
+
+    def __str__(self):
+        incipit = ""
+        if self.incipit:
+            incipit = self.incipit
+        elif self.manuscript_full_text:
+            split_text = self.manuscript_full_text.split()
+            incipit = " ".join(split_text[:4])
+        return '"{incip}" ({id})'.format(incip = incipit, id = self.id)
+
+
     def get_ci_url(self) -> str:
         """Construct the url to the entry in Cantus Index correponding to the chant.
 

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -1,4 +1,3 @@
-from this import d
 from django.contrib.postgres.search import SearchVectorField
 from django.db import models
 from django.db.models.query import QuerySet

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -7,9 +7,12 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
+    name = models.CharField(max_length=255, blank=True, null=True)
 
     def __str__(self):
-        if self.first_name and self.last_name:
+        if self.name:
+            return self.name
+        elif self.first_name and self.last_name:
             return f'{self.first_name} {self.last_name}'
         else:
             return self.username

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -7,12 +7,17 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
-    name = models.CharField(max_length=255, blank=True, null=True)
+    full_name = models.CharField(max_length=255, blank=True, null=True)
+
+    @property
+    def name(self):
+        if self.full_name:
+            return self.full_name
+        elif self.first_name and self.last_name:
+            return f'{self.first_name} {self.last_name}'
 
     def __str__(self):
         if self.name:
             return self.name
-        elif self.first_name and self.last_name:
-            return f'{self.first_name} {self.last_name}'
         else:
             return self.username


### PR DESCRIPTION
A step towards addressing #168.

At some point, we'll need to convert all the references to "first_name" and "last_name" in the code base (`first_name` and `last_name` seem not to have been defined in our code, but rather they're inherited from Django's `AbstractUser` class), and update the scripts which import info on indexers etc. from OldCantus into NewCantus (as they appear to use first name and last name, so they'll need to be converted to `full_name`)