### PR TITLE
Add next_chant and prev_chant properties to chant object

### DIFF
--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -1,3 +1,4 @@
+from this import d
 from django.contrib.postgres.search import SearchVectorField
 from django.db import models
 from django.db.models.query import QuerySet
@@ -114,6 +115,17 @@ class Chant(BaseModel):
     # # Digital Analysis of Chant Transmission
     # dact = models.CharField(blank=True, null=True, max_length=64)
     # also a second differentia field
+
+    def __str__(self):
+        incipit = ""
+        if self.incipit:
+            incipit = self.incipit
+        elif self.manuscript_full_text:
+            split_text = self.manuscript_full_text.split()
+            incipit = " ".join(split_text[:4])
+        return '"{incip}" ({id})'.format(incip = incipit, id = self.id)
+
+
     def get_ci_url(self) -> str:
         """Construct the url to the entry in Cantus Index correponding to the chant.
 

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -1,4 +1,3 @@
-from this import d
 from django.contrib.postgres.search import SearchVectorField
 from django.db import models
 from django.db.models.query import QuerySet
@@ -111,6 +110,9 @@ class Chant(BaseModel):
         max_length=64,
         help_text="Additional folio number field, if folio numbers appear on the leaves but are not in the 'binding order'.",
     )
+    next_chant = models.OneToOneField("self", related_name="prev_chant", null=True, blank=True, on_delete=models.SET_NULL)
+    # prev_chant = ...prev_chant is created via the next_chant's related_name property 
+
     # fragmentarium_id = models.CharField(blank=True, null=True, max_length=64)
     # # Digital Analysis of Chant Transmission
     # dact = models.CharField(blank=True, null=True, max_length=64)

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -7,9 +7,12 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
+    name = models.CharField(max_length=255, blank=True, null=True)
 
     def __str__(self):
-        if self.first_name and self.last_name:
+        if self.name:
+            return self.name
+        elif self.first_name and self.last_name:
             return f'{self.first_name} {self.last_name}'
         else:
             return self.username

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -7,12 +7,17 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
-    name = models.CharField(max_length=255, blank=True, null=True)
+    full_name = models.CharField(max_length=255, blank=True, null=True)
+
+    @property
+    def name(self):
+        if self.full_name:
+            return self.full_name
+        elif self.first_name and self.last_name:
+            return f'{self.first_name} {self.last_name}'
 
     def __str__(self):
         if self.name:
             return self.name
-        elif self.first_name and self.last_name:
-            return f'{self.first_name} {self.last_name}'
         else:
             return self.username


### PR DESCRIPTION
Chant objects now have `next_chant` and `prev_chant` fields. `prev_chant` is set automatically when another chant's `next_chant` points to it.

Please don't merge this pull request until you've merged https://github.com/DDMAL/CantusDB/pull/169 (in the future, I'll try to be more proactive about creating new branches for every change I make!)