### PR TITLE
Update pagination of my-sources page

### DIFF
--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -62,7 +62,24 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                    {% include "pagination.html" %}
+                    <div class="pagination">
+                        <span class="step-links">
+                            {% if user_created_sources_page_obj.has_previous %}
+                                <a href="?{% url_add_get_params page2=1%}">&laquo;
+                                    first</a>
+                                <a href="?{% url_add_get_params page2=user_created_sources_page_obj.previous_page_number %}">previous</a>
+                            {% endif %}
+                            <span class="current">
+                                Page {{ user_created_sources_page_obj.number }} of {{ user_created_sources_page_obj.paginator.num_pages }}
+                            </span>
+
+                            {% if user_created_sources_page_obj.has_next %}
+                                <a href="?{% url_add_get_params page2=user_created_sources_page_obj.next_page_number %}">next</a>
+                                <a href="?{% url_add_get_params page2=user_created_sources_page_obj.paginator.num_pages %}">last
+                                    &raquo;</a>
+                            {% endif %}
+                        </span>
+                    </div>
                 </div>    
             </div>    
         </div>

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -39,7 +39,11 @@ def month_to_string(value: Optional[Union[str, int]]) -> Optional[Union[str, int
 @register.simple_tag(takes_context=True)
 def url_add_get_params(context, **kwargs):
     query = context["request"].GET.copy()
-    query.pop("page", None)
+    # accounts for the situations where there may be two paginations in one page
+    if "page" in kwargs:
+        query.pop("page", None)
+    if "page2" in kwargs:
+        query.pop("page2", None)
     query.update(kwargs)
     return query.urlencode()
 

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -37,12 +37,12 @@ class UserSourceListView(LoginRequiredMixin, ListView):
             # | Q(melodies_entered_by=self.request.user)
             # | Q(proofreaders=self.request.user)
             # | Q(other_editors=self.request.user) 
-        ).order_by("title").distinct()
+        ).order_by("-date_created").distinct()
         
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        user_created_sources = Source.objects.filter(created_by=self.request.user)
+        user_created_sources = Source.objects.filter(created_by=self.request.user).order_by("-date_created").distinct()
         paginator = Paginator(user_created_sources, 10)
         page_number = self.request.GET.get('page2')
         page_obj = paginator.get_page(page_number)

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -343,7 +343,7 @@
                                         <a href="/admin/">Taxonomy Manager</a>
                                     </li>
                                     <li class="list-group-item p-0">
-                                        <a href="">Content Overview</a>
+                                        <a href="{% url 'content-overview' %}">Content Overview</a>
                                     </li>
                                 {% endif %}
                             </ul>


### PR DESCRIPTION
Previously, the pagination of the "Sources created by user" card on the right half of the page was non-functional. This has been fixed and in addition, the lists of sources are now sorted by "date_created" in reverse order, such that the most recently created source appears first.