### PR TITLE
optimize .get_suggested_feasts()

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -711,17 +711,17 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             return None
 
         current_feast = latest_chant.feast
-        chants_assocd_w_current_feast = Chant.objects.filter(feast=current_feast)
-        next_chants = [chant.get_next_chant()
+        chants_that_end_feast = Chant.objects.filter(is_last_chant_in_feast = True)
+        chants_that_end_current_feast = chants_that_end_feast.filter(feast=current_feast)
+        next_chants = [chant.next_chant
             for chant
-            in chants_assocd_w_current_feast
+            in chants_that_end_current_feast
             ]
         next_feasts = [chant.feast
             for chant
             in next_chants
             if type(chant) is Chant # .get_next_chant() sometimes returns None
                 and chant.feast is not None # some chants aren't associated with a feast
-                and chant.feast.id != current_feast.id
             ]
         feast_counts = Counter(next_feasts)
         sorted_feast_counts = dict( sorted(feast_counts.items(),


### PR DESCRIPTION
`.get_suggested_feasts()` now uses the `is_last_chant_in_feast` and `next_chant` properties of Chant objects to optimize chant-create page loading time.

This optimization requires some pre-calculation - both `populate_next_chant_fields` and `populate_is_last_chant_in_feast` scripts must be run via `manage.py` in order for feasts to be suggested.