### PR TITLE
Chant views: filter by source__published

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -390,7 +390,7 @@ class ChantSearchView(ListView):
     def get_queryset(self) -> QuerySet:
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
-
+        display_unpublished = self.request.user.is_authenticated
         # if the search is accessed by the global search bar
         if self.request.GET.get("search_bar"):
             chant_set = Chant.objects.filter(source__published=True)
@@ -447,9 +447,12 @@ class ChantSearchView(ListView):
                 # as a substring
                 feasts = Feast.objects.filter(name__icontains=feast)
                 q_obj_filter &= Q(feast__in=feasts)
-
-            chant_set = Chant.objects.filter(source__published=True)
-            sequence_set = Sequence.objects.filter(source__published=True)
+            if not display_unpublished:
+                chant_set = Chant.objects.filter(source__published=True)
+                sequence_set = Sequence.objects.filter(source__published=True)
+            else:
+                chant_set = Chant.objects
+                sequence_set = Sequence.objects
             # Filter the QuerySet with Q object
             chant_set = chant_set.filter(q_obj_filter)
             sequence_set = sequence_set.filter(q_obj_filter)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -340,6 +340,10 @@ class ChantByCantusIDView(ListView):
     def get_queryset(self):
         chant_set = Chant.objects.filter(cantus_id=self.cantus_id)
         sequence_set = Sequence.objects.filter(cantus_id=self.cantus_id)
+        display_unpublished = self.request.user.is_authenticated
+        if not display_unpublished:
+            chant_set = chant_set.filter(source__published=True)
+            sequence_set = sequence_set.filter(source__published=True)
         # the union operation turns sequences into chants, the resulting queryset contains only "chant" objects
         # this forces us to do something special on the template to render correct absolute url for sequences
         queryset = chant_set.union(sequence_set)

--- a/django/cantusdb_project/main_app/views/feast.py
+++ b/django/cantusdb_project/main_app/views/feast.py
@@ -30,8 +30,7 @@ class FeastDetailView(DetailView):
     template_name = "feast_detail.html"
 
     def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs) 
-        print(context)
+        context = super().get_context_data(**kwargs)
 
         display_unpublished = self.request.user.is_authenticated
 

--- a/django/cantusdb_project/main_app/views/feast.py
+++ b/django/cantusdb_project/main_app/views/feast.py
@@ -30,8 +30,15 @@ class FeastDetailView(DetailView):
     template_name = "feast_detail.html"
 
     def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        chants_in_feast = self.get_object().chant_set.filter(source__published=True)
+        context = super().get_context_data(**kwargs) 
+        print(context)
+
+        display_unpublished = self.request.user.is_authenticated
+
+        chants_in_feast = self.get_object().chant_set
+        if not display_unpublished:
+            chants_in_feast = chants_in_feast.filter(source__published=True)
+
         cantus_ids = list(
             chants_in_feast.values_list("cantus_id", flat=True).distinct()
         )

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -338,9 +338,12 @@ def ajax_melody_search(request):
     feast_name = request.GET.get("feast")
     mode = request.GET.get("mode")
     source = request.GET.get("source")
-
-    # only include published chants in the result
-    chants = Chant.objects.filter(source__published=True)
+    
+    display_unpublished = request.user.is_authenticated
+    if not display_unpublished:
+        chants = Chant.objects.filter(source__published=True)
+    else:
+        chants = Chant.objects
 
     # if "search exact matches + transpositions"
     if transpose == "true":


### PR DESCRIPTION
This pull request accounts for all chant views that involve displaying chants from multiple sources; there are several chant views that display only chants from a single source, and these will be restricted in a future pull request.