### PR TITLE
Source signals

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/populate_chant_and_melody_counts.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_chant_and_melody_counts.py
@@ -1,0 +1,12 @@
+from main_app.models import Source
+from django.core.management.base import BaseCommand
+
+# `python manage.py python manage.py populate_chant_and_melody_counts`
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        sources = Source.objects.all()
+        for source in sources:
+            source.number_of_chants = source.chant_set.count() + source.sequence_set.count()
+            source.number_of_melodies = source.chant_set.filter(volpiano__isnull=False).count()
+            source.save()

--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -121,3 +121,12 @@ class BaseChant(BaseModel):
     # # Digital Analysis of Chant Transmission
     # dact = models.CharField(blank=True, null=True, max_length=64)
     # also a second differentia field
+    
+    def __str__(self):
+        incipit = ""
+        if self.incipit:
+            incipit = self.incipit
+        elif self.manuscript_full_text:
+            split_text = self.manuscript_full_text.split()
+            incipit = " ".join(split_text[:4])
+        return '"{incip}" ({id})'.format(incip = incipit, id = self.id)

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -14,15 +14,6 @@ class Chant(BaseChant):
     models harmonized, even if only one of the two models uses a particular field.
     """
 
-    def __str__(self):
-        incipit = ""
-        if self.incipit:
-            incipit = self.incipit
-        elif self.manuscript_full_text:
-            split_text = self.manuscript_full_text.split()
-            incipit = " ".join(split_text[:4])
-        return '"{incip}" ({id})'.format(incip = incipit, id = self.id)
-
 
     def get_ci_url(self) -> str:
         """Construct the url to the entry in Cantus Index correponding to the chant.

--- a/django/cantusdb_project/main_app/models/sequence.py
+++ b/django/cantusdb_project/main_app/models/sequence.py
@@ -1,8 +1,4 @@
-from django.contrib.postgres.search import SearchVectorField
-from django.db import models
 from main_app.models.base_chant import BaseChant
-from users.models import User
-
 
 class Sequence(BaseChant):
     """The model for sequences

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -99,13 +99,11 @@ class Source(BaseModel):
     fragmentarium_id = models.CharField(max_length=15, blank=True, null=True)
     dact_id = models.CharField(max_length=15, blank=True, null=True)
 
-    def number_of_chants(self) -> int:
-        """Returns the number of Chants and Sequences in this Source."""
-        return self.chant_set.count() + self.sequence_set.count()
-
-    def number_of_melodies(self) -> int:
-        """Returns the number of Chants in this Source that have melodies."""
-        return self.chant_set.filter(volpiano__isnull=False).count()
+    # number_of_chants and number_of_melodies are used for rendering the source-list page (perhaps among other places)
+    # they are automatically recalculated in main_app.signals.update_source_chant_count and
+    # main_app.signals.update_source_melody_count every time a chant or sequence is saved or deleted
+    number_of_chants = models.IntegerField(blank=True, null=True)
+    number_of_melodies = models.IntegerField(blank=True, null=True)
 
     def __str__(self):
         string = '[{s}] {t} ({i})'.format(s=self.rism_siglum, t=self.title, i=self.id)

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -11,7 +11,7 @@ from main_app.models import Chant
 
 
 @receiver(post_save, sender=Chant)
-def on_save(instance, **kwargs):
+def update_chant_search_vector(instance, **kwargs):
     """When saving an instance of Chant, update its search vector field."""
     index_components = instance.index_components()
     pk = instance.pk

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -4,10 +4,11 @@ from functools import reduce
 from django.contrib.postgres.search import SearchVector
 from django.db import models
 from django.db.models import Value
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
 from main_app.models import Chant
+from main_app.models import Sequence
 
 
 @receiver(post_save, sender=Chant)
@@ -26,3 +27,21 @@ def update_chant_search_vector(instance, **kwargs):
     instance.__class__.objects.filter(pk=pk).update(
         search_vector=reduce(operator.add, search_vectors)
     )
+
+@receiver(post_save, sender=Chant)
+@receiver(post_save, sender=Sequence)
+@receiver(post_delete, sender=Chant)
+@receiver(post_delete, sender=Sequence)
+def update_source_chant_count(instance, **kwargs):
+    """When saving or deleting a Chant or Sequence, update its Source's number_of_chants field"""
+    source = instance.source
+    source.number_of_chants = source.chant_set.count() + source.sequence_set.count()
+    source.save()
+
+@receiver(post_save, sender=Chant)
+@receiver(post_delete, sender=Chant)
+def update_source_melody_count(instance, **kwargs):
+    """When saving or deleting a Chant, update its Source's number_of_melodies field"""
+    source = instance.source
+    source.number_of_melodies = source.chant_set.filter(volpiano__isnull=False).count()
+    source.save()


### PR DESCRIPTION
This PR replaces the `number_of_chants` and `number_of_melodies` methods of Source objects and replaces them with `IntegerField`s of the same names. Instead of being calculated on the fly, these fields are updated any time a Chant is saved, updated or deleted using functions defined in `main_app/signals.py`. A new management command has also been added, which initially populates the aforementioned fields for all sources.

Along the way, several files were cleaned up and some refactoring occurred.