### PR TITLE
in SequenceListView, only filter by source__published if user not logged in

### DIFF
--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -46,7 +46,11 @@ class SequenceListView(ListView):
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        q_obj_filter = Q(source__published=True)
+        display_unpublished = self.request.user.is_authenticated
+        if display_unpublished:
+            q_obj_filter = Q()
+        else:
+            q_obj_filter = Q(source__published=True)
 
         if self.request.GET.get("incipit"):
             incipit = self.request.GET.get("incipit")


### PR DESCRIPTION
For sequences, there remains the SequenceDetailView where we need to restrict access to the page rather than filtering.