### PR TITLE
limit access to sources based on whether source is public

### DIFF
--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -109,5 +109,6 @@ class Source(BaseModel):
         return self.chant_set.filter(volpiano__isnull=False).count()
 
     def __str__(self):
-        return self.title
+        string = '{t} ({i})'.format(t=self.title, i=self.id)
+        return string
     

--- a/django/cantusdb_project/main_app/templates/403.html
+++ b/django/cantusdb_project/main_app/templates/403.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="mr-3 p-3 col-md-8 bg-white rounded">
+            <h3>403</h3>
+            <h5>Access denied</h5>
+            <br>
+            <dl>
+                <dd>You are not authorized to access this page.</dd>
+            </dl> 
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from main_app.forms import SequenceEditForm
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 
 
 class SequenceDetailView(DetailView):
@@ -16,6 +17,13 @@ class SequenceDetailView(DetailView):
     template_name = "sequence_detail.html"
 
     def get_context_data(self, **kwargs):
+
+        # if the sequence's source isn't public, only logged-in users should be able to view the sequence's detail page
+        sequence = self.get_object()
+        source = sequence.source
+        if (source.public is False) and (not self.request.user.is_authenticated):
+            raise PermissionDenied()
+        
         context = super().get_context_data(**kwargs)
         context["concordances"] = Sequence.objects.filter(
             cantus_id=self.get_object().cantus_id

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -5,7 +5,7 @@ from main_app.forms import SourceCreateForm, SourceEditForm
 from django.contrib import messages
 from django.urls import reverse
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseRedirect, HttpResponseNotAllowed
+from django.http import HttpResponseRedirect
 from django.core.exceptions import PermissionDenied
 
 class SourceDetailView(DetailView):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -5,7 +5,8 @@ from main_app.forms import SourceCreateForm, SourceEditForm
 from django.contrib import messages
 from django.urls import reverse
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponseNotAllowed
+from django.core.exceptions import PermissionDenied
 
 class SourceDetailView(DetailView):
     model = Source
@@ -67,6 +68,9 @@ class SourceDetailView(DetailView):
             return folios_with_feasts
 
         source = self.get_object()
+        if (source.public is False) and (not self.request.user.is_authenticated):
+            raise PermissionDenied()
+
         context = super().get_context_data(**kwargs)
 
         if source.segment and source.segment.id == 4064:
@@ -87,8 +91,8 @@ class SourceDetailView(DetailView):
             context["folios"] = folios
             # the options for the feast selector on the right, only chant sources have this
             context["feasts_with_folios"] = get_feast_selector_options(source, folios)
-
         return context
+
 
 
 class SourceListView(ListView):


### PR DESCRIPTION
an initial step toward fixing #172. If a source is not public, the detail pages of the source + its chants + its sequences can now be viewed only if the user is logged in.