### PR TITLE
Set up next_chants function to filter chants based on whether or not they come from published sources

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -684,7 +684,9 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         if cantus_id is None:
             return None
 
-        suggested_chants = next_chants(cantus_id)
+        display_unpublished = self.request.user.is_authenticated
+
+        suggested_chants = next_chants(cantus_id, display_unpublished=display_unpublished)
 
         # sort by number of occurrences
         sorted_suggested_chants = sorted(suggested_chants,

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -684,9 +684,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         if cantus_id is None:
             return None
 
-        display_unpublished = self.request.user.is_authenticated
-
-        suggested_chants = next_chants(cantus_id, display_unpublished=display_unpublished)
+        suggested_chants = next_chants(cantus_id, display_unpublished=True)
 
         # sort by number of occurrences
         sorted_suggested_chants = sorted(suggested_chants,

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -589,7 +589,7 @@ def json_sources_export(request):
 
 
 def json_nextchants(request, cantus_id):
-    ids_and_counts = next_chants(cantus_id)
+    ids_and_counts = next_chants(cantus_id, display_unpublished=False)
     suggested_chants_dict = {id: count for (id, count) in ids_and_counts}
     return JsonResponse(suggested_chants_dict)
     

--- a/django/cantusdb_project/next_chants.py
+++ b/django/cantusdb_project/next_chants.py
@@ -2,7 +2,7 @@ from main_app.models import Chant
 from collections import Counter
 
 
-def next_chants(cantus_id):
+def next_chants(cantus_id, display_unpublished=False):
     """find instances of the chant with the given cantus_id
     in all manuscripts, gather a list of other chants that follow the
     specified chant in those manuscripts, and count how often each
@@ -14,11 +14,25 @@ def next_chants(cantus_id):
     concordances = Chant.objects.filter(cantus_id=cantus_id).only(
         "source", "folio", "sequence_number"
     )
-    next_chants = [chant.next_chant for chant in concordances]
+    # if not display_unpublished:
+    #     concordances = concordances.filter(source__published=True)
+    
+    next_chants = [chant.next_chant
+            for chant
+            in concordances
+            if chant.next_chant is not None
+        ]
+    if not display_unpublished:
+        next_chants = [chant
+            for chant
+            in next_chants
+            if chant.source.published
+        ]
+
     ids = [chant.cantus_id
         for chant
         in next_chants
-        if chant is not None and chant.cantus_id is not None]   # chant would be None if .get_next_chant() returned None,
+        if chant.cantus_id is not None]   # chant would be None if .get_next_chant() returned None,
                                                                 # i.e. if the chant in concordances was the last in the manuscript
     counts = Counter(ids)
     ids_and_counts = [item for item in counts.items()] # each item is an id-count key-value pair

--- a/django/cantusdb_project/next_chants.py
+++ b/django/cantusdb_project/next_chants.py
@@ -14,21 +14,14 @@ def next_chants(cantus_id, display_unpublished=False):
     concordances = Chant.objects.filter(cantus_id=cantus_id).only(
         "source", "folio", "sequence_number"
     )
-    # if not display_unpublished:
-    #     concordances = concordances.filter(source__published=True)
+    if not display_unpublished:
+        concordances = concordances.filter(source__published=True)
     
     next_chants = [chant.next_chant
             for chant
             in concordances
             if chant.next_chant is not None
         ]
-    if not display_unpublished:
-        next_chants = [chant
-            for chant
-            in next_chants
-            if chant.source.published
-        ]
-
     ids = [chant.cantus_id
         for chant
         in next_chants


### PR DESCRIPTION
This pull request deals with the next_chants function. The function now has two modes, controlled with the `display_unpublished` boolean flag. If display_unpublished is False, next_chants filters results based on whether the chant comes from a published source.

The json_nextchants API calls next_chants with display_unpublished set to False, while the ChantCreate view calls it with the flag set to True.