### PR TITLE
update user migration scripts

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/add_all_users.py
+++ b/django/cantusdb_project/main_app/management/commands/add_all_users.py
@@ -20,9 +20,12 @@ class Command(BaseCommand):
                 institution = row[5]
                 city = row[6]
                 country = row[7]
+                username = row[8]
+                email = row[9]
 
                 user, created = User.objects.get_or_create(
-                    username = f"{name}_{uid}",
+                    username = username,
+                    email = email,
                     id = uid,
                     first_name = name,
                     last_name = surname,
@@ -35,6 +38,20 @@ class Command(BaseCommand):
                     user.set_password("cantusdb")
                     user.save()
 
+                if user.groups.first() is None:
+                    old_role = "none"
+                else:
+                    old_role = user.groups.first().name
+
+                roles_weights = {
+                    "project manager": 3, 
+                    "editor": 2, 
+                    "contributor": 1,
+                    "none": 0
+                }
+                
                 if new_role != "none":
-                    group = Group.objects.get(name=new_role) 
-                    group.user_set.add(user)
+                    if roles_weights[new_role] > roles_weights[old_role]:
+                        user.groups.clear()
+                        group = Group.objects.get(name=new_role) 
+                        group.user_set.add(user)

--- a/django/cantusdb_project/old_users_list.py
+++ b/django/cantusdb_project/old_users_list.py
@@ -1,67 +1,74 @@
 import csv
-from itertools import count
 import lxml.html as lh
 import requests
 
 with open('oldcantususer_uid_role.csv','r') as csvinput:
     with open('oldcantususer_uid_role_detailed.csv', 'w') as csvoutput:
-        writer = csv.writer(csvoutput, lineterminator='\n')
-        reader = csv.reader(csvinput)
+        with open('id_username_email.csv','r') as csvinput_username_email:
 
-        # header
-        writer.writerow(['uid', 'old role', 'new role', 'name', 'surname', 'institution', 'town', 'country'])
+            writer = csv.writer(csvoutput, lineterminator='\n')
+            reader = csv.reader(csvinput)
+            reader_username_email = csv.reader(csvinput_username_email)
 
-        for row in reader:
-            old_role = row[1]
-            if old_role == "administrator":
-                row.append("project manager")
-            elif old_role == "anonymous user":
-                row.append("")
-            elif old_role == "authenticated user":
-                row.append("")
-            elif old_role == "contributor":
-                row.append("contributor")
-            elif old_role == "Debra":
-                row.append("project manager")
-            elif old_role == "editor":
-                row.append("editor")
-            elif old_role == "power":
-                row.append("editor")
-            elif old_role == "proofreader":
-                row.append("editor")
-            elif old_role == "SIMSSA contributor":
-                row.append("contributor")
+            # header
+            writer.writerow(['uid', 'old role', 'new role', 'name', 'surname', 'institution', 'town', 'country', 'username', 'email'])
 
-            id = row[0]
-            url = f"https://cantus.uwaterloo.ca/user/{id}"
-            response = requests.get(url)
-            doc = lh.fromstring(response.content)
+            for row, row_username_email in zip(reader, reader_username_email):
+                old_role = row[1]
+                if old_role == "administrator":
+                    row.append("project manager")
+                elif old_role == "anonymous user":
+                    row.append("")
+                elif old_role == "authenticated user":
+                    row.append("")
+                elif old_role == "contributor":
+                    row.append("contributor")
+                elif old_role == "Debra":
+                    row.append("project manager")
+                elif old_role == "editor":
+                    row.append("editor")
+                elif old_role == "power":
+                    row.append("editor")
+                elif old_role == "proofreader":
+                    row.append("editor")
+                elif old_role == "SIMSSA contributor":
+                    row.append("contributor")
 
-            try:
-                name = doc.find_class("field-name-field-name")[0].find_class("field-item")[0].text_content()
-            except:
-                name = ""
-            try:
-                surname = doc.find_class("field-name-field-surname")[0].find_class("field-item")[0].text_content()
-            except:
-                surname = ""
-            try:
-                institution = doc.find_class("field-name-field-institution")[0].find_class("field-item")[0].text_content()
-            except:
-                institution = ""
-            try:
-                town = doc.find_class("field-name-field-town")[0].find_class("field-item")[0].text_content()
-            except:
-                town = ""
-            try:
-                country = doc.find_class("field-name-field-country")[0].find_class("field-item")[0].text_content()
-            except:
-                country = ""
-               
-            row.append(name)
-            row.append(surname)
-            row.append(institution)
-            row.append(town)
-            row.append(country)
+                id = row[0]
+                url = f"https://cantus.uwaterloo.ca/user/{id}"
+                response = requests.get(url)
+                doc = lh.fromstring(response.content)
 
-            writer.writerow(row)
+                try:
+                    name = doc.find_class("field-name-field-name")[0].find_class("field-item")[0].text_content()
+                except:
+                    name = ""
+                try:
+                    surname = doc.find_class("field-name-field-surname")[0].find_class("field-item")[0].text_content()
+                except:
+                    surname = ""
+                try:
+                    institution = doc.find_class("field-name-field-institution")[0].find_class("field-item")[0].text_content()
+                except:
+                    institution = ""
+                try:
+                    town = doc.find_class("field-name-field-town")[0].find_class("field-item")[0].text_content()
+                except:
+                    town = ""
+                try:
+                    country = doc.find_class("field-name-field-country")[0].find_class("field-item")[0].text_content()
+                except:
+                    country = ""
+                
+                username = row_username_email[1]
+                email = row_username_email[2]
+                
+                row.append(name)
+                row.append(surname)
+                row.append(institution)
+                row.append(town)
+                row.append(country)
+                row.append(username)
+                row.append(email)
+
+                writer.writerow(row)


### PR DESCRIPTION
Users will now belong in only one group when they're created.
This change will also migrate over the users' usernames and emails.

_**IMPORTANT:**_
**Do not push `id_username_email.csv` and the csv that is produced from running the `old_users_list.py` script, as they contain sensitive information (emails)**