### PR TITLE
prevent select element from spilling over beyond edge of parent div

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -224,7 +224,7 @@
 
                         <br>
 
-                        <select id="feastSelect">
+                        <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
                             {% for folio, feast in feasts_with_folios %}
                                 <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>


### PR DESCRIPTION
fixes #242

I tried doing this with bootstrap classes and couldn't get anything to stick. This solution is not ideal, but it works for all but the tiniest of window sizes.