### PR TITLE
Remove duplicate sources from my-sources page

### DIFF
--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -35,7 +35,7 @@ class UserSourceListView(LoginRequiredMixin, ListView):
             # | Q(melodies_entered_by=self.request.user)
             # | Q(proofreaders=self.request.user)
             # | Q(other_editors=self.request.user) 
-        ).order_by("title")
+        ).order_by("title").distinct()
         
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Previously, in some cases, the my-sources page would display duplicate sources. Now, it should only display unique ones.