### PR TITLE
update facebook plugin in footer

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -109,6 +109,7 @@
 </head>
 
 <body>
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v14.0" nonce="ILOxiQ1O"></script>
     <header>
         <!-- Navbar -->
         <div class="container">
@@ -247,10 +248,7 @@
                     </div>
                     <div class="col-md" id="facebook">
                         <h5>Facebook</h5>
-                        <iframe class="w-100"
-                            src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FCantusDatabase&width=340&height=500&small_header=true&adapt_container_width=true&hide_cover=false&appId=390784934606260"
-                            style="border:none;" scrolling="yes" frameborder="0" allowTransparency="true">
-                        </iframe>
+                        <div class="fb-page" data-href="https://www.facebook.com/CantusDatabase/" data-width="" data-height="" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false"><blockquote cite="https://www.facebook.com/CantusDatabase/" class="fb-xfbml-parse-ignore"><a href="hhttps://www.facebook.com/CantusDatabase/">Cantus Database</a></blockquote></div>
                     </div>
                     <div class="col-md" id="license">
                         <h5>Creative Commons License</h5>


### PR DESCRIPTION
fixes #219 

the old facebook plugin seems to have become broken, probably an issue on Facebook's end. This PR updates the footer to use the currently working plugin.