### PR TITLE
Fixing test_models as well as other issues

### DIFF
--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -23,7 +23,7 @@ class Source(BaseModel):
     # Here in the new Cantus, we only use one field, and there are two levels: published and unpublished.
     # Published sources are available to the public. 
     # Unpublished sources are hidden from the list and cannot be accessed by URL until the user logs in.
-    published = models.BooleanField(blank=False, null=False)
+    published = models.BooleanField(blank=False, null=False, default=False)
 
     title = models.CharField(
         max_length=255,

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -113,6 +113,7 @@ class Source(BaseModel):
 
     def save(self, *args, **kwargs):
         # when creating a source, assign it to "CANTUS Database" segment by default
-        cantus_db_segment = Segment.objects.get(name="CANTUS Database")
-        self.segment = cantus_db_segment
+        if not self.segment:
+            cantus_db_segment = Segment.objects.get(name="CANTUS Database")
+            self.segment = cantus_db_segment
         super().save(*args, **kwargs)

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -67,7 +67,7 @@ def make_fake_chant() -> Chant:
     )
 
     chant = Chant.objects.create(
-        source=make_fake_source(),
+        source=make_fake_source(segment_name="CANTUS Database"),
         marginalia=make_fake_text(SHORT_CHAR_FIELD_MAX),
         # folio in the form of two digit and one letter
         folio=faker.bothify("##?"),
@@ -183,9 +183,11 @@ def make_fake_rism_siglum() -> RismSiglum:
     return rism_siglum
 
 
-def make_fake_segment() -> Segment:
+def make_fake_segment(name=None) -> Segment:
     """Generates a fake Segment object."""
-    segment = Segment.objects.create(name=make_fake_text(SHORT_CHAR_FIELD_MAX))
+    if not name:
+        name = make_fake_text(SHORT_CHAR_FIELD_MAX)
+    segment = Segment.objects.create(name=name)
     return segment
 
 
@@ -206,7 +208,7 @@ def make_fake_sequence() -> Sequence:
         ),
         date=make_fake_text(LONG_CHAR_FIELD_MAX),
         ah_volume=make_fake_text(LONG_CHAR_FIELD_MAX),
-        source=make_fake_source(),
+        source=make_fake_source(segment_name="Bower Sequence Database"),
         # cantus_id in the form of six digits
         cantus_id=faker.numerify("######"),
         image_link=faker.image_url(),
@@ -214,7 +216,7 @@ def make_fake_sequence() -> Sequence:
     return sequence
 
 
-def make_fake_source(published=True) -> Source:
+def make_fake_source(published=True, segment_name=None) -> Source:
     """Generates a fake Source object."""
     # The cursus_choices and source_status_choices lists in Source are lists of
     # tuples and we only need the first element of each tuple
@@ -233,7 +235,7 @@ def make_fake_source(published=True) -> Source:
         full_source=faker.boolean(),
         date=make_fake_text(SHORT_CHAR_FIELD_MAX),
         cursus=random.choice(cursus_choices),
-        segment=make_fake_segment(),
+        segment=make_fake_segment(name=segment_name),
         source_status=random.choice(source_status_choices),
         complete_inventory=faker.boolean(),
         summary=make_fake_text(


### PR DESCRIPTION
With this pull request, the test_models test suite now runs without errors or failures.

Along the way, I fixed an error that had the possibility of overwriting the name of a source's segment. I also fixed an error that caused the source-create page to display an error message, since the page doesn't include a field to specify whether the source is published or not. 