### PR TITLE
Update create_superuser method

### DIFF
--- a/django/cantusdb_project/users/managers.py
+++ b/django/cantusdb_project/users/managers.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth.base_user import BaseUserManager
 from django.utils.translation import gettext_lazy as _
-
+from django.contrib.auth.models import Group
 
 class CustomUserManager(BaseUserManager):
     """
@@ -33,4 +33,7 @@ class CustomUserManager(BaseUserManager):
             raise ValueError(_('Superuser must have is_staff=True.'))
         if extra_fields.get('is_superuser') is not True:
             raise ValueError(_('Superuser must have is_superuser=True.'))
-        return self.create_user(email, password, **extra_fields)
+        user = self.create_user(email, password, **extra_fields)
+        pm = Group.objects.get(name='project manager') 
+        pm.user_set.add(user)
+        return user


### PR DESCRIPTION
fixes #209 

When a user is created by `python manage.py createsuperuser`, they will now be automatically assigned to the project manager group.