### PR TITLE
fix search bar

### DIFF
--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -429,13 +429,13 @@ def ajax_search_bar(request, search_term):
     # load only the first seven chants
     CHANT_CNT = 7
 
-    if search_term.isdigit():
-        # if the search term contains only digits, search Cantus ID
+    if any(char.isdigit() for char in search_term):
+        # if the search term contains at least one digit, assume user is searching by Cantus ID
         chants = Chant.objects.filter(cantus_id__istartswith=search_term).order_by(
             "id"
         )[:CHANT_CNT]
     else:
-        # if the search term contains non-digit characters, search incipit
+        # if the search term does not contain any digits, assume user is searching by incipit
         chants = Chant.objects.filter(incipit__icontains=search_term).order_by("id")[
             :CHANT_CNT
         ]

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -429,16 +429,16 @@ def ajax_search_bar(request, search_term):
     # load only the first seven chants
     CHANT_CNT = 7
 
-    if search_term.isalpha():
-        # if the search term contains only alphabet letters, search incipit
-        chants = Chant.objects.filter(incipit__icontains=search_term).order_by("id")[
-            :CHANT_CNT
-        ]
-    else:
-        # if the search term contains digits, search Cantus ID
+    if search_term.isdigit():
+        # if the search term contains only digits, search Cantus ID
         chants = Chant.objects.filter(cantus_id__istartswith=search_term).order_by(
             "id"
         )[:CHANT_CNT]
+    else:
+        # if the search term contains non-digit characters, search incipit
+        chants = Chant.objects.filter(incipit__icontains=search_term).order_by("id")[
+            :CHANT_CNT
+        ]
     returned_values = chants.values(
         "incipit",
         "genre__name",


### PR DESCRIPTION
fixes #230 

Up until now, ajax_search_bar used `.isalpha()` as a negative test to determine whether or not the search term might be a Cantus ID. But `.isalpha` returns `False` as soon as there is a space in the search term, and that seems to break things. Switching the test to use `.isdigit()`  as a positive test causes the search box to behave as expected.