### PR TITLE
Fix tests in test_views_general

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -452,9 +452,14 @@ class GenreDetailViewTest(TestCase):
 
     def test_chants_by_genre(self):
         genre = make_fake_genre()
-        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000")
-        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="100000")
-        chant3 = Chant.objects.create(incipit="chant3", genre=genre, cantus_id="123456")
+
+        # create a source because if chants1, 2 and 3 don't have a source,
+        # source.published will be None, and they won't be included in
+        # the response context
+        source = make_fake_source()
+        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000", source=source)
+        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="100000", source=source)
+        chant3 = Chant.objects.create(incipit="chant3", genre=genre, cantus_id="123456", source=source)
         response = self.client.get(reverse("genre-detail", args=[genre.id]))
         self.assertEqual(response.status_code, 200)
         # the context should be a list of dicts, each corresponding to one cantus id

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -1122,6 +1122,12 @@ class ChantByCantusIDViewTest(TestCase):
 
 
 class ChantSearchViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
     def test_url_and_templates(self):
         response = self.client.get(reverse("chant-search"))
         self.assertEqual(response.status_code, 200)

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -32,6 +32,13 @@ def get_random_search_term(target):
 
 
 class IndexerListViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
+
     def test_url_and_templates(self):
         """Test the url and templates used"""
         response = self.client.get(reverse("indexer-list"))

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -515,7 +515,7 @@ class OfficeDetailViewTest(TestCase):
 class SourceListViewTest(TestCase):
     def setUp(self):
         # unless a segment is specified when a source is created, the source is automatically assigned
-        # to a segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
         # such a segment exists
         Segment.objects.create(name="CANTUS Database")
 
@@ -1842,6 +1842,10 @@ class SourceCreateViewTest(TestCase):
         project_manager = Group.objects.get(name='project manager') 
         project_manager.user_set.add(self.user)
         self.client.login(email='test@test.com', password='pass')
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
 
     def test_url_and_templates(self):
         response = self.client.get(reverse("source-create"))

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -824,6 +824,12 @@ class SourceDetailViewTest(TestCase):
 
 
 class SequenceListViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
     def test_url_and_templates(self):
         response = self.client.get(reverse("sequence-list"))
         self.assertEqual(response.status_code, 200)

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -515,7 +515,8 @@ class OfficeDetailViewTest(TestCase):
 class SourceListViewTest(TestCase):
     def setUp(self):
         # unless a segment is specified when a source is created, the source is automatically assigned
-        # to a segment with the name "CANTUS Database"
+        # to a segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
         Segment.objects.create(name="CANTUS Database")
 
     def test_url_and_templates(self):

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -1788,21 +1788,21 @@ class ChantEditVolpianoViewTest(TestCase):
         self.client.login(email='test@test.com', password='pass')
 
     def test_url_and_templates(self):
-        source = make_fake_source()
-        Chant.objects.create(source=source)
+        source1 = make_fake_source()
+        Chant.objects.create(source=source1)
 
-        response = self.client.get(reverse("source-edit-volpiano", args=[source.id]))
+        response = self.client.get(reverse("source-edit-volpiano", args=[source1.id]))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "chant_edit.html")
 
-        response = self.client.get(reverse("source-edit-volpiano", args=[source.id + 100]))
+        response = self.client.get(reverse("source-edit-volpiano", args=[source1.id + 100]))
         self.assertEqual(response.status_code, 404)
         self.assertTemplateUsed(response, "404.html")
 
         # trying to access chant-edit with a source that has no chant should return 404
-        source = make_fake_source()
+        source2 = make_fake_source()
 
-        response = self.client.get(reverse("source-edit-volpiano", args=[source.id]))
+        response = self.client.get(reverse("source-edit-volpiano", args=[source2.id]))
         self.assertEqual(response.status_code, 404)
         self.assertTemplateUsed(response, "404.html")
 

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -513,6 +513,11 @@ class OfficeDetailViewTest(TestCase):
 
 
 class SourceListViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to a segment with the name "CANTUS Database"
+        Segment.objects.create(name="CANTUS Database")
+
     def test_url_and_templates(self):
         response = self.client.get(reverse("source-list"))
         self.assertEqual(response.status_code, 200)
@@ -544,8 +549,8 @@ class SourceListViewTest(TestCase):
 
     def test_filter_by_segment(self):
         """The source list can be filtered by `segment`, `provenance`, `century`, and `full_source`"""
-        cantus_segment = Segment.objects.create(name="cantus")
-        clavis_segment = Segment.objects.create(name="clavis")
+        cantus_segment = make_fake_segment(name="cantus")
+        clavis_segment = make_fake_segment(name="clavis")
         chant_source = Source.objects.create(
             segment=cantus_segment, title="chant source", published=True
         )

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -1789,7 +1789,9 @@ class ChantEditVolpianoViewTest(TestCase):
 
     def test_url_and_templates(self):
         source1 = make_fake_source()
-        Chant.objects.create(source=source1)
+
+        # must specify folio, or ChantEditVolpianoView.get_queryset will fail when it tries to default to displaying the first folio
+        Chant.objects.create(source=source1, folio="001r")
 
         response = self.client.get(reverse("source-edit-volpiano", args=[source1.id]))
         self.assertEqual(response.status_code, 200)

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -266,6 +266,13 @@ class FeastListViewTest(TestCase):
 
 
 class FeastDetailViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+        pass
+
     def test_url_and_templates(self):
         """Test the url and templates used"""
         feast = make_fake_feast()

--- a/django/cantusdb_project/main_app/tests/test_views_general.py
+++ b/django/cantusdb_project/main_app/tests/test_views_general.py
@@ -452,7 +452,6 @@ class GenreDetailViewTest(TestCase):
 
     def test_chants_by_genre(self):
         genre = make_fake_genre()
-
         # create a source because if chants1, 2 and 3 don't have a source,
         # source.published will be None, and they won't be included in
         # the response context
@@ -473,8 +472,12 @@ class GenreDetailViewTest(TestCase):
 
     def test_search_incipit(self):
         genre = make_fake_genre()
-        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000")
-        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="123456")
+        # create a source because if chants1 and 2 don't have a source,
+        # source.published will be None, and they won't be included in
+        # the response context
+        source = make_fake_source()
+        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000", source=source)
+        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="123456", source=source)
         response = self.client.get(reverse("genre-detail", args=[genre.id]))
         self.assertEqual(response.status_code, 200)
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -998,6 +998,10 @@ class ChantEditVolpianoView(LoginRequiredMixin, UserPassesTestMixin, UpdateView)
                 .distinct()
                 .order_by("folio")
             )
+            if not folios:
+                # if the source has no chants (conceivable), or if it has chants but
+                # none of them have folios specified (we don't really expect this to happen)
+                raise Http404
             initial_folio = folios[0]
             chants = chants.filter(folio=initial_folio)
         self.queryset = chants

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -723,7 +723,6 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             chant_dict = json.loads(response.text[2:])[0]
             # add number of occurence to the dict, so that we can display it easily
             chant_dict["count"] = sugg_chant_count
-            print(chant_dict)
             return chant_dict
 
         suggested_chants_dicts = [
@@ -758,9 +757,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             if type(chant) is Chant # .get_next_chant() sometimes returns None
                 and chant.feast is not None # some chants aren't associated with a feast
             ]
-        print(next_feasts)
         feast_counts = Counter(next_feasts)
-        print(feast_counts)
         sorted_feast_counts = dict( sorted(feast_counts.items(),
                            key=lambda item: item[1],
                            reverse=True))

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1209,7 +1209,11 @@ class ChantEditVolpianoView(LoginRequiredMixin, UserPassesTestMixin, UpdateView)
             request = requests.get(
                     "http://cantusindex.org/json-cid/{}".format(cantus_id)
             )
-            context["suggested_fulltext"] = json.loads(request.text[2:])[0]["fulltext"]
+            request_text = json.loads(request.text[2:])
+            if request_text:
+                context["suggested_fulltext"] = request_text[0]["fulltext"]
+            else:
+                context["suggested_fulltext"] = ""
 
         chant = self.get_object()
 

--- a/django/cantusdb_project/main_app/views/genre.py
+++ b/django/cantusdb_project/main_app/views/genre.py
@@ -63,7 +63,6 @@ class GenreDetailView(SingleObjectMixin, ListView):
         return context
 
     def get_queryset(self):
-        # return self.object.chant_set.all()
         display_unpublished = self.request.user.is_authenticated
         search_term = self.request.GET.get("incipit")
         if not search_term:


### PR DESCRIPTION
This PR fixes all but one of the tests in `test_views_general`. A number of views were touched in the process, so it may make sense to go through commit-by-commit.

The one remaining test that fails is `ChantEditVolpianoViewTest.test_update_chant`, which I left because I don't understand what the testcase is trying to test.