### PR TITLE
Prevent feast selector from spilling beyond parent div on multiple pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -134,7 +134,7 @@
                         {% endif %}                                
                         <br>
 
-                        <select name="feast" id="feastSelect">
+                        <select name="feast" id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
                             {% for folio, feast in feasts_with_folios %}
                                 <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -152,7 +152,7 @@
                             {% endfor %}
                         </select>                              
 
-                        <select id="feastSelect" onchange="jumpToFeast({{ source.id }})">
+                        <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
                             {% for folio, feast in feasts_with_folios %}
                                 <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -208,7 +208,7 @@
 
                         <br>
 
-                        <select id="feastSelect">
+                        <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
                             {% for folio, feast in feasts_with_folios %}
                                 <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>


### PR DESCRIPTION
fixes #302 . Addresses source-detail, source-edit and chant-list pages.