### PR TITLE
change string representation of Source to include rism siglum

### DIFF
--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -106,7 +106,7 @@ class Source(BaseModel):
         return self.chant_set.filter(volpiano__isnull=False).count()
 
     def __str__(self):
-        string = '{t} ({i})'.format(t=self.title, i=self.id)
+        string = '[{s}] {t} ({i})'.format(s=self.rism_siglum, t=self.title, i=self.id)
         return string
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
sort of fixes #217 - looking at the admin panel locally now, the <select> elements seem to be quite wide, and don't shrink when the width of the window is decreased (i.e. the main issue seems to be fixed). With that said, I do think that including the RISM siglum of the source to the string representations of Source objects is a good idea, so I implemented it.