### PR TITLE
implemented log in and permissions requirements on all protected routes

### DIFF
--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -109,5 +109,5 @@ class Source(BaseModel):
         return self.chant_set.filter(volpiano__isnull=False).count()
 
     def __str__(self):
-        return self.title
+        return f'{self.title} [ Source ID: {self.id} ]'
     

--- a/django/cantusdb_project/main_app/templates/403.html
+++ b/django/cantusdb_project/main_app/templates/403.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="mr-3 p-3 col-md-8 bg-white rounded">
+            <h3>403</h3>
+            <h5>Access denied</h5>
+            <br>
+            <dl>
+                <dd>You are not authorized to access this page.</dd>
+            </dl> 
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -774,7 +774,7 @@ class ChantDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
         user = self.request.user
         chant_id = self.kwargs.get(self.pk_url_kwarg)
         chant = Chant.objects.get(id=chant_id)
-        source = Source.objects.get(chant=chant)
+        source = chant.source
         # checks if the user is an editor or a proofreader,
         # and if the user is given privilege to make changes to this source
         is_editor_proofreader = user.groups.filter(Q(name="editor")|Q(name="proofreader")).exists()

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -6,8 +6,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 
-from main_app.models.source import Source
-
 
 class SequenceDetailView(DetailView):
     """
@@ -71,7 +69,7 @@ class SequenceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         sequence_id = self.kwargs.get(self.pk_url_kwarg)
         sequence = Sequence.objects.get(id=sequence_id)
         # find the source of this sequence
-        source = Source.objects.get(sequence=sequence)
+        source = sequence.source
         # checks if the user is an editor or a proofreader,
         # and if the user is given privilege to edit this source and thus, it's sequences
         is_editor_proofreader = user.groups.filter(Q(name="editor")|Q(name="proofreader")).exists()

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -7,6 +7,7 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
+    sources_user_can_edit = models.ManyToManyField("main_app.Source", related_name="sources_user_can_edit", blank=True)
 
     def __str__(self):
         if self.first_name and self.last_name:

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -7,7 +7,7 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
-    sources_user_can_edit = models.ManyToManyField("main_app.Source", related_name="sources_user_can_edit", blank=True)
+    sources_user_can_edit = models.ManyToManyField("main_app.Source", related_name="users_who_can_edit_this_source", blank=True)
 
     def __str__(self):
         if self.first_name and self.last_name:


### PR DESCRIPTION
fixes #174 

LoginRequiredMixin and UserPassesTestMixin have been implemented for the following views:

- ChantCreateView
- ChantDeleteView
- ChantEditVolpianoView
- SequenceEditView
- SourceCreateView
- SourceEditView

The privileges are as follows:

- "Create" views can only be accessed by contributors and project managers
- "Edit" and "Delete" views can only be accessed by editors and proofreaders who were granted access to the source, contributors who created the source, and project managers

### **IMPORTANT (PLEASE READ)**
This should be the workflow for CantusDB:

1. In CantusDB's admin interface, the following groups should be added:

- "contributor"
- "editor"
- "proofreader"
- "project manager"

**It's important that the groups are named exactly like above (else, we would have to modify the code accordingly)**

2. When a new user is created, the administrator should assign the user to one or more of the groups listed above, as well as designate sources that they are able to make changes to.