### PR TITLE
Remove sources_user_can_edit field from User model

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -40,11 +40,7 @@ class SegmentAdmin(BaseModelAdmin):
 class SequenceAdmin(BaseModelAdmin):
     pass
 
-class SourcesUserCanEditInline(admin.TabularInline):
-    model = get_user_model().sources_user_can_edit.through
-
 class SourceAdmin(BaseModelAdmin):
-    inlines = [SourcesUserCanEditInline]
     filter_horizontal = ('century', 'notation', 'current_editors', 'inventoried_by', 'full_text_entered_by', 'melodies_entered_by', 'proofreaders', 'other_editors')
 
 admin.site.register(Chant, ChantAdmin)

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -65,7 +65,7 @@ class Source(BaseModel):
         blank=True, null=True, choices=cursus_choices, max_length=63
     )
     # TODO: Fill this field up with JSON info when I have access to the Users
-    current_editors = models.ManyToManyField(get_user_model(), related_name="sources_edited")
+    current_editors = models.ManyToManyField(get_user_model(), related_name="sources_user_can_edit")
     inventoried_by = models.ManyToManyField(
         "Indexer", related_name="sources_inventoried"
     )

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -295,14 +295,14 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
     def form_valid(self, form):
         form.instance.last_updated_by = self.request.user
+        old_current_editors = list(Source.objects.get(id=form.instance.id).current_editors.all())
+        new_current_editors = form.cleaned_data["current_editors"]
         source = form.save()
-        current_editors = source.current_editors.all()
-        assigned_users = source.users_who_can_edit_this_source.all()
 
-        for user in assigned_users:
-            user.sources_user_can_edit.remove(source)
+        for old_editor in old_current_editors:
+            old_editor.sources_user_can_edit.remove(source)
         
-        for editor in current_editors:
-            editor.sources_user_can_edit.add(source)
+        for new_editor in new_current_editors:
+            new_editor.sources_user_can_edit.add(source)
         
         return HttpResponseRedirect(self.get_success_url())

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -1,9 +1,13 @@
 from django.contrib import admin
 from .models import *
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
-from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from main_app.models import Source
 
 # Register your models here.
+
+# this will allow us to assign sources to users in the User admin page
+class SourceInline(admin.TabularInline):
+    model = Source.current_editors.through
 
 class UserAdmin(BaseUserAdmin):
     readonly_fields = ('date_joined', 'last_login',)
@@ -12,15 +16,16 @@ class UserAdmin(BaseUserAdmin):
     fieldsets = (
         ('Account info', {'fields': (('email', 'password'), 'is_active', ('date_joined', 'last_login'))}),
         ('Personal info', {'fields': ('full_name', ('first_name', 'last_name'), 'institution', ('city', 'country'), 'website',)}),
-        ('Permissions', {'fields': ('is_staff', 'is_superuser', 'groups', 'sources_user_can_edit',)}),
+        ('Permissions', {'fields': ('is_staff', 'is_superuser', 'groups',)}),
     )
     add_fieldsets = (
         ('Account info', {'fields': ('email', ('password1', 'password2'),)}),
         ('Personal info', {'fields': ('full_name', ('first_name', 'last_name'), 'institution', ('city', 'country'), 'website',)}),
-        ('Permissions', {'fields': ('is_staff', 'is_superuser', 'groups', 'sources_user_can_edit',)}),
+        ('Permissions', {'fields': ('is_staff', 'is_superuser', 'groups',)}),
     )
     search_fields = ('email', 'first_name', 'last_name', 'institution',)
     ordering = ('email',)
-    filter_horizontal = ('groups', 'sources_user_can_edit',)
+    filter_horizontal = ('groups',)
+    inlines = [SourceInline]
 
 admin.site.register(User, UserAdmin)

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -8,7 +8,6 @@ class User(AbstractUser):
     city = models.CharField(max_length=255, blank=True, null=True)
     country = models.CharField(max_length=255, blank=True, null=True)
     website = models.URLField(blank=True, null=True)
-    sources_user_can_edit = models.ManyToManyField("main_app.Source", related_name="users_who_can_edit_this_source", blank=True)
     full_name = models.CharField(max_length=255, blank=True, null=True)
     username = None
     email = models.EmailField(unique=True)


### PR DESCRIPTION
This PR removes the `sources_user_can_edit` field of the User model. This field stored the set of the sources that was assigned to the user. Now, any reference to `user.sources_user_can_edit` will be specifying the reverse relation of `source.current_editors`.

That is, `source.current_editors` represents the editors that were assigned to this `source`, whereas `user.sources_user_can_edit` represents the sources that the `user` was assigned.

With this modification, adding/removing editors from `current_editors`, will automatically assign/"unassign" this source from the editor's `sources_user_can_edit` set, and vice versa.