### PR TITLE
Write tests for functions that didn't have tests

### DIFF
--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -65,6 +65,7 @@ def make_fake_chant(source=None,
     position=None,
     sequence_number=None,
     cantus_id=None,
+    feast=None,
     manuscript_full_text_std_spelling=None,
     manuscript_full_text_std_proofread=None,
     volpiano=None,
@@ -83,6 +84,8 @@ def make_fake_chant(source=None,
         sequence_number = random.randint(1, MAX_SEQUENCE_NUMBER)
     if cantus_id is None:
         cantus_id = faker.numerify("######")
+    if feast is None:
+        feast = make_fake_feast()
     if manuscript_full_text_std_spelling is None:
         manuscript_full_text_std_spelling = make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
@@ -107,7 +110,7 @@ def make_fake_chant(source=None,
         position=position,
         # cantus_id in the form of six digits
         cantus_id=cantus_id,
-        feast=make_fake_feast(),
+        feast=feast,
         mode=make_fake_text(SHORT_CHAR_FIELD_MAX),
         differentia=make_fake_text(SHORT_CHAR_FIELD_MAX),
         finalis=make_fake_text(SHORT_CHAR_FIELD_MAX),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -68,7 +68,8 @@ def make_fake_chant(source=None,
     manuscript_full_text_std_spelling=None,
     manuscript_full_text_std_proofread=None,
     volpiano=None,
-    next_chant=None
+    manuscript_syllabized_full_text=None,
+    next_chant=None,
 ) -> Chant:
     """Generates a fake Chant object."""
     if source is None:
@@ -90,6 +91,10 @@ def make_fake_chant(source=None,
         manuscript_full_text_std_proofread = False
     if volpiano is None:
         volpiano = make_fake_text(20)
+    if manuscript_syllabized_full_text is None:
+        manuscript_syllabized_full_text = make_fake_text(
+            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
+        )
         
 
     chant = Chant.objects.create(
@@ -121,9 +126,7 @@ def make_fake_chant(source=None,
         image_link=faker.image_url(),
         cao_concordances=make_fake_text(SHORT_CHAR_FIELD_MAX),
         melody_id=make_fake_text(SHORT_CHAR_FIELD_MAX),
-        manuscript_syllabized_full_text=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        manuscript_syllabized_full_text=manuscript_syllabized_full_text,
         indexing_notes=make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         ),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -65,6 +65,7 @@ def make_fake_chant(source=None,
     sequence_number=None,
     cantus_id=None,
     manuscript_full_text_std_spelling=None,
+    manuscript_full_text_std_proofread=None,
     volpiano=None,
     next_chant=None
 ) -> Chant:
@@ -82,6 +83,8 @@ def make_fake_chant(source=None,
         manuscript_full_text_std_spelling = make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         )
+    if manuscript_full_text_std_proofread is None:
+        manuscript_full_text_std_proofread = False
     if volpiano is None:
         volpiano = make_fake_text(20)
         
@@ -105,7 +108,7 @@ def make_fake_chant(source=None,
         addendum=make_fake_text(LONG_CHAR_FIELD_MAX),
         manuscript_full_text_std_spelling=manuscript_full_text_std_spelling,
         incipit=manuscript_full_text_std_spelling[0:INCIPIT_LENGTH],
-        manuscript_full_text_std_proofread=faker.boolean(),
+        manuscript_full_text_std_proofread=manuscript_full_text_std_proofread,
         manuscript_full_text=manuscript_full_text_std_spelling,
         manuscript_full_text_proofread=faker.boolean(),
         volpiano=make_fake_text(

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -256,16 +256,20 @@ def make_fake_sequence(source=None, title=None, incipit=None, cantus_id=None) ->
     return sequence
 
 
-def make_fake_source(published=True, segment_name=None) -> Source:
+def make_fake_source(published=True, title=None, segment_name=None) -> Source:
     """Generates a fake Source object."""
     # The cursus_choices and source_status_choices lists in Source are lists of
     # tuples and we only need the first element of each tuple
+
+    if title is None:
+        title=make_fake_text(LONG_CHAR_FIELD_MAX)
+
     cursus_choices = [x[0] for x in Source.cursus_choices]
     source_status_choices = [x[0] for x in Source.source_status_choices]
 
     source = Source.objects.create(
         published=published,
-        title=make_fake_text(LONG_CHAR_FIELD_MAX),
+        title=title,
         siglum=make_fake_text(SHORT_CHAR_FIELD_MAX),
         rism_siglum=make_fake_rism_siglum(),
         provenance=make_fake_provenance(),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -62,6 +62,7 @@ def make_fake_century() -> Century:
 
 def make_fake_chant(source=None,
     folio=None,
+    position=None,
     sequence_number=None,
     cantus_id=None,
     manuscript_full_text_std_spelling=None,
@@ -75,6 +76,8 @@ def make_fake_chant(source=None,
     if folio is None:
         # two digits and one letter
         folio = faker.bothify("##?")
+    if position is None:
+        position = make_fake_text(SHORT_CHAR_FIELD_MAX)
     if sequence_number is None:
         sequence_number = random.randint(1, MAX_SEQUENCE_NUMBER)
     if cantus_id is None:
@@ -96,7 +99,7 @@ def make_fake_chant(source=None,
         sequence_number=sequence_number,
         office=make_fake_office(),
         genre=make_fake_genre(),
-        position=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        position=position,
         # cantus_id in the form of six digits
         cantus_id=cantus_id,
         feast=make_fake_feast(),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -62,6 +62,7 @@ def make_fake_century() -> Century:
 
 def make_fake_chant(source=None,
     folio=None,
+    genre=None,
     position=None,
     sequence_number=None,
     cantus_id=None,
@@ -78,6 +79,8 @@ def make_fake_chant(source=None,
     if folio is None:
         # two digits and one letter
         folio = faker.bothify("##?")
+    if genre is None:
+        genre = make_fake_genre()
     if position is None:
         position = make_fake_text(SHORT_CHAR_FIELD_MAX)
     if sequence_number is None:
@@ -106,7 +109,7 @@ def make_fake_chant(source=None,
         folio=folio,
         sequence_number=sequence_number,
         office=make_fake_office(),
-        genre=make_fake_genre(),
+        genre=genre,
         position=position,
         # cantus_id in the form of six digits
         cantus_id=cantus_id,

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1,5 +1,6 @@
 import unittest
 import random
+from urllib import response
 from django.urls import reverse
 from django.test import TestCase
 from django.http import HttpResponseNotFound
@@ -1421,6 +1422,25 @@ class FeastDetailViewTest(TestCase):
         self.assertEqual(frequent_chants_zip[1][-1], 2)
         self.assertEqual(frequent_chants_zip[2][-1], 1)
 
+    def test_chants_in_feast_published_vs_unpublished(self):
+        feast = make_fake_feast()
+        source = make_fake_source()
+        chant = make_fake_chant(source=source, feast=feast)
+
+        source.published = True
+        source.save()
+        response_1 = self.client.get(reverse("feast-detail", args=[feast.id]))
+        frequent_chants_zip = response_1.context["frequent_chants_zip"]
+        cantus_ids = [x[0] for x in frequent_chants_zip]
+        self.assertIn(chant.cantus_id, cantus_ids)
+
+        source.published = False
+        source.save()
+        response_1 = self.client.get(reverse("feast-detail", args=[feast.id]))
+        frequent_chants_zip = response_1.context["frequent_chants_zip"]
+        cantus_ids = [x[0] for x in frequent_chants_zip]
+        self.assertNotIn(chant.cantus_id, cantus_ids)
+        
     def test_sources_containing_this_feast(self):
         big_source = Source.objects.create(
             published=True, title="big_source", siglum="big"

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1109,6 +1109,38 @@ class ChantProofreadViewTest(TestCase):
         self.assertIs(chant.manuscript_full_text_std_proofread, True)
 
 
+class ChantEditSyllabificationViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client = Client()
+        project_manager = Group.objects.get(name='project manager') 
+        project_manager.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+    def test_view_url_and_templates(self):
+        source = make_fake_source()
+        chant = make_fake_chant(source=source)
+        chant_id = chant.id
+
+        response_1 = self.client.get(f"/edit-syllabification/{chant_id}")
+        self.assertEqual(response_1.status_code, 200)
+        self.assertTemplateUsed(response_1, "base.html")
+        self.assertTemplateUsed(response_1, "chant_syllabification_edit.html")
+
+        response_2 = self.client.get(reverse("source-edit-syllabification", args=[chant_id]))
+        self.assertEqual(response_2.status_code, 200)
+
+        self.client.logout()
+        response_3 = self.client.get(reverse("source-edit-syllabification", args=[chant_id]))
+        self.assertEqual(response_3.status_code, 302) # 302: redirect to login page
+
+
 class FeastListViewTest(TestCase):
     def test_view_url_path(self):
         response = self.client.get("/feasts/")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -608,6 +608,24 @@ class ChantSearchViewTest(TestCase):
         self.assertTemplateUsed(response, "base.html")
         self.assertTemplateUsed(response, "chant_search.html")
 
+    def test_published_vs_unpublished(self):
+        source = make_fake_source()
+        chant = make_fake_chant(source=source, manuscript_full_text_std_spelling="lorem ipsum")
+
+        source.published = True
+        source.save()
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": "lorem", "op": "contains"}
+        )
+        self.assertIn(chant, response.context["chants"])
+
+        source.published = False
+        source.save()
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": "lorem", "op": "contains"}
+        )
+        self.assertNotIn(chant, response.context["chants"])
+
     def test_search_by_office(self):
         source = Source.objects.create(published=True, title="a source")
         office = make_fake_office()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2265,6 +2265,16 @@ class SourceDetailViewTest(TestCase):
         # the list of sequences should be ordered by the "sequence" field
         self.assertEqual(response.context["sequences"].query.order_by, ("sequence",))
 
+    def test_published_vs_unpublished(self):
+        source = make_fake_source(published=False)
+        response_1 = self.client.get(reverse("source-detail", args=[source.id]))
+        self.assertEqual(response_1.status_code, 403)
+        
+        source.published = True
+        source.save()
+        response_2 = self.client.get(reverse("source-detail", args=[source.id]))
+        self.assertEqual(response_2.status_code, 200)
+
 
 class JsonMelodyExportTest(TestCase):
     def test_json_melody_response(self):
@@ -2585,7 +2595,7 @@ class JsonNextChantsTest(TestCase):
         self.assertIsInstance(response_1, JsonResponse)
         unpacked_response_1 = json.loads(response_1.content)
         self.assertEqual(unpacked_response_1, {"2000": 1})
-        
+
         fake_source_2.published = True
         fake_source_2.save()
         response_2 = self.client.get(path)

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1644,6 +1644,25 @@ class GenreDetailViewTest(TestCase):
         self.assertEqual(chant_info_list[0]["num_chants"], 2)
         self.assertEqual(chant_info_list[1]["cantus_id"], "123456")
         self.assertEqual(chant_info_list[1]["num_chants"], 1)
+    
+    def test_genre_cantus_ids_published_vs_unpublished(self):
+        genre = make_fake_genre()
+        published_source = make_fake_source(published=True)
+        unpublished_source = make_fake_source(published=False)
+        published_chant = make_fake_chant(
+            source=published_source,
+            genre=genre,
+            cantus_id="111111",
+        )
+        unpublished_chant = make_fake_chant(
+            source=unpublished_source,
+            genre=genre,
+            cantus_id="999999",
+        )
+        response = self.client.get(reverse("genre-detail", args=[genre.id]))
+        chant_info_list = response.context["object_list"]
+        self.assertEqual(len(chant_info_list), 1)
+        self.assertEqual(chant_info_list[0]["cantus_id"], "111111")
 
     def test_search_incipit(self):
         genre = make_fake_genre()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1066,7 +1066,7 @@ class ChantProofreadViewTest(TestCase):
         for i in range(3):
             chant = make_fake_chant(source=source, folio="001r", sequence_number=i)
             sample_folio = chant.folio
-            sample_pk = chant.sequence_number
+            sample_pk = chant.id
         nonexistent_folio = "001v"
 
         response_1 = self.client.get(f"/proofread-chant/{source_id}")
@@ -1091,7 +1091,14 @@ class ChantProofreadViewTest(TestCase):
         self.assertEqual(response_6.status_code, 302) # redirect to login page
     
     def test_proofread_chant(self):
-        pass
+        chant = make_fake_chant(manuscript_full_text_std_spelling="lorem ipsum", folio="001r")
+        self.assertIs(chant.manuscript_full_text_std_proofread, False)
+        source = chant.source
+        response = self.client.post(f"/proofread-chant/{source.id}?pk={chant.id}&folio=001r", 
+            {'manuscript_full_text_std_proofread': 'True'})
+        self.assertEqual(response.status_code, 302)
+        chant.refresh_from_db()
+        self.assertIs(chant.manuscript_full_text_std_proofread, True)
 
 
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -599,6 +599,14 @@ class ChantSearchViewTest(TestCase):
         response = self.client.get(reverse("chant-search"), {"feast": search_term})
         self.assertIn(chant, response.context["chants"])
 
+    def test_search_by_position(self):
+        source = Source.objects.create(published=True, title="a source")
+        position = 1
+        chant = Chant.objects.create(source=source, position=position)
+        search_term = "1"
+        response = self.client.get(reverse("chant-search"), {"position": search_term})
+        self.assertIn(chant, response.context["chants"])
+
     def test_filter_by_melody(self):
         source = Source.objects.create(published=True, title="a source")
         chant_with_melody = Chant.objects.create(

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1101,7 +1101,6 @@ class ChantProofreadViewTest(TestCase):
         self.assertIs(chant.manuscript_full_text_std_proofread, True)
 
 
-
 class FeastListViewTest(TestCase):
     def test_view_url_path(self):
         response = self.client.get("/feasts/")
@@ -2512,3 +2511,21 @@ class CISearchViewTest(TestCase):
         fake_search_term = faker.word()
         response = self.client.get(f"/ci-search/{fake_search_term}")
         self.assertTrue("results" in response.context)
+
+
+class ChangePasswordViewTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client.login(email='test@test.com', password='pass')
+
+    def test_url_and_templates(self):
+        response_2 = self.client.get("/change-password/")
+        self.assertEqual(response_2.status_code, 200)
+        self.assertTemplateUsed(response_2, "base.html")
+        self.assertTemplateUsed(response_2, "registration/change_password.html")
+        response_1 = self.client.get(reverse("change-password"))
+        self.assertEqual(response_1.status_code, 200)
+        self.assertTemplateUsed(response_1, "base.html")
+        self.assertTemplateUsed(response_1, "registration/change_password.html")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1088,7 +1088,7 @@ class ChantProofreadViewTest(TestCase):
 
         self.client.logout()
         response_6 = self.client.get(reverse("chant-proofread", args=[source_id]))
-        self.assertEqual(response_6.status_code, 302) # redirect to login page
+        self.assertEqual(response_6.status_code, 302) # 302 Found
     
     def test_proofread_chant(self):
         chant = make_fake_chant(manuscript_full_text_std_spelling="lorem ipsum", folio="001r")
@@ -1096,7 +1096,7 @@ class ChantProofreadViewTest(TestCase):
         source = chant.source
         response = self.client.post(f"/proofread-chant/{source.id}?pk={chant.id}&folio=001r", 
             {'manuscript_full_text_std_proofread': 'True'})
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302) # 302 Found
         chant.refresh_from_db()
         self.assertIs(chant.manuscript_full_text_std_proofread, True)
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2554,6 +2554,46 @@ class JsonNextChantsTest(TestCase):
         unpacked_response = json.loads(response.content)
         self.assertEqual(unpacked_response, {})
 
+    def test_published_vs_unpublished(self):
+        fake_source_1 = make_fake_source(published=True)
+        fake_source_2 = make_fake_source(published=False)
+
+        fake_chant_2 = Chant.objects.create(
+            source = fake_source_1,
+            cantus_id = "2000"
+        )
+
+        fake_chant_1 = Chant.objects.create(
+            source = fake_source_1,
+            next_chant = fake_chant_2,
+            cantus_id = "1000"
+        )
+        
+        fake_chant_4 = Chant.objects.create(
+            source = fake_source_2,
+            cantus_id = "2000"
+        )
+
+        fake_chant_3 = Chant.objects.create(
+            source = fake_source_2,
+            next_chant = fake_chant_4,
+            cantus_id = "1000"
+        )
+
+        path = reverse("json-nextchants", args=["1000"])
+        response_1 = self.client.get(path)
+        self.assertIsInstance(response_1, JsonResponse)
+        unpacked_response_1 = json.loads(response_1.content)
+        self.assertEqual(unpacked_response_1, {"2000": 1})
+        
+        fake_source_2.published = True
+        fake_source_2.save()
+        response_2 = self.client.get(path)
+        self.assertIsInstance(response_2, JsonResponse)
+        unpacked_response_2 = json.loads(response_2.content)
+        self.assertEqual(unpacked_response_2, {"2000": 2})
+
+
 
 class CISearchViewTest(TestCase):
     def test_view_url_path(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1465,6 +1465,23 @@ class FeastDetailViewTest(TestCase):
         self.assertEqual(sources_zip[0][1], 3)
         self.assertEqual(sources_zip[1][1], 1)
 
+    def test_sources_containing_feast_published_vs_unpublished(self):
+        published_source = make_fake_source(
+            published=True,
+            title="published source",
+        )
+        unpublished_source = make_fake_source(published=False)
+        feast = make_fake_feast()
+        for _ in range(2):
+            make_fake_chant(source=published_source, feast=feast)
+        make_fake_chant(source=unpublished_source, feast=feast)
+
+        response = self.client.get(reverse("feast-detail", args=[feast.id]))
+        sources_zip = response.context["sources_zip"]
+        self.assertEqual(len(sources_zip), 1) # only item should be a duple corresponding to published_source
+        self.assertEqual(sources_zip[0][0].title, "published source")
+        self.assertEqual(sources_zip[0][1], 2)
+
 
 class GenreListViewTest(TestCase):
     def test_view_url_path(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -572,6 +572,24 @@ class ChantByCantusIDViewTest(TestCase):
         )
         self.assertIn(chant, response.context["chants"])
 
+    def test_published_vs_unpublished(self):
+        source = make_fake_source()
+        chant = make_fake_chant(source=source)
+
+        source.published = True
+        source.save()
+        response_1 = self.client.get(
+            reverse("chant-by-cantus-id", args=[chant.cantus_id])
+        )
+        self.assertIn(chant, response_1.context["chants"])
+
+        source.published = False
+        source.save()
+        response_2 = self.client.get(
+            reverse("chant-by-cantus-id", args=[chant.cantus_id])
+        )
+        self.assertNotIn(chant, response_2.context["chants"])
+
 
 class ChantSearchViewTest(TestCase):
     def setUp(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1,6 +1,5 @@
 import unittest
 import random
-from urllib import response
 from django.urls import reverse
 from django.test import TestCase
 from django.http import HttpResponseNotFound

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -351,6 +351,15 @@ class ChantListViewTest(TestCase):
         self.assertTemplateUsed(response, "base.html")
         self.assertTemplateUsed(response, "chant_list.html")
 
+    def test_published_vs_unpublished(self):
+        published_source = make_fake_source(published=True)
+        response_1 = self.client.get(reverse("chant-list"), {"source": published_source.id})
+        self.assertEqual(response_1.status_code, 200)
+        
+        unpublished_source = make_fake_source(published=False)
+        response_2 = self.client.get(reverse("chant-list"), {"source": unpublished_source.id})
+        self.assertEqual(response_2.status_code, 403)
+
     def test_filter_by_source(self):
         source = make_fake_source()
         another_source = make_fake_source()
@@ -2269,7 +2278,7 @@ class SourceDetailViewTest(TestCase):
         source = make_fake_source(published=False)
         response_1 = self.client.get(reverse("source-detail", args=[source.id]))
         self.assertEqual(response_1.status_code, 403)
-        
+
         source.published = True
         source.save()
         response_2 = self.client.get(reverse("source-detail", args=[source.id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1124,8 +1124,7 @@ class ChantEditSyllabificationViewTest(TestCase):
         self.client.login(email='test@test.com', password='pass')
 
     def test_view_url_and_templates(self):
-        source = make_fake_source()
-        chant = make_fake_chant(source=source)
+        chant = make_fake_chant()
         chant_id = chant.id
 
         response_1 = self.client.get(f"/edit-syllabification/{chant_id}")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -67,985 +67,279 @@ def get_random_search_term(target):
     return search_term
 
 
-class IndexerListViewTest(TestCase):
-    def setUp(self):
-        # unless a segment is specified when a source is created, the source is automatically assigned
-        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
-        # such a segment exists
-        Segment.objects.create(name="CANTUS Database")
-
-    def test_view_url_path(self):
-        response = self.client.get("/indexers/")
-        self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        response = self.client.get(reverse("indexer-list"))
-        self.assertEqual(response.status_code, 200)
-
-    def test_url_and_templates(self):
-        """Test the url and templates used"""
-        response = self.client.get(reverse("indexer-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "indexer_list.html")
-
-    def test_only_public_indexer_visible(self):
-        """In the indexer list view, only public indexers (those who have at least one published source) should be visible"""
-        # generate some indexers
-        indexer_with_published_source = make_fake_indexer()
-        indexer_with_unpublished_source = make_fake_indexer()
-        indexer_with_no_source = make_fake_indexer()
-
-        # generate published/unpublished sources and assign indexers to them
-        unpublished_source = Source.objects.create(title="unpublished source", published=False)
-        unpublished_source.inventoried_by.set([indexer_with_unpublished_source])
-
-        published_source = Source.objects.create(title="published source", published=True)
-        published_source.inventoried_by.set([indexer_with_published_source])
-
-        source_with_multiple_indexers = Source.objects.create(
-            title="unpublished source with multiple indexers", published=False,
-        )
-        source_with_multiple_indexers.inventoried_by.set(
-            [indexer_with_published_source, indexer_with_unpublished_source]
-        )
-
-        # access the page context, only the public indexer should be in the context
-        response = self.client.get(reverse("indexer-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(indexer_with_published_source, response.context["indexers"])
-        self.assertNotIn(indexer_with_unpublished_source, response.context["indexers"])
-        self.assertNotIn(indexer_with_no_source, response.context["indexers"])
-
-    def test_search_given_name(self):
-        """
-        Indexer can be searched by passing a `q` parameter to the url \\
-        Search fields include first name, family name, country, city, and institution \\
-        Only public indexers should appear in the results
-        """
-        indexer_with_published_source = make_fake_indexer()
-        published_source = Source.objects.create(title="published source", published=True)
-        published_source.inventoried_by.set([indexer_with_published_source])
-
-        # search with a random slice of first name
-        target = indexer_with_published_source.given_name
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("indexer-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(indexer_with_published_source, response.context["indexers"])
-
-    def test_search_family_name(self):
-        indexer_with_published_source = make_fake_indexer()
-        published_source = Source.objects.create(title="published source", published=True)
-        published_source.inventoried_by.set([indexer_with_published_source])
-
-        target = indexer_with_published_source.family_name
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("indexer-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(indexer_with_published_source, response.context["indexers"])
-
-    def test_search_country(self):
-        indexer_with_published_source = make_fake_indexer()
-        published_source = Source.objects.create(title="published source", published=True)
-        published_source.inventoried_by.set([indexer_with_published_source])
-
-        target = indexer_with_published_source.country
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("indexer-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(indexer_with_published_source, response.context["indexers"])
-
-    def test_search_city(self):
-        indexer_with_published_source = make_fake_indexer()
-        published_source = Source.objects.create(title="published source", published=True)
-        published_source.inventoried_by.set([indexer_with_published_source])
-
-        target = indexer_with_published_source.city
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("indexer-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(indexer_with_published_source, response.context["indexers"])
-
-    def test_search_institution(self):
-        indexer_with_published_source = make_fake_indexer()
-        published_source = Source.objects.create(title="published source", published=True)
-        published_source.inventoried_by.set([indexer_with_published_source])
-
-        target = indexer_with_published_source.institution
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("indexer-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(indexer_with_published_source, response.context["indexers"])
-
-
-class IndexerDetailViewTest(TestCase):
-    NUM_INDEXERS = 10
-
+class PermissionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        for i in range(cls.NUM_INDEXERS):
-            make_fake_indexer()
+        Group.objects.create(name="project manager")
+        Group.objects.create(name="contributor")
+        Group.objects.create(name="editor")
 
-    def test_view_url_path(self):
-        for indexer in Indexer.objects.all():
-            response = self.client.get(f"/indexer/{indexer.id}")
-            self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        for indexer in Indexer.objects.all():
-            response = self.client.get(reverse("indexer-detail", args=[indexer.id]))
-            self.assertEqual(response.status_code, 200)
-
-    def test_url_and_templates(self):
-        """Test the url and templates used"""
-        indexer = make_fake_indexer()
-        response = self.client.get(reverse("indexer-detail", args=[indexer.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "indexer_detail.html")
-
-    def test_context(self):
-        indexer = make_fake_indexer()
-        response = self.client.get(reverse("indexer-detail", args=[indexer.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(indexer, response.context["indexer"])
-
-
-class FeastListViewTest(TestCase):
-    def test_view_url_path(self):
-        response = self.client.get("/feasts/")
-        self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        response = self.client.get(reverse("feast-list"))
-        self.assertEqual(response.status_code, 200)
-
-    def test_url_and_templates(self):
-        """Test the url and templates used"""
-        response = self.client.get(reverse("feast-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "feast_list.html")
-
-    def test_filter_by_month(self):
-        for i in range(1, 13):
-            Feast.objects.create(name=f"test_feast{i}", month=i)
-        for i in range(1, 13):
-            month = str(i)
-            response = self.client.get(reverse("feast-list"), {"month": month})
-            self.assertEqual(response.status_code, 200)
-            feasts = response.context["feasts"]
-            self.assertTrue(all(feast.month == i for feast in feasts))
-
-    def test_ordering(self):
-        """Feast can be ordered by name or feast_code"""
-        # Order by feast_code
-        response = self.client.get(reverse("feast-list"), {"sort_by": "feast_code"})
-        self.assertEqual(response.status_code, 200)
-        feasts = response.context["feasts"]
-        self.assertEqual(feasts.query.order_by[0], "feast_code")
-
-        # Order by name
-        response = self.client.get(reverse("feast-list"), {"sort_by": "name"})
-        self.assertEqual(response.status_code, 200)
-        feasts = response.context["feasts"]
-        self.assertEqual(feasts.query.order_by[0], "name")
-
-        # Empty ordering parameters in GET request should default to ordering by name
-        response = self.client.get(reverse("feast-list"), {"sort_by": ""})
-        self.assertEqual(response.status_code, 200)
-        feasts = response.context["feasts"]
-        self.assertEqual(feasts.query.order_by[0], "name")
-
-        # Anything other than name and feast_code should default to ordering by name
-        response = self.client.get(
-            reverse("feast-list"), {"sort_by": make_fake_text(max_size=5)}
-        )
-        self.assertEqual(response.status_code, 200)
-        feasts = response.context["feasts"]
-        self.assertEqual(feasts.query.order_by[0], "name")
-
-    def test_search_name(self):
-        """Feast can be searched by any part of its name, description, or feast_code"""
-        feast = make_fake_feast()
-        target = feast.name
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("feast-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(feast, response.context["feasts"])
-
-    def test_search_description(self):
-        feast = make_fake_feast()
-        target = feast.description
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("feast-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(feast, response.context["feasts"])
-
-    def test_search_feast_code(self):
-        feast = make_fake_feast()
-        target = feast.feast_code
-        search_term = get_random_search_term(target)
-        response = self.client.get(reverse("feast-list"), {"q": search_term})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(feast, response.context["feasts"])
-
-    def test_pagination(self):
-        PAGINATE_BY = FeastListView.paginate_by
-        # test 2 full pages of feasts
-        feast_count = PAGINATE_BY * 2
-        for i in range(feast_count):
-            make_fake_feast()
-        page_count = int(feast_count / PAGINATE_BY)
-        assert page_count == 2
-        for page_num in range(1, page_count + 1):
-            response = self.client.get(reverse("feast-list"), {"page": page_num})
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue("is_paginated" in response.context)
-            self.assertTrue(response.context["is_paginated"])
-            self.assertEqual(len(response.context["feasts"]), PAGINATE_BY)
-
-        # test a little more than 2 full pages of feasts
-        new_feast_count = feast_count + random.randint(1, PAGINATE_BY - 1)
-        for i in range(new_feast_count - feast_count):
-            make_fake_feast()
-        new_page_count = page_count + 1
-        # The last page should have the same number of feasts as we added
-        response = self.client.get(reverse("feast-list"), {"page": new_page_count})
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue("is_paginated" in response.context)
-        self.assertTrue(response.context["is_paginated"])
-        self.assertEqual(len(response.context["feasts"]), new_feast_count - feast_count)
-
-        # test the "last" syntax
-        response = self.client.get(reverse("feast-list"), {"page": "last"})
-        self.assertEqual(response.status_code, 200)
-
-        # Test some invalid values for pages
-        response = self.client.get(reverse("feast-list"), {"page": -1})
-        self.assertEqual(response.status_code, 404)
-        response = self.client.get(reverse("feast-list"), {"page": 0})
-        self.assertEqual(response.status_code, 404)
-        response = self.client.get(reverse("feast-list"), {"page": "lst"})
-        self.assertEqual(response.status_code, 404)
-        response = self.client.get(reverse("feast-list"), {"page": new_page_count + 1})
-        self.assertEqual(response.status_code, 404)
-
-
-class FeastDetailViewTest(TestCase):
+        for i in range(5):
+            source = make_fake_source()
+            for i in range(5):
+                Chant.objects.create(source=source)
+                Sequence.objects.create(source=source)
+                
     def setUp(self):
-        # unless a segment is specified when a source is created, the source is automatically assigned
-        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
-        # such a segment exists
-        Segment.objects.create(name="CANTUS Database")
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client = Client()
 
-    def test_url_and_templates(self):
-        """Test the url and templates used"""
-        feast = make_fake_feast()
-        response = self.client.get(reverse("feast-detail", args=[feast.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "feast_detail.html")
-
-    def test_context(self):
-        feast = make_fake_feast()
-        response = self.client.get(reverse("feast-detail", args=[feast.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(feast, response.context["feast"])
-
-    def test_most_frequent_chants(self):
-        source = Source.objects.create(published=True, title="published_source")
-        feast = make_fake_feast()
-        # 3 chants with cantus id: 300000
-        for i in range(3):
-            Chant.objects.create(feast=feast, cantus_id="300000", source=source)
-        # 2 chants with cantus id: 200000
-        for i in range(2):
-            Chant.objects.create(feast=feast, cantus_id="200000", source=source)
-        # 1 chant with cantus id: 100000
-        Chant.objects.create(feast=feast, cantus_id="100000", source=source)
-
-        response = self.client.get(reverse("feast-detail", args=[feast.id]))
-        frequent_chants_zip = response.context["frequent_chants_zip"]
-        # the items in zip should be ordered by chant count
-        # the first field is cantus id
-        self.assertEqual(frequent_chants_zip[0][0], "300000")
-        self.assertEqual(frequent_chants_zip[1][0], "200000")
-        self.assertEqual(frequent_chants_zip[2][0], "100000")
-        # the last field is cantus count
-        self.assertEqual(frequent_chants_zip[0][-1], 3)
-        self.assertEqual(frequent_chants_zip[1][-1], 2)
-        self.assertEqual(frequent_chants_zip[2][-1], 1)
-
-    def test_sources_containing_this_feast(self):
-        big_source = Source.objects.create(
-            published=True, title="big_source", siglum="big"
-        )
-        small_source = Source.objects.create(
-            published=True, title="small_source", siglum="small"
-        )
-        feast = make_fake_feast()
-        # 3 chants in the big source
-        for i in range(3):
-            Chant.objects.create(feast=feast, source=big_source)
-        # 1 chant in the small source
-        Chant.objects.create(feast=feast, source=small_source)
-
-        response = self.client.get(reverse("feast-detail", args=[feast.id]))
-        sources_zip = response.context["sources_zip"]
-        # the items in zip should be ordered by chant count
-        # the first field is siglum
-        self.assertEqual(sources_zip[0][0].siglum, "big")
-        self.assertEqual(sources_zip[1][0].siglum, "small")
-        # the second field is chant_count
-        self.assertEqual(sources_zip[0][1], 3)
-        self.assertEqual(sources_zip[1][1], 1)
-
-
-class GenreListViewTest(TestCase):
-    def test_view_url_path(self):
-        response = self.client.get("/genres/")
-        self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        response = self.client.get(reverse("genre-list"))
-        self.assertEqual(response.status_code, 200)
-    
-    def test_url_and_templates(self):
-        """Test the url and templates used"""
-        response = self.client.get(reverse("genre-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "genre_list.html")
-
-    def test_filter_by_mass(self):
-        mass_office_genre = Genre.objects.create(
-            name="genre1", description="test", mass_office="Mass, Office",
-        )
-        mass_genre = Genre.objects.create(
-            name="genre2", description="test", mass_office="Mass"
-        )
-        office_genre = Genre.objects.create(
-            name="genre3", description="test", mass_office="Office"
-        )
-        old_hispanic_genre = Genre.objects.create(
-            name="genre4", description="test", mass_office="Old Hispanic",
-        )
-        # filter by Mass
-        response = self.client.get(reverse("genre-list"), {"mass_office": "Mass"})
-        genres = response.context["genres"]
-        # Mass, Office and Mass should be in the list, while the others should not
-        self.assertIn(mass_genre, genres)
-        self.assertIn(mass_office_genre, genres)
-        self.assertNotIn(office_genre, genres)
-        self.assertNotIn(old_hispanic_genre, genres)
-
-    def test_filter_by_office(self):
-        mass_office_genre = Genre.objects.create(
-            name="genre1", description="test", mass_office="Mass, Office",
-        )
-        mass_genre = Genre.objects.create(
-            name="genre2", description="test", mass_office="Mass"
-        )
-        office_genre = Genre.objects.create(
-            name="genre3", description="test", mass_office="Office"
-        )
-        old_hispanic_genre = Genre.objects.create(
-            name="genre4", description="test", mass_office="Old Hispanic",
-        )
-        # filter by Office
-        response = self.client.get(reverse("genre-list"), {"mass_office": "Office"})
-        genres = response.context["genres"]
-        # Office, Office and Mass should be in the list, while the others should not
-        self.assertNotIn(mass_genre, genres)
-        self.assertIn(mass_office_genre, genres)
-        self.assertIn(office_genre, genres)
-        self.assertNotIn(old_hispanic_genre, genres)
-
-    def test_no_filtering(self):
-        mass_office_genre = Genre.objects.create(
-            name="genre1", description="test", mass_office="Mass, Office",
-        )
-        mass_genre = Genre.objects.create(
-            name="genre2", description="test", mass_office="Mass"
-        )
-        office_genre = Genre.objects.create(
-            name="genre3", description="test", mass_office="Office"
-        )
-        old_hispanic_genre = Genre.objects.create(
-            name="genre4", description="test", mass_office="Old Hispanic",
-        )
-        # default is no filtering
-        response = self.client.get(reverse("genre-list"))
-        genres = response.context["genres"]
-        # all genres should be in the list
-        self.assertIn(mass_genre, genres)
-        self.assertIn(mass_office_genre, genres)
-        self.assertIn(office_genre, genres)
-        self.assertIn(old_hispanic_genre, genres)
-
-    def test_invalid_filtering(self):
-        mass_office_genre = Genre.objects.create(
-            name="genre1", description="test", mass_office="Mass, Office",
-        )
-        mass_genre = Genre.objects.create(
-            name="genre2", description="test", mass_office="Mass"
-        )
-        office_genre = Genre.objects.create(
-            name="genre3", description="test", mass_office="Office"
-        )
-        old_hispanic_genre = Genre.objects.create(
-            name="genre4", description="test", mass_office="Old Hispanic",
-        )
-        # invalid filtering parameter should default to no filtering
-        response = self.client.get(
-            reverse("genre-list"), {"mass_office": "invalid param"}
-        )
-        genres = response.context["genres"]
-        # all genres should be in the list
-        self.assertIn(mass_genre, genres)
-        self.assertIn(mass_office_genre, genres)
-        self.assertIn(office_genre, genres)
-        self.assertIn(old_hispanic_genre, genres)
-
-
-class GenreDetailViewTest(TestCase):
-    def setUp(self):
-        for _ in range(10):
-            make_fake_genre()
-
-    def test_view_url_path(self):
-        for genre in Genre.objects.all():
-            response = self.client.get(f"/genre/{genre.id}")
-            self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        for genre in Genre.objects.all():
-            response = self.client.get(reverse("genre-detail", args=[genre.id]))
-            self.assertEqual(response.status_code, 200)
-
-    def test_view_context_data(self):
-        for genre in Genre.objects.all():
-            response = self.client.get(reverse("genre-detail", args=[genre.id]))
-            self.assertTrue("genre" in response.context)
-            self.assertEqual(genre, response.context["genre"])
-
-    def test_url_and_templates(self):
-        """Test the url and templates used"""
-        genre = make_fake_genre()
-        response = self.client.get(reverse("genre-detail", args=[genre.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "genre_detail.html")
-
-    def test_context(self):
-        genre = make_fake_genre()
-        response = self.client.get(reverse("genre-detail", args=[genre.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(genre, response.context["genre"])
-
-    def test_chants_by_genre(self):
-        genre = make_fake_genre()
-        # create a source because if chants1, 2 and 3 don't have a source,
-        # source.published will be None, and they won't be included in
-        # the response context
+    def test_login(self):
         source = make_fake_source()
-        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000", source=source)
-        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="100000", source=source)
-        chant3 = Chant.objects.create(incipit="chant3", genre=genre, cantus_id="123456", source=source)
-        response = self.client.get(reverse("genre-detail", args=[genre.id]))
-        self.assertEqual(response.status_code, 200)
-        # the context should be a list of dicts, each corresponding to one cantus id
-        chant_info_list = response.context["object_list"]
-        # the chant info list should be ordered by the number of chants
-        # the first one should be the one that has two chants
-        self.assertEqual(chant_info_list[0]["cantus_id"], "100000")
-        self.assertEqual(chant_info_list[0]["num_chants"], 2)
-        self.assertEqual(chant_info_list[1]["cantus_id"], "123456")
-        self.assertEqual(chant_info_list[1]["num_chants"], 1)
-
-    def test_search_incipit(self):
-        genre = make_fake_genre()
-        # create a source because if chants1 and 2 don't have a source,
-        # source.published will be None, and they won't be included in
-        # the response context
-        source = make_fake_source()
-        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000", source=source)
-        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="123456", source=source)
-        response = self.client.get(reverse("genre-detail", args=[genre.id]))
-        self.assertEqual(response.status_code, 200)
-
-        # search for the common part of incipit
-        response = self.client.get(
-            reverse("genre-detail", args=[genre.id]), {"incipit": "chant"}
-        )
-        # both cantus_ids should be in the list
-        self.assertEqual(len(response.context["object_list"]), 2)
-        # search for the unique part of incipit
-        response = self.client.get(
-            reverse("genre-detail", args=[genre.id]), {"incipit": "chant1"}
-        )
-        # only one record should be in the list
-        self.assertEqual(len(response.context["object_list"]), 1)
-        # search for random incipit that don't exist
-        response = self.client.get(
-            reverse("genre-detail", args=[genre.id]), {"incipit": "random"}
-        )
-        # the list should be empty
-        self.assertEqual(len(response.context["object_list"]), 0)
-
-
-class OfficeListViewTest(TestCase):
-    OFFICE_COUNT = 10
-
-    def setUp(self):
-        for _ in range(self.OFFICE_COUNT):
-            make_fake_office()
-
-    def test_view_url_path(self):
-        response = self.client.get("/offices/")
-        self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        response = self.client.get(reverse("office-list"))
-        self.assertEqual(response.status_code, 200)
-
-    def test_url_and_templates(self):
-        response = self.client.get(reverse("office-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "office_list.html")
-
-    def test_context(self):
-        response = self.client.get(reverse("office-list"))
-        offices = response.context["offices"]
-        # the list view should contain all offices
-        self.assertEqual(offices.count(), self.OFFICE_COUNT)
-
-
-class OfficeDetailViewTest(TestCase):
-    def setUp(self):
-        for _ in range(10):
-            make_fake_office()
-
-    def test_view_url_path(self):
-        for office in Office.objects.all():
-            response = self.client.get(f"/office/{office.id}")
-            self.assertEqual(response.status_code, 200)
-
-    def test_view_url_reverse_name(self):
-        for office in Office.objects.all():
-            response = self.client.get(reverse("office-detail", args=[office.id]))
-            self.assertEqual(response.status_code, 200)
-
-    def test_view_context_data(self):
-        for office in Office.objects.all():
-            response = self.client.get(reverse("office-detail", args=[office.id]))
-            self.assertTrue("office" in response.context)
-            self.assertEqual(office, response.context["office"])
-
-    def test_url_and_templates(self):
-        office = make_fake_office()
-        response = self.client.get(reverse("office-detail", args=[office.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "office_detail.html")
-
-    def test_context(self):
-        office = make_fake_office()
-        response = self.client.get(reverse("office-detail", args=[office.id]))
-        self.assertEqual(office, response.context["office"])
-
-
-class SourceListViewTest(TestCase):
-    def setUp(self):
-        # unless a segment is specified when a source is created, the source is automatically assigned
-        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
-        # such a segment exists
-        Segment.objects.create(name="CANTUS Database")
-
-    def test_url_and_templates(self):
-        response = self.client.get(reverse("source-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "source_list.html")
-
-    def test_provenances_and_centuries_in_context(self):
-        """Test the `provenances` and `centuries` in the context. They are displayed as options in the selectors"""
-        provenance = make_fake_provenance()
-        century = make_fake_century()
-        response = self.client.get(reverse("source-list"))
-        provenances = response.context["provenances"]
-        self.assertIn({"id": provenance.id, "name": provenance.name}, provenances)
-        centuries = response.context["centuries"]
-        self.assertIn({"id": century.id, "name": century.name}, centuries)
-
-    def test_only_published_sources_visible(self):
-        """For a source to be displayed in the list, its `published` field must be `True`"""
-        published_source = Source.objects.create(
-            published=True, title="published source"
-        )
-        private_source = Source.objects.create(
-            published=False, title="private source"
-        )
-        response = self.client.get(reverse("source-list"))
-        sources = response.context["sources"]
-        self.assertIn(published_source, sources)
-        self.assertNotIn(private_source, sources)
-
-    def test_filter_by_segment(self):
-        """The source list can be filtered by `segment`, `provenance`, `century`, and `full_source`"""
-        cantus_segment = make_fake_segment(name="cantus")
-        clavis_segment = make_fake_segment(name="clavis")
-        chant_source = Source.objects.create(
-            segment=cantus_segment, title="chant source", published=True
-        )
-        seq_source = Source.objects.create(
-            segment=clavis_segment, title="sequence source", published=True
-        )
-
-        # display chant sources only
-        response = self.client.get(
-            reverse("source-list"), {"segment": cantus_segment.id}
-        )
-        sources = response.context["sources"]
-        self.assertIn(chant_source, sources)
-        self.assertNotIn(seq_source, sources)
-
-        # display sequence sources only
-        response = self.client.get(
-            reverse("source-list"), {"segment": clavis_segment.id}
-        )
-        sources = response.context["sources"]
-        self.assertIn(seq_source, sources)
-        self.assertNotIn(chant_source, sources)
-
-    def test_filter_by_provenance(self):
-        aachen = make_fake_provenance()
-        albi = make_fake_provenance()
-        aachen_source = Source.objects.create(
-            provenance=aachen,
-            published=True,
-            title="source originated in Aachen",
-        )
-        albi_source = Source.objects.create(
-            provenance=albi,
-            published=True,
-            title="source originated in Albi",
-        )
-        no_provenance_source = Source.objects.create(
-            published=True, title="source with empty provenance"
-        )
-
-        # display sources in Aachen
-        response = self.client.get(reverse("source-list"), {"provenance": aachen.id})
-        sources = response.context["sources"]
-        # only aachen_source should be in the list
-        self.assertIn(aachen_source, sources)
-        self.assertNotIn(albi_source, sources)
-        self.assertNotIn(no_provenance_source, sources)
-
-    def test_filter_by_century(self):
-        ninth_century = Century.objects.create(name="09th century")
-        ninth_century_first_half = Century.objects.create(
-            name="09th century (1st half)"
-        )
-        tenth_century = Century.objects.create(name="10th century")
-
-        ninth_century_source = Source.objects.create(
-            published=True, title="source",
-        )
-        ninth_century_source.century.set([ninth_century])
-
-        ninth_century_first_half_source = Source.objects.create(
-            published=True, title="source",
-        )
-        ninth_century_first_half_source.century.set([ninth_century_first_half])
-
-        multiple_century_source = Source.objects.create(
-            published=True, title="source",
-        )
-        multiple_century_source.century.set([ninth_century, tenth_century])
-
-        # display sources in ninth century
-        response = self.client.get(
-            reverse("source-list"), {"century": ninth_century.id}
-        )
-        sources = response.context["sources"]
-        # ninth_century_source, ninth_century_first_half_source, and
-        # multiple_century_source should all be in the list
-        self.assertIn(ninth_century_source, sources)
-        self.assertIn(ninth_century_first_half_source, sources)
-        self.assertIn(multiple_century_source, sources)
-
-        # display sources in ninth century first half
-        response = self.client.get(
-            reverse("source-list"), {"century": ninth_century_first_half.id}
-        )
-        sources = response.context["sources"]
-        # only ninth_century_first_half_source should be in the list
-        self.assertNotIn(ninth_century_source, sources)
-        self.assertIn(ninth_century_first_half_source, sources)
-        self.assertNotIn(multiple_century_source, sources)
-
-    def test_filter_by_full_source(self):
-        full_source = Source.objects.create(
-            full_source=True, published=True, title="full source"
-        )
-        fragment = Source.objects.create(
-            full_source=False, published=True, title="fragment"
-        )
-        unknown = Source.objects.create(
-            published=True, title="full_source field is empty"
-        )
-
-        # display full sources
-        response = self.client.get(reverse("source-list"), {"fullSource": "true"})
-        sources = response.context["sources"]
-        # full_source and unknown_source should be in the list, fragment should not
-        self.assertIn(full_source, sources)
-        self.assertNotIn(fragment, sources)
-        self.assertIn(unknown, sources)
-
-        # display fragments
-        response = self.client.get(reverse("source-list"), {"fullSource": "false"})
-        sources = response.context["sources"]
-        # fragment should be in the list, full_source and unknown_source should not
-        self.assertNotIn(full_source, sources)
-        self.assertIn(fragment, sources)
-        self.assertNotIn(unknown, sources)
-
-        # display all sources
-        response = self.client.get(reverse("source-list"))
-        sources = response.context["sources"]
-        # all three should be in the list
-        self.assertIn(full_source, sources)
-        self.assertIn(fragment, sources)
-        self.assertIn(unknown, sources)
-
-    def test_search_by_title(self):
-        """The "general search" field searches in `title`, `siglum`, `rism_siglum`, `description`, and `summary`"""
-        source = Source.objects.create(
-            title=make_fake_text(max_size=20), published=True
-        )
-        search_term = get_random_search_term(source.title)
-        response = self.client.get(reverse("source-list"), {"general": search_term})
-        self.assertIn(source, response.context["sources"])
-
-    def test_search_by_siglum(self):
-        source = Source.objects.create(
-            siglum=make_fake_text(max_size=20), published=True, title="title"
-        )
-        search_term = get_random_search_term(source.siglum)
-        response = self.client.get(reverse("source-list"), {"general": search_term})
-        self.assertIn(source, response.context["sources"])
-
-    def test_search_by_rism_siglum_name(self):
-        rism_siglum = make_fake_rism_siglum()
-        source = Source.objects.create(
-            rism_siglum=rism_siglum, published=True, title="title",
-        )
-        search_term = get_random_search_term(source.rism_siglum.name)
-        response = self.client.get(reverse("source-list"), {"general": search_term})
-        self.assertIn(source, response.context["sources"])
-
-    def test_search_by_rism_siglum_description(self):
-        rism_siglum = make_fake_rism_siglum()
-        source = Source.objects.create(
-            rism_siglum=rism_siglum, published=True, title="title",
-        )
-        search_term = get_random_search_term(source.rism_siglum.description)
-        response = self.client.get(reverse("source-list"), {"general": search_term})
-        self.assertIn(source, response.context["sources"])
-
-    def test_search_by_description(self):
-        source = Source.objects.create(
-            description=make_fake_text(max_size=200),
-            published=True,
-            title="title",
-        )
-        search_term = get_random_search_term(source.description)
-        response = self.client.get(reverse("source-list"), {"general": search_term})
-        self.assertIn(source, response.context["sources"])
-
-    def test_search_by_summary(self):
-        source = Source.objects.create(
-            summary=make_fake_text(max_size=200),
-            published=True,
-            title="title",
-        )
-        search_term = get_random_search_term(source.summary)
-        response = self.client.get(reverse("source-list"), {"general": search_term})
-        self.assertIn(source, response.context["sources"])
-
-    def test_search_by_indexing_notes(self):
-        """The "indexing notes" field searches in `indexing_notes` and indexer/editor related fields"""
-        source = Source.objects.create(
-            indexing_notes=make_fake_text(max_size=200),
-            published=True,
-            title="title",
-        )
-        search_term = get_random_search_term(source.indexing_notes)
-        response = self.client.get(reverse("source-list"), {"indexing": search_term})
-        self.assertIn(source, response.context["sources"])
-
-
-class SourceDetailViewTest(TestCase):
-    def test_url_and_templates(self):
-        source = make_fake_source()
-        response = self.client.get(reverse("source-detail", args=[source.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "source_detail.html")
-
-    def test_context_chant_folios(self):
-        # create a source and several chants in it
-        source = make_fake_source()
-        Chant.objects.create(source=source, folio="001r")
-        Chant.objects.create(source=source, folio="001r")
-        Chant.objects.create(source=source, folio="001v")
-        Chant.objects.create(source=source, folio="001v")
-        Chant.objects.create(source=source, folio="002r")
-        Chant.objects.create(source=source, folio="002v")
-        # request the page
-        response = self.client.get(reverse("source-detail", args=[source.id]))
-        # the element in "folios" should be unique and ordered in this way
-        folios = response.context["folios"]
-        self.assertEqual(list(folios), ["001r", "001v", "002r", "002v"])
-
-    def test_context_sequence_folios(self):
-        # create a sequence source and several sequences in it
-        source = Source.objects.create(
-            segment=Segment.objects.create(id=4064, name="Bower Sequence Database"),
-            title="a sequence source",
-            published=True
-        )
-        Sequence.objects.create(source=source, folio="001r")
-        Sequence.objects.create(source=source, folio="001r")
-        Sequence.objects.create(source=source, folio="001v")
-        Sequence.objects.create(source=source, folio="001v")
-        Sequence.objects.create(source=source, folio="002r")
-        Sequence.objects.create(source=source, folio="002v")
-        # request the page
-        response = self.client.get(reverse("source-detail", args=[source.id]))
-        # the element in "folios" should be unique and ordered in this way
-        folios = response.context["folios"]
-        self.assertEqual(list(folios), ["001r", "001v", "002r", "002v"])
-        # the folios should be ordered by the "folio" field
-        self.assertEqual(folios.query.order_by, ("folio",))
-
-    def test_context_feasts_with_folios(self):
-        # create a source and several chants (associated with feasts) in it
-        source = make_fake_source()
-        feast_1 = make_fake_feast()
-        feast_2 = make_fake_feast()
-        Chant.objects.create(source=source, folio="001r", feast=feast_1)
-        Chant.objects.create(source=source, folio="001r", feast=feast_1)
-        Chant.objects.create(source=source, folio="001v", feast=feast_2)
-        Chant.objects.create(source=source, folio="001v")
-        Chant.objects.create(source=source, folio="001v", feast=feast_2)
-        Chant.objects.create(source=source, folio="002r", feast=feast_1)
-        # request the page
-        response = self.client.get(reverse("source-detail", args=[source.id]))
-        # context "feasts_with_folios" is a list of tuples
-        # it records the folios where the feast changes
-        expected_result = [("001r", feast_1), ("001v", feast_2), ("002r", feast_1)]
-        self.assertEqual(response.context["feasts_with_folios"], expected_result)
-
-    def test_context_sequences(self):
-        # create a sequence source and several sequences in it
-        source = Source.objects.create(
-            segment=Segment.objects.create(id=4064, name="Bower Sequence Database"),
-            title="a sequence source",
-            published=True
-        )
-        sequence = Sequence.objects.create(source=source)
-        # request the page
-        response = self.client.get(reverse("source-detail", args=[source.id]))
-        # the sequence should be in the list of sequences
-        self.assertIn(sequence, response.context["sequences"])
-        # the list of sequences should be ordered by the "sequence" field
-        self.assertEqual(response.context["sequences"].query.order_by, ("sequence",))
-
-
-class SequenceListViewTest(TestCase):
-    def setUp(self):
-        # unless a segment is specified when a source is created, the source is automatically assigned
-        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
-        # such a segment exists
-        Segment.objects.create(name="CANTUS Database")
-
-    def test_url_and_templates(self):
-        response = self.client.get(reverse("sequence-list"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "sequence_list.html")
-
-    def test_ordering(self):
-        # the sequences in the list should be ordered by the "siglum" and "sequence" fields
-        response = self.client.get(reverse("sequence-list"))
-        sequences = response.context["sequences"]
-        self.assertEqual(sequences.query.order_by, ("siglum", "sequence"))
-
-    def test_search_incipit(self):
-        # create a published sequence source and some sequence in it
-        source = Source.objects.create(
-            published=True, title="a sequence source"
-        )
-        sequence = Sequence.objects.create(
-            incipit=make_fake_text(max_size=30), source=source
-        )
-        search_term = get_random_search_term(sequence.incipit)
-        # request the page, search for the incipit
-        response = self.client.get(reverse("sequence-list"), {"incipit": search_term})
-        # the sequence should be present in the results
-        self.assertIn(sequence, response.context["sequences"])
-
-    def test_search_siglum(self):
-        # create a published sequence source and some sequence in it
-        source = Source.objects.create(
-            published=True, title="a sequence source"
-        )
-        sequence = Sequence.objects.create(
-            siglum=make_fake_text(max_size=10), source=source
-        )
-        search_term = get_random_search_term(sequence.siglum)
-        # request the page, search for the siglum
-        response = self.client.get(reverse("sequence-list"), {"siglum": search_term})
-        # the sequence should be present in the results
-        self.assertIn(sequence, response.context["sequences"])
-
-    def test_search_cantus_id(self):
-        # create a published sequence source and some sequence in it
-        source = Source.objects.create(
-            published=True, title="a sequence source"
-        )
-        # faker generates a fake cantus id, in the form of two letters followed by five digits
-        sequence = Sequence.objects.create(
-            cantus_id=faker.bothify("??#####"), source=source
-        )
-        search_term = get_random_search_term(sequence.cantus_id)
-        # request the page, search for the incipit
-        response = self.client.get(reverse("sequence-list"), {"cantus_id": search_term})
-        # the sequence should be present in the results
-        self.assertIn(sequence, response.context["sequences"])
-
-
-class SequenceDetailViewTest(TestCase):
-    def test_url_and_templates(self):
+        chant = make_fake_chant()
         sequence = make_fake_sequence()
-        response = self.client.get(reverse("sequence-detail", args=[sequence.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "base.html")
-        self.assertTemplateUsed(response, "sequence_detail.html")
 
-    def test_concordances(self):
-        sequence = make_fake_sequence()
-        sequence_with_same_cantus_id = make_fake_sequence(cantus_id=sequence.cantus_id)
-        response = self.client.get(reverse("sequence-detail", args=[sequence.id]))
-        concordances = response.context["concordances"]
-        self.assertIn(sequence_with_same_cantus_id, concordances)
+        # currently not logged in, should redirect
+
+        # ChantCreateView
+        response = self.client.get(f'/chant-create/{source.id}')
+        self.assertRedirects(response, f'/login/?next=/chant-create/{source.id}')       
+
+        # ChantDeleteView
+        response = self.client.get(f'/chant-delete/{chant.id}')
+        self.assertRedirects(response, f'/login/?next=/chant-delete/{chant.id}')        
+        
+        # ChantEditVolpianoView
+        response = self.client.get(f'/edit-volpiano/{source.id}')
+        self.assertRedirects(response, f'/login/?next=/edit-volpiano/{source.id}')        
+
+        # SequenceEditView
+        response = self.client.get(f'/edit-sequence/{sequence.id}')
+        self.assertRedirects(response, f'/login/?next=/edit-sequence/{sequence.id}')        
+
+        # SourceCreateView
+        response = self.client.get('/source-create/')
+        self.assertRedirects(response, '/login/?next=/source-create/')    
+
+        # SourceEditView
+        response = self.client.get(f'/edit-source/{source.id}')
+        self.assertRedirects(response, f'/login/?next=/edit-source/{source.id}')
+
+        # UserSourceListView
+        response = self.client.get('/my-sources/')
+        self.assertRedirects(response, '/login/?next=/my-sources/')        
+
+        # UserListView
+        response = self.client.get('/users/')
+        self.assertRedirects(response, '/login/?next=/users/')        
+
+    def test_permissions_project_manager(self):
+        project_manager = Group.objects.get(name='project manager') 
+        project_manager.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+        # get random source, chant and sequence
+        source = Source.objects.order_by('?').first()
+        chant = Chant.objects.order_by('?').first()
+        sequence = Sequence.objects.order_by('?').first()
+
+        # ChantCreateView
+        response = self.client.get(f'/chant-create/{source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # ChantDeleteView
+        response = self.client.get(f'/chant-delete/{chant.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # ChantEditVolpianoView
+        response = self.client.get(f'/edit-volpiano/{source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # SequenceEditView
+        response = self.client.get(f'/edit-sequence/{sequence.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # SourceCreateView
+        response = self.client.get('/source-create/')
+        self.assertEqual(response.status_code, 200)
+
+        # SourceEditView
+        response = self.client.get(f'/edit-source/{source.id}')
+        self.assertEqual(response.status_code, 200)
+
+    def test_permissions_contributor(self):
+        contributor = Group.objects.get(name='contributor') 
+        contributor.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+        # a source assigned to the current user
+        assigned_source = make_fake_source()
+        self.user.sources_user_can_edit.add(assigned_source)
+        for i in range(5):
+            Chant.objects.create(source=assigned_source)
+        chant_in_assigned_source = Chant.objects.filter(source=assigned_source).order_by('?').first()
+
+        # a source created by the current user
+        source_created_by_contributor = make_fake_source()
+        source_created_by_contributor.created_by = self.user
+        source_created_by_contributor.save()
+        for i in range(5):
+            Chant.objects.create(source=source_created_by_contributor)
+        chant_in_source_created_by_contributor = Chant.objects.filter(source=source_created_by_contributor).order_by('?').first()
+
+        # did not create the source, was not assigned the source
+        restricted_source = Source.objects.filter(~Q(created_by=self.user)&~Q(id=assigned_source.id)).order_by('?').first()
+        restricted_chant = Chant.objects.filter(source=restricted_source).order_by('?').first()
+        
+        # a random sequence
+        sequence = Sequence.objects.order_by('?').first()
+
+        # ChantCreateView
+        response = self.client.get(f'/chant-create/{restricted_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/chant-create/{source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/chant-create/{assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # ChantDeleteView
+        response = self.client.get(f'/chant-delete/{restricted_chant.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/chant-delete/{chant_in_source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/chant-delete/{chant_in_assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # ChantEditVolpianoView
+        response = self.client.get(f'/edit-volpiano/{restricted_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/edit-volpiano/{source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/edit-volpiano/{assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # SequenceEditView
+        response = self.client.get(f'/edit-sequence/{sequence.id}')
+        self.assertEqual(response.status_code, 403)
+
+        # SourceCreateView
+        response = self.client.get('/source-create/')
+        self.assertEqual(response.status_code, 200)
+
+        # SourceEditView
+        response = self.client.get(f'/edit-source/{restricted_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/edit-source/{source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/edit-source/{assigned_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+    def test_permissions_editor(self):
+        editor = Group.objects.get(name='editor') 
+        editor.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+        # a source assigned to the current user
+        assigned_source = make_fake_source()
+        self.user.sources_user_can_edit.add(assigned_source)
+        for i in range(5):
+            Chant.objects.create(source=assigned_source)
+        chant_in_assigned_source = Chant.objects.filter(source=assigned_source).order_by('?').first()
+
+        # a source created by the current user
+        source_created_by_contributor = make_fake_source()
+        source_created_by_contributor.created_by = self.user
+        source_created_by_contributor.save()
+        for i in range(5):
+            Chant.objects.create(source=source_created_by_contributor)
+        chant_in_source_created_by_contributor = Chant.objects.filter(source=source_created_by_contributor).order_by('?').first()
+
+        # did not create the source, was not assigned the source
+        restricted_source = Source.objects.filter(~Q(created_by=self.user)&~Q(id=assigned_source.id)).order_by('?').first()
+        restricted_chant = Chant.objects.filter(source=restricted_source).order_by('?').first()
+        
+        # a random sequence
+        sequence = Sequence.objects.order_by('?').first()
+
+        # ChantCreateView
+        response = self.client.get(f'/chant-create/{restricted_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/chant-create/{source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/chant-create/{assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # ChantDeleteView
+        response = self.client.get(f'/chant-delete/{restricted_chant.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/chant-delete/{chant_in_source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/chant-delete/{chant_in_assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # ChantEditVolpianoView
+        response = self.client.get(f'/edit-volpiano/{restricted_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/edit-volpiano/{source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/edit-volpiano/{assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+        # SequenceEditView
+        response = self.client.get(f'/edit-sequence/{sequence.id}')
+        self.assertEqual(response.status_code, 403)
+
+        # SourceCreateView
+        response = self.client.get('/source-create/')
+        self.assertEqual(response.status_code, 200)
+
+        # SourceEditView
+        response = self.client.get(f'/edit-source/{restricted_source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(f'/edit-source/{source_created_by_contributor.id}')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f'/edit-source/{assigned_source.id}')
+        self.assertEqual(response.status_code, 200)
+
+    def test_permissions_default(self):
+        self.client.login(email='test@test.com', password='pass')
+
+        # get random source, chant and sequence
+        source = Source.objects.order_by('?').first()
+        chant = Chant.objects.order_by('?').first()
+        sequence = Sequence.objects.order_by('?').first()
+
+        # ChantCreateView
+        response = self.client.get(f'/chant-create/{source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        # ChantDeleteView
+        response = self.client.get(f'/chant-delete/{chant.id}')
+        self.assertEqual(response.status_code, 403)
+
+        # ChantEditVolpianoView
+        response = self.client.get(f'/edit-volpiano/{source.id}')
+        self.assertEqual(response.status_code, 403)
+
+        # SequenceEditView
+        response = self.client.get(f'/edit-sequence/{sequence.id}')
+        self.assertEqual(response.status_code, 403)
+
+        # SourceCreateView
+        response = self.client.get('/source-create/')
+        self.assertEqual(response.status_code, 403)
+
+        # SourceEditView
+        response = self.client.get(f'/edit-source/{source.id}')
+        self.assertEqual(response.status_code, 403)
 
 
 class ChantListViewTest(TestCase):
@@ -1751,6 +1045,1106 @@ class ChantEditVolpianoViewTest(TestCase):
         self.assertEqual(chant.manuscript_full_text_std_spelling, 'test')
 
 
+class FeastListViewTest(TestCase):
+    def test_view_url_path(self):
+        response = self.client.get("/feasts/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        response = self.client.get(reverse("feast-list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_url_and_templates(self):
+        """Test the url and templates used"""
+        response = self.client.get(reverse("feast-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "feast_list.html")
+
+    def test_filter_by_month(self):
+        for i in range(1, 13):
+            Feast.objects.create(name=f"test_feast{i}", month=i)
+        for i in range(1, 13):
+            month = str(i)
+            response = self.client.get(reverse("feast-list"), {"month": month})
+            self.assertEqual(response.status_code, 200)
+            feasts = response.context["feasts"]
+            self.assertTrue(all(feast.month == i for feast in feasts))
+
+    def test_ordering(self):
+        """Feast can be ordered by name or feast_code"""
+        # Order by feast_code
+        response = self.client.get(reverse("feast-list"), {"sort_by": "feast_code"})
+        self.assertEqual(response.status_code, 200)
+        feasts = response.context["feasts"]
+        self.assertEqual(feasts.query.order_by[0], "feast_code")
+
+        # Order by name
+        response = self.client.get(reverse("feast-list"), {"sort_by": "name"})
+        self.assertEqual(response.status_code, 200)
+        feasts = response.context["feasts"]
+        self.assertEqual(feasts.query.order_by[0], "name")
+
+        # Empty ordering parameters in GET request should default to ordering by name
+        response = self.client.get(reverse("feast-list"), {"sort_by": ""})
+        self.assertEqual(response.status_code, 200)
+        feasts = response.context["feasts"]
+        self.assertEqual(feasts.query.order_by[0], "name")
+
+        # Anything other than name and feast_code should default to ordering by name
+        response = self.client.get(
+            reverse("feast-list"), {"sort_by": make_fake_text(max_size=5)}
+        )
+        self.assertEqual(response.status_code, 200)
+        feasts = response.context["feasts"]
+        self.assertEqual(feasts.query.order_by[0], "name")
+
+    def test_search_name(self):
+        """Feast can be searched by any part of its name, description, or feast_code"""
+        feast = make_fake_feast()
+        target = feast.name
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("feast-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(feast, response.context["feasts"])
+
+    def test_search_description(self):
+        feast = make_fake_feast()
+        target = feast.description
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("feast-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(feast, response.context["feasts"])
+
+    def test_search_feast_code(self):
+        feast = make_fake_feast()
+        target = feast.feast_code
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("feast-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(feast, response.context["feasts"])
+
+    def test_pagination(self):
+        PAGINATE_BY = FeastListView.paginate_by
+        # test 2 full pages of feasts
+        feast_count = PAGINATE_BY * 2
+        for i in range(feast_count):
+            make_fake_feast()
+        page_count = int(feast_count / PAGINATE_BY)
+        assert page_count == 2
+        for page_num in range(1, page_count + 1):
+            response = self.client.get(reverse("feast-list"), {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue("is_paginated" in response.context)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["feasts"]), PAGINATE_BY)
+
+        # test a little more than 2 full pages of feasts
+        new_feast_count = feast_count + random.randint(1, PAGINATE_BY - 1)
+        for i in range(new_feast_count - feast_count):
+            make_fake_feast()
+        new_page_count = page_count + 1
+        # The last page should have the same number of feasts as we added
+        response = self.client.get(reverse("feast-list"), {"page": new_page_count})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("is_paginated" in response.context)
+        self.assertTrue(response.context["is_paginated"])
+        self.assertEqual(len(response.context["feasts"]), new_feast_count - feast_count)
+
+        # test the "last" syntax
+        response = self.client.get(reverse("feast-list"), {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        # Test some invalid values for pages
+        response = self.client.get(reverse("feast-list"), {"page": -1})
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse("feast-list"), {"page": 0})
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse("feast-list"), {"page": "lst"})
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse("feast-list"), {"page": new_page_count + 1})
+        self.assertEqual(response.status_code, 404)
+
+
+class FeastDetailViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
+    def test_url_and_templates(self):
+        """Test the url and templates used"""
+        feast = make_fake_feast()
+        response = self.client.get(reverse("feast-detail", args=[feast.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "feast_detail.html")
+
+    def test_context(self):
+        feast = make_fake_feast()
+        response = self.client.get(reverse("feast-detail", args=[feast.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(feast, response.context["feast"])
+
+    def test_most_frequent_chants(self):
+        source = Source.objects.create(published=True, title="published_source")
+        feast = make_fake_feast()
+        # 3 chants with cantus id: 300000
+        for i in range(3):
+            Chant.objects.create(feast=feast, cantus_id="300000", source=source)
+        # 2 chants with cantus id: 200000
+        for i in range(2):
+            Chant.objects.create(feast=feast, cantus_id="200000", source=source)
+        # 1 chant with cantus id: 100000
+        Chant.objects.create(feast=feast, cantus_id="100000", source=source)
+
+        response = self.client.get(reverse("feast-detail", args=[feast.id]))
+        frequent_chants_zip = response.context["frequent_chants_zip"]
+        # the items in zip should be ordered by chant count
+        # the first field is cantus id
+        self.assertEqual(frequent_chants_zip[0][0], "300000")
+        self.assertEqual(frequent_chants_zip[1][0], "200000")
+        self.assertEqual(frequent_chants_zip[2][0], "100000")
+        # the last field is cantus count
+        self.assertEqual(frequent_chants_zip[0][-1], 3)
+        self.assertEqual(frequent_chants_zip[1][-1], 2)
+        self.assertEqual(frequent_chants_zip[2][-1], 1)
+
+    def test_sources_containing_this_feast(self):
+        big_source = Source.objects.create(
+            published=True, title="big_source", siglum="big"
+        )
+        small_source = Source.objects.create(
+            published=True, title="small_source", siglum="small"
+        )
+        feast = make_fake_feast()
+        # 3 chants in the big source
+        for i in range(3):
+            Chant.objects.create(feast=feast, source=big_source)
+        # 1 chant in the small source
+        Chant.objects.create(feast=feast, source=small_source)
+
+        response = self.client.get(reverse("feast-detail", args=[feast.id]))
+        sources_zip = response.context["sources_zip"]
+        # the items in zip should be ordered by chant count
+        # the first field is siglum
+        self.assertEqual(sources_zip[0][0].siglum, "big")
+        self.assertEqual(sources_zip[1][0].siglum, "small")
+        # the second field is chant_count
+        self.assertEqual(sources_zip[0][1], 3)
+        self.assertEqual(sources_zip[1][1], 1)
+
+
+class GenreListViewTest(TestCase):
+    def test_view_url_path(self):
+        response = self.client.get("/genres/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        response = self.client.get(reverse("genre-list"))
+        self.assertEqual(response.status_code, 200)
+    
+    def test_url_and_templates(self):
+        """Test the url and templates used"""
+        response = self.client.get(reverse("genre-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "genre_list.html")
+
+    def test_filter_by_mass(self):
+        mass_office_genre = Genre.objects.create(
+            name="genre1", description="test", mass_office="Mass, Office",
+        )
+        mass_genre = Genre.objects.create(
+            name="genre2", description="test", mass_office="Mass"
+        )
+        office_genre = Genre.objects.create(
+            name="genre3", description="test", mass_office="Office"
+        )
+        old_hispanic_genre = Genre.objects.create(
+            name="genre4", description="test", mass_office="Old Hispanic",
+        )
+        # filter by Mass
+        response = self.client.get(reverse("genre-list"), {"mass_office": "Mass"})
+        genres = response.context["genres"]
+        # Mass, Office and Mass should be in the list, while the others should not
+        self.assertIn(mass_genre, genres)
+        self.assertIn(mass_office_genre, genres)
+        self.assertNotIn(office_genre, genres)
+        self.assertNotIn(old_hispanic_genre, genres)
+
+    def test_filter_by_office(self):
+        mass_office_genre = Genre.objects.create(
+            name="genre1", description="test", mass_office="Mass, Office",
+        )
+        mass_genre = Genre.objects.create(
+            name="genre2", description="test", mass_office="Mass"
+        )
+        office_genre = Genre.objects.create(
+            name="genre3", description="test", mass_office="Office"
+        )
+        old_hispanic_genre = Genre.objects.create(
+            name="genre4", description="test", mass_office="Old Hispanic",
+        )
+        # filter by Office
+        response = self.client.get(reverse("genre-list"), {"mass_office": "Office"})
+        genres = response.context["genres"]
+        # Office, Office and Mass should be in the list, while the others should not
+        self.assertNotIn(mass_genre, genres)
+        self.assertIn(mass_office_genre, genres)
+        self.assertIn(office_genre, genres)
+        self.assertNotIn(old_hispanic_genre, genres)
+
+    def test_no_filtering(self):
+        mass_office_genre = Genre.objects.create(
+            name="genre1", description="test", mass_office="Mass, Office",
+        )
+        mass_genre = Genre.objects.create(
+            name="genre2", description="test", mass_office="Mass"
+        )
+        office_genre = Genre.objects.create(
+            name="genre3", description="test", mass_office="Office"
+        )
+        old_hispanic_genre = Genre.objects.create(
+            name="genre4", description="test", mass_office="Old Hispanic",
+        )
+        # default is no filtering
+        response = self.client.get(reverse("genre-list"))
+        genres = response.context["genres"]
+        # all genres should be in the list
+        self.assertIn(mass_genre, genres)
+        self.assertIn(mass_office_genre, genres)
+        self.assertIn(office_genre, genres)
+        self.assertIn(old_hispanic_genre, genres)
+
+    def test_invalid_filtering(self):
+        mass_office_genre = Genre.objects.create(
+            name="genre1", description="test", mass_office="Mass, Office",
+        )
+        mass_genre = Genre.objects.create(
+            name="genre2", description="test", mass_office="Mass"
+        )
+        office_genre = Genre.objects.create(
+            name="genre3", description="test", mass_office="Office"
+        )
+        old_hispanic_genre = Genre.objects.create(
+            name="genre4", description="test", mass_office="Old Hispanic",
+        )
+        # invalid filtering parameter should default to no filtering
+        response = self.client.get(
+            reverse("genre-list"), {"mass_office": "invalid param"}
+        )
+        genres = response.context["genres"]
+        # all genres should be in the list
+        self.assertIn(mass_genre, genres)
+        self.assertIn(mass_office_genre, genres)
+        self.assertIn(office_genre, genres)
+        self.assertIn(old_hispanic_genre, genres)
+
+
+class GenreDetailViewTest(TestCase):
+    def setUp(self):
+        for _ in range(10):
+            make_fake_genre()
+
+    def test_view_url_path(self):
+        for genre in Genre.objects.all():
+            response = self.client.get(f"/genre/{genre.id}")
+            self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        for genre in Genre.objects.all():
+            response = self.client.get(reverse("genre-detail", args=[genre.id]))
+            self.assertEqual(response.status_code, 200)
+
+    def test_view_context_data(self):
+        for genre in Genre.objects.all():
+            response = self.client.get(reverse("genre-detail", args=[genre.id]))
+            self.assertTrue("genre" in response.context)
+            self.assertEqual(genre, response.context["genre"])
+
+    def test_url_and_templates(self):
+        """Test the url and templates used"""
+        genre = make_fake_genre()
+        response = self.client.get(reverse("genre-detail", args=[genre.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "genre_detail.html")
+
+    def test_context(self):
+        genre = make_fake_genre()
+        response = self.client.get(reverse("genre-detail", args=[genre.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(genre, response.context["genre"])
+
+    def test_chants_by_genre(self):
+        genre = make_fake_genre()
+        # create a source because if chants1, 2 and 3 don't have a source,
+        # source.published will be None, and they won't be included in
+        # the response context
+        source = make_fake_source()
+        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000", source=source)
+        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="100000", source=source)
+        chant3 = Chant.objects.create(incipit="chant3", genre=genre, cantus_id="123456", source=source)
+        response = self.client.get(reverse("genre-detail", args=[genre.id]))
+        self.assertEqual(response.status_code, 200)
+        # the context should be a list of dicts, each corresponding to one cantus id
+        chant_info_list = response.context["object_list"]
+        # the chant info list should be ordered by the number of chants
+        # the first one should be the one that has two chants
+        self.assertEqual(chant_info_list[0]["cantus_id"], "100000")
+        self.assertEqual(chant_info_list[0]["num_chants"], 2)
+        self.assertEqual(chant_info_list[1]["cantus_id"], "123456")
+        self.assertEqual(chant_info_list[1]["num_chants"], 1)
+
+    def test_search_incipit(self):
+        genre = make_fake_genre()
+        # create a source because if chants1 and 2 don't have a source,
+        # source.published will be None, and they won't be included in
+        # the response context
+        source = make_fake_source()
+        chant1 = Chant.objects.create(incipit="chant1", genre=genre, cantus_id="100000", source=source)
+        chant2 = Chant.objects.create(incipit="chant2", genre=genre, cantus_id="123456", source=source)
+        response = self.client.get(reverse("genre-detail", args=[genre.id]))
+        self.assertEqual(response.status_code, 200)
+
+        # search for the common part of incipit
+        response = self.client.get(
+            reverse("genre-detail", args=[genre.id]), {"incipit": "chant"}
+        )
+        # both cantus_ids should be in the list
+        self.assertEqual(len(response.context["object_list"]), 2)
+        # search for the unique part of incipit
+        response = self.client.get(
+            reverse("genre-detail", args=[genre.id]), {"incipit": "chant1"}
+        )
+        # only one record should be in the list
+        self.assertEqual(len(response.context["object_list"]), 1)
+        # search for random incipit that don't exist
+        response = self.client.get(
+            reverse("genre-detail", args=[genre.id]), {"incipit": "random"}
+        )
+        # the list should be empty
+        self.assertEqual(len(response.context["object_list"]), 0)
+
+
+class IndexerListViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
+    def test_view_url_path(self):
+        response = self.client.get("/indexers/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        response = self.client.get(reverse("indexer-list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_url_and_templates(self):
+        """Test the url and templates used"""
+        response = self.client.get(reverse("indexer-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "indexer_list.html")
+
+    def test_only_public_indexer_visible(self):
+        """In the indexer list view, only public indexers (those who have at least one published source) should be visible"""
+        # generate some indexers
+        indexer_with_published_source = make_fake_indexer()
+        indexer_with_unpublished_source = make_fake_indexer()
+        indexer_with_no_source = make_fake_indexer()
+
+        # generate published/unpublished sources and assign indexers to them
+        unpublished_source = Source.objects.create(title="unpublished source", published=False)
+        unpublished_source.inventoried_by.set([indexer_with_unpublished_source])
+
+        published_source = Source.objects.create(title="published source", published=True)
+        published_source.inventoried_by.set([indexer_with_published_source])
+
+        source_with_multiple_indexers = Source.objects.create(
+            title="unpublished source with multiple indexers", published=False,
+        )
+        source_with_multiple_indexers.inventoried_by.set(
+            [indexer_with_published_source, indexer_with_unpublished_source]
+        )
+
+        # access the page context, only the public indexer should be in the context
+        response = self.client.get(reverse("indexer-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(indexer_with_published_source, response.context["indexers"])
+        self.assertNotIn(indexer_with_unpublished_source, response.context["indexers"])
+        self.assertNotIn(indexer_with_no_source, response.context["indexers"])
+
+    def test_search_given_name(self):
+        """
+        Indexer can be searched by passing a `q` parameter to the url \\
+        Search fields include first name, family name, country, city, and institution \\
+        Only public indexers should appear in the results
+        """
+        indexer_with_published_source = make_fake_indexer()
+        published_source = Source.objects.create(title="published source", published=True)
+        published_source.inventoried_by.set([indexer_with_published_source])
+
+        # search with a random slice of first name
+        target = indexer_with_published_source.given_name
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("indexer-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(indexer_with_published_source, response.context["indexers"])
+
+    def test_search_family_name(self):
+        indexer_with_published_source = make_fake_indexer()
+        published_source = Source.objects.create(title="published source", published=True)
+        published_source.inventoried_by.set([indexer_with_published_source])
+
+        target = indexer_with_published_source.family_name
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("indexer-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(indexer_with_published_source, response.context["indexers"])
+
+    def test_search_country(self):
+        indexer_with_published_source = make_fake_indexer()
+        published_source = Source.objects.create(title="published source", published=True)
+        published_source.inventoried_by.set([indexer_with_published_source])
+
+        target = indexer_with_published_source.country
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("indexer-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(indexer_with_published_source, response.context["indexers"])
+
+    def test_search_city(self):
+        indexer_with_published_source = make_fake_indexer()
+        published_source = Source.objects.create(title="published source", published=True)
+        published_source.inventoried_by.set([indexer_with_published_source])
+
+        target = indexer_with_published_source.city
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("indexer-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(indexer_with_published_source, response.context["indexers"])
+
+    def test_search_institution(self):
+        indexer_with_published_source = make_fake_indexer()
+        published_source = Source.objects.create(title="published source", published=True)
+        published_source.inventoried_by.set([indexer_with_published_source])
+
+        target = indexer_with_published_source.institution
+        search_term = get_random_search_term(target)
+        response = self.client.get(reverse("indexer-list"), {"q": search_term})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(indexer_with_published_source, response.context["indexers"])
+
+
+class IndexerDetailViewTest(TestCase):
+    NUM_INDEXERS = 10
+
+    @classmethod
+    def setUpTestData(cls):
+        for i in range(cls.NUM_INDEXERS):
+            make_fake_indexer()
+
+    def test_view_url_path(self):
+        for indexer in Indexer.objects.all():
+            response = self.client.get(f"/indexer/{indexer.id}")
+            self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        for indexer in Indexer.objects.all():
+            response = self.client.get(reverse("indexer-detail", args=[indexer.id]))
+            self.assertEqual(response.status_code, 200)
+
+    def test_url_and_templates(self):
+        """Test the url and templates used"""
+        indexer = make_fake_indexer()
+        response = self.client.get(reverse("indexer-detail", args=[indexer.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "indexer_detail.html")
+
+    def test_context(self):
+        indexer = make_fake_indexer()
+        response = self.client.get(reverse("indexer-detail", args=[indexer.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(indexer, response.context["indexer"])
+
+
+class OfficeListViewTest(TestCase):
+    OFFICE_COUNT = 10
+
+    def setUp(self):
+        for _ in range(self.OFFICE_COUNT):
+            make_fake_office()
+
+    def test_view_url_path(self):
+        response = self.client.get("/offices/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        response = self.client.get(reverse("office-list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_url_and_templates(self):
+        response = self.client.get(reverse("office-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "office_list.html")
+
+    def test_context(self):
+        response = self.client.get(reverse("office-list"))
+        offices = response.context["offices"]
+        # the list view should contain all offices
+        self.assertEqual(offices.count(), self.OFFICE_COUNT)
+
+
+class OfficeDetailViewTest(TestCase):
+    def setUp(self):
+        for _ in range(10):
+            make_fake_office()
+
+    def test_view_url_path(self):
+        for office in Office.objects.all():
+            response = self.client.get(f"/office/{office.id}")
+            self.assertEqual(response.status_code, 200)
+
+    def test_view_url_reverse_name(self):
+        for office in Office.objects.all():
+            response = self.client.get(reverse("office-detail", args=[office.id]))
+            self.assertEqual(response.status_code, 200)
+
+    def test_view_context_data(self):
+        for office in Office.objects.all():
+            response = self.client.get(reverse("office-detail", args=[office.id]))
+            self.assertTrue("office" in response.context)
+            self.assertEqual(office, response.context["office"])
+
+    def test_url_and_templates(self):
+        office = make_fake_office()
+        response = self.client.get(reverse("office-detail", args=[office.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "office_detail.html")
+
+    def test_context(self):
+        office = make_fake_office()
+        response = self.client.get(reverse("office-detail", args=[office.id]))
+        self.assertEqual(office, response.context["office"])
+
+
+class SequenceListViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
+    def test_url_and_templates(self):
+        response = self.client.get(reverse("sequence-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "sequence_list.html")
+
+    def test_ordering(self):
+        # the sequences in the list should be ordered by the "siglum" and "sequence" fields
+        response = self.client.get(reverse("sequence-list"))
+        sequences = response.context["sequences"]
+        self.assertEqual(sequences.query.order_by, ("siglum", "sequence"))
+
+    def test_search_incipit(self):
+        # create a published sequence source and some sequence in it
+        source = Source.objects.create(
+            published=True, title="a sequence source"
+        )
+        sequence = Sequence.objects.create(
+            incipit=make_fake_text(max_size=30), source=source
+        )
+        search_term = get_random_search_term(sequence.incipit)
+        # request the page, search for the incipit
+        response = self.client.get(reverse("sequence-list"), {"incipit": search_term})
+        # the sequence should be present in the results
+        self.assertIn(sequence, response.context["sequences"])
+
+    def test_search_siglum(self):
+        # create a published sequence source and some sequence in it
+        source = Source.objects.create(
+            published=True, title="a sequence source"
+        )
+        sequence = Sequence.objects.create(
+            siglum=make_fake_text(max_size=10), source=source
+        )
+        search_term = get_random_search_term(sequence.siglum)
+        # request the page, search for the siglum
+        response = self.client.get(reverse("sequence-list"), {"siglum": search_term})
+        # the sequence should be present in the results
+        self.assertIn(sequence, response.context["sequences"])
+
+    def test_search_cantus_id(self):
+        # create a published sequence source and some sequence in it
+        source = Source.objects.create(
+            published=True, title="a sequence source"
+        )
+        # faker generates a fake cantus id, in the form of two letters followed by five digits
+        sequence = Sequence.objects.create(
+            cantus_id=faker.bothify("??#####"), source=source
+        )
+        search_term = get_random_search_term(sequence.cantus_id)
+        # request the page, search for the incipit
+        response = self.client.get(reverse("sequence-list"), {"cantus_id": search_term})
+        # the sequence should be present in the results
+        self.assertIn(sequence, response.context["sequences"])
+
+
+class SequenceDetailViewTest(TestCase):
+    def test_url_and_templates(self):
+        sequence = make_fake_sequence()
+        response = self.client.get(reverse("sequence-detail", args=[sequence.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "sequence_detail.html")
+
+    def test_concordances(self):
+        sequence = make_fake_sequence()
+        sequence_with_same_cantus_id = make_fake_sequence(cantus_id=sequence.cantus_id)
+        response = self.client.get(reverse("sequence-detail", args=[sequence.id]))
+        concordances = response.context["concordances"]
+        self.assertIn(sequence_with_same_cantus_id, concordances)
+
+
+class SequenceEditViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client = Client()
+        project_manager = Group.objects.get(name='project manager') 
+        project_manager.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+    def test_context(self):
+        sequence = make_fake_sequence()
+        response = self.client.get(reverse("sequence-edit", args=[sequence.id]))
+        self.assertEqual(sequence, response.context["object"])
+
+    def test_url_and_templates(self):
+        sequence = make_fake_sequence()
+
+        response = self.client.get(reverse("sequence-edit", args=[sequence.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "sequence_edit.html")
+
+        response = self.client.get(reverse("sequence-edit", args=[sequence.id + 100]))
+        self.assertEqual(response.status_code, 404)
+        self.assertTemplateUsed(response, "404.html")
+
+    def test_update_sequence(self):
+        sequence = make_fake_sequence(incipit="test_update_sequence")
+        sequence_id = str(sequence.id)
+        response = self.client.post(
+            reverse('sequence-edit', args=[sequence_id]), 
+            {'title': 'test', 'source': sequence.source.id})
+        self.assertEqual(response.status_code, 302)
+        sequence.refresh_from_db()
+        self.assertEqual(sequence.title, 'test')
+
+
+class SourceListViewTest(TestCase):
+    def setUp(self):
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
+    def test_url_and_templates(self):
+        response = self.client.get(reverse("source-list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "source_list.html")
+
+    def test_provenances_and_centuries_in_context(self):
+        """Test the `provenances` and `centuries` in the context. They are displayed as options in the selectors"""
+        provenance = make_fake_provenance()
+        century = make_fake_century()
+        response = self.client.get(reverse("source-list"))
+        provenances = response.context["provenances"]
+        self.assertIn({"id": provenance.id, "name": provenance.name}, provenances)
+        centuries = response.context["centuries"]
+        self.assertIn({"id": century.id, "name": century.name}, centuries)
+
+    def test_only_published_sources_visible(self):
+        """For a source to be displayed in the list, its `published` field must be `True`"""
+        published_source = Source.objects.create(
+            published=True, title="published source"
+        )
+        private_source = Source.objects.create(
+            published=False, title="private source"
+        )
+        response = self.client.get(reverse("source-list"))
+        sources = response.context["sources"]
+        self.assertIn(published_source, sources)
+        self.assertNotIn(private_source, sources)
+
+    def test_filter_by_segment(self):
+        """The source list can be filtered by `segment`, `provenance`, `century`, and `full_source`"""
+        cantus_segment = make_fake_segment(name="cantus")
+        clavis_segment = make_fake_segment(name="clavis")
+        chant_source = Source.objects.create(
+            segment=cantus_segment, title="chant source", published=True
+        )
+        seq_source = Source.objects.create(
+            segment=clavis_segment, title="sequence source", published=True
+        )
+
+        # display chant sources only
+        response = self.client.get(
+            reverse("source-list"), {"segment": cantus_segment.id}
+        )
+        sources = response.context["sources"]
+        self.assertIn(chant_source, sources)
+        self.assertNotIn(seq_source, sources)
+
+        # display sequence sources only
+        response = self.client.get(
+            reverse("source-list"), {"segment": clavis_segment.id}
+        )
+        sources = response.context["sources"]
+        self.assertIn(seq_source, sources)
+        self.assertNotIn(chant_source, sources)
+
+    def test_filter_by_provenance(self):
+        aachen = make_fake_provenance()
+        albi = make_fake_provenance()
+        aachen_source = Source.objects.create(
+            provenance=aachen,
+            published=True,
+            title="source originated in Aachen",
+        )
+        albi_source = Source.objects.create(
+            provenance=albi,
+            published=True,
+            title="source originated in Albi",
+        )
+        no_provenance_source = Source.objects.create(
+            published=True, title="source with empty provenance"
+        )
+
+        # display sources in Aachen
+        response = self.client.get(reverse("source-list"), {"provenance": aachen.id})
+        sources = response.context["sources"]
+        # only aachen_source should be in the list
+        self.assertIn(aachen_source, sources)
+        self.assertNotIn(albi_source, sources)
+        self.assertNotIn(no_provenance_source, sources)
+
+    def test_filter_by_century(self):
+        ninth_century = Century.objects.create(name="09th century")
+        ninth_century_first_half = Century.objects.create(
+            name="09th century (1st half)"
+        )
+        tenth_century = Century.objects.create(name="10th century")
+
+        ninth_century_source = Source.objects.create(
+            published=True, title="source",
+        )
+        ninth_century_source.century.set([ninth_century])
+
+        ninth_century_first_half_source = Source.objects.create(
+            published=True, title="source",
+        )
+        ninth_century_first_half_source.century.set([ninth_century_first_half])
+
+        multiple_century_source = Source.objects.create(
+            published=True, title="source",
+        )
+        multiple_century_source.century.set([ninth_century, tenth_century])
+
+        # display sources in ninth century
+        response = self.client.get(
+            reverse("source-list"), {"century": ninth_century.id}
+        )
+        sources = response.context["sources"]
+        # ninth_century_source, ninth_century_first_half_source, and
+        # multiple_century_source should all be in the list
+        self.assertIn(ninth_century_source, sources)
+        self.assertIn(ninth_century_first_half_source, sources)
+        self.assertIn(multiple_century_source, sources)
+
+        # display sources in ninth century first half
+        response = self.client.get(
+            reverse("source-list"), {"century": ninth_century_first_half.id}
+        )
+        sources = response.context["sources"]
+        # only ninth_century_first_half_source should be in the list
+        self.assertNotIn(ninth_century_source, sources)
+        self.assertIn(ninth_century_first_half_source, sources)
+        self.assertNotIn(multiple_century_source, sources)
+
+    def test_filter_by_full_source(self):
+        full_source = Source.objects.create(
+            full_source=True, published=True, title="full source"
+        )
+        fragment = Source.objects.create(
+            full_source=False, published=True, title="fragment"
+        )
+        unknown = Source.objects.create(
+            published=True, title="full_source field is empty"
+        )
+
+        # display full sources
+        response = self.client.get(reverse("source-list"), {"fullSource": "true"})
+        sources = response.context["sources"]
+        # full_source and unknown_source should be in the list, fragment should not
+        self.assertIn(full_source, sources)
+        self.assertNotIn(fragment, sources)
+        self.assertIn(unknown, sources)
+
+        # display fragments
+        response = self.client.get(reverse("source-list"), {"fullSource": "false"})
+        sources = response.context["sources"]
+        # fragment should be in the list, full_source and unknown_source should not
+        self.assertNotIn(full_source, sources)
+        self.assertIn(fragment, sources)
+        self.assertNotIn(unknown, sources)
+
+        # display all sources
+        response = self.client.get(reverse("source-list"))
+        sources = response.context["sources"]
+        # all three should be in the list
+        self.assertIn(full_source, sources)
+        self.assertIn(fragment, sources)
+        self.assertIn(unknown, sources)
+
+    def test_search_by_title(self):
+        """The "general search" field searches in `title`, `siglum`, `rism_siglum`, `description`, and `summary`"""
+        source = Source.objects.create(
+            title=make_fake_text(max_size=20), published=True
+        )
+        search_term = get_random_search_term(source.title)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+    def test_search_by_siglum(self):
+        source = Source.objects.create(
+            siglum=make_fake_text(max_size=20), published=True, title="title"
+        )
+        search_term = get_random_search_term(source.siglum)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+    def test_search_by_rism_siglum_name(self):
+        rism_siglum = make_fake_rism_siglum()
+        source = Source.objects.create(
+            rism_siglum=rism_siglum, published=True, title="title",
+        )
+        search_term = get_random_search_term(source.rism_siglum.name)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+    def test_search_by_rism_siglum_description(self):
+        rism_siglum = make_fake_rism_siglum()
+        source = Source.objects.create(
+            rism_siglum=rism_siglum, published=True, title="title",
+        )
+        search_term = get_random_search_term(source.rism_siglum.description)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+    def test_search_by_description(self):
+        source = Source.objects.create(
+            description=make_fake_text(max_size=200),
+            published=True,
+            title="title",
+        )
+        search_term = get_random_search_term(source.description)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+    def test_search_by_summary(self):
+        source = Source.objects.create(
+            summary=make_fake_text(max_size=200),
+            published=True,
+            title="title",
+        )
+        search_term = get_random_search_term(source.summary)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+    def test_search_by_indexing_notes(self):
+        """The "indexing notes" field searches in `indexing_notes` and indexer/editor related fields"""
+        source = Source.objects.create(
+            indexing_notes=make_fake_text(max_size=200),
+            published=True,
+            title="title",
+        )
+        search_term = get_random_search_term(source.indexing_notes)
+        response = self.client.get(reverse("source-list"), {"indexing": search_term})
+        self.assertIn(source, response.context["sources"])
+
+
+class SourceCreateViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client = Client()
+        project_manager = Group.objects.get(name='project manager') 
+        project_manager.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+        # unless a segment is specified when a source is created, the source is automatically assigned
+        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
+        # such a segment exists
+        Segment.objects.create(name="CANTUS Database")
+
+    def test_url_and_templates(self):
+        response = self.client.get(reverse("source-create"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "source_create_form.html")
+
+    def test_create_source(self):
+        response = self.client.post(
+            reverse('source-create'), 
+            {'title': 'test'})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('source-create'))       
+
+        source = Source.objects.first()
+        self.assertEqual(source.title, 'test')
+
+
+class SourceEditViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client = Client()
+        project_manager = Group.objects.get(name='project manager') 
+        project_manager.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+    def test_context(self):
+        source = make_fake_source()
+        response = self.client.get(reverse("source-edit", args=[source.id]))
+        self.assertEqual(source, response.context["object"])
+
+    def test_url_and_templates(self):
+        source = make_fake_source()
+
+        response = self.client.get(reverse("source-edit", args=[source.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "source_edit.html")
+
+        response = self.client.get(reverse("source-edit", args=[source.id + 100]))
+        self.assertEqual(response.status_code, 404)
+        self.assertTemplateUsed(response, "404.html")
+
+    def test_edit_source(self):
+        source = make_fake_source()
+
+        response = self.client.post(
+            reverse('source-edit', args=[source.id]), 
+            {'title': 'test'})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('source-detail', args=[source.id]))       
+        source.refresh_from_db()
+        self.assertEqual(source.title, 'test')
+
+
+class SourceDetailViewTest(TestCase):
+    def test_url_and_templates(self):
+        source = make_fake_source()
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "source_detail.html")
+
+    def test_context_chant_folios(self):
+        # create a source and several chants in it
+        source = make_fake_source()
+        Chant.objects.create(source=source, folio="001r")
+        Chant.objects.create(source=source, folio="001r")
+        Chant.objects.create(source=source, folio="001v")
+        Chant.objects.create(source=source, folio="001v")
+        Chant.objects.create(source=source, folio="002r")
+        Chant.objects.create(source=source, folio="002v")
+        # request the page
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        # the element in "folios" should be unique and ordered in this way
+        folios = response.context["folios"]
+        self.assertEqual(list(folios), ["001r", "001v", "002r", "002v"])
+
+    def test_context_sequence_folios(self):
+        # create a sequence source and several sequences in it
+        source = Source.objects.create(
+            segment=Segment.objects.create(id=4064, name="Bower Sequence Database"),
+            title="a sequence source",
+            published=True
+        )
+        Sequence.objects.create(source=source, folio="001r")
+        Sequence.objects.create(source=source, folio="001r")
+        Sequence.objects.create(source=source, folio="001v")
+        Sequence.objects.create(source=source, folio="001v")
+        Sequence.objects.create(source=source, folio="002r")
+        Sequence.objects.create(source=source, folio="002v")
+        # request the page
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        # the element in "folios" should be unique and ordered in this way
+        folios = response.context["folios"]
+        self.assertEqual(list(folios), ["001r", "001v", "002r", "002v"])
+        # the folios should be ordered by the "folio" field
+        self.assertEqual(folios.query.order_by, ("folio",))
+
+    def test_context_feasts_with_folios(self):
+        # create a source and several chants (associated with feasts) in it
+        source = make_fake_source()
+        feast_1 = make_fake_feast()
+        feast_2 = make_fake_feast()
+        Chant.objects.create(source=source, folio="001r", feast=feast_1)
+        Chant.objects.create(source=source, folio="001r", feast=feast_1)
+        Chant.objects.create(source=source, folio="001v", feast=feast_2)
+        Chant.objects.create(source=source, folio="001v")
+        Chant.objects.create(source=source, folio="001v", feast=feast_2)
+        Chant.objects.create(source=source, folio="002r", feast=feast_1)
+        # request the page
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        # context "feasts_with_folios" is a list of tuples
+        # it records the folios where the feast changes
+        expected_result = [("001r", feast_1), ("001v", feast_2), ("002r", feast_1)]
+        self.assertEqual(response.context["feasts_with_folios"], expected_result)
+
+    def test_context_sequences(self):
+        # create a sequence source and several sequences in it
+        source = Source.objects.create(
+            segment=Segment.objects.create(id=4064, name="Bower Sequence Database"),
+            title="a sequence source",
+            published=True
+        )
+        sequence = Sequence.objects.create(source=source)
+        # request the page
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        # the sequence should be in the list of sequences
+        self.assertIn(sequence, response.context["sequences"])
+        # the list of sequences should be ordered by the "sequence" field
+        self.assertEqual(response.context["sequences"].query.order_by, ("sequence",))
+
+
 class JsonMelodyExportTest(TestCase):
     def test_json_melody_response(self):
         NUM_CHANTS = 10
@@ -2038,400 +2432,6 @@ class JsonNextChantsTest(TestCase):
         self.assertIsInstance(response, JsonResponse)
         unpacked_response = json.loads(response.content)
         self.assertEqual(unpacked_response, {})
-
-
-class PermissionsTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        Group.objects.create(name="project manager")
-        Group.objects.create(name="contributor")
-        Group.objects.create(name="editor")
-
-        for i in range(5):
-            source = make_fake_source()
-            for i in range(5):
-                Chant.objects.create(source=source)
-                Sequence.objects.create(source=source)
-                
-    def setUp(self):
-        self.user = get_user_model().objects.create(email='test@test.com')
-        self.user.set_password('pass')
-        self.user.save()
-        self.client = Client()
-
-    def test_login(self):
-        source = make_fake_source()
-        chant = make_fake_chant()
-        sequence = make_fake_sequence()
-
-        # currently not logged in, should redirect
-
-        # ChantCreateView
-        response = self.client.get(f'/chant-create/{source.id}')
-        self.assertRedirects(response, f'/login/?next=/chant-create/{source.id}')       
-
-        # ChantDeleteView
-        response = self.client.get(f'/chant-delete/{chant.id}')
-        self.assertRedirects(response, f'/login/?next=/chant-delete/{chant.id}')        
-        
-        # ChantEditVolpianoView
-        response = self.client.get(f'/edit-volpiano/{source.id}')
-        self.assertRedirects(response, f'/login/?next=/edit-volpiano/{source.id}')        
-
-        # SequenceEditView
-        response = self.client.get(f'/edit-sequence/{sequence.id}')
-        self.assertRedirects(response, f'/login/?next=/edit-sequence/{sequence.id}')        
-
-        # SourceCreateView
-        response = self.client.get('/source-create/')
-        self.assertRedirects(response, '/login/?next=/source-create/')    
-
-        # SourceEditView
-        response = self.client.get(f'/edit-source/{source.id}')
-        self.assertRedirects(response, f'/login/?next=/edit-source/{source.id}')
-
-        # UserSourceListView
-        response = self.client.get('/my-sources/')
-        self.assertRedirects(response, '/login/?next=/my-sources/')        
-
-        # UserListView
-        response = self.client.get('/users/')
-        self.assertRedirects(response, '/login/?next=/users/')        
-
-    def test_permissions_project_manager(self):
-        project_manager = Group.objects.get(name='project manager') 
-        project_manager.user_set.add(self.user)
-        self.client.login(email='test@test.com', password='pass')
-
-        # get random source, chant and sequence
-        source = Source.objects.order_by('?').first()
-        chant = Chant.objects.order_by('?').first()
-        sequence = Sequence.objects.order_by('?').first()
-
-        # ChantCreateView
-        response = self.client.get(f'/chant-create/{source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # ChantDeleteView
-        response = self.client.get(f'/chant-delete/{chant.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # ChantEditVolpianoView
-        response = self.client.get(f'/edit-volpiano/{source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # SequenceEditView
-        response = self.client.get(f'/edit-sequence/{sequence.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # SourceCreateView
-        response = self.client.get('/source-create/')
-        self.assertEqual(response.status_code, 200)
-
-        # SourceEditView
-        response = self.client.get(f'/edit-source/{source.id}')
-        self.assertEqual(response.status_code, 200)
-
-    def test_permissions_contributor(self):
-        contributor = Group.objects.get(name='contributor') 
-        contributor.user_set.add(self.user)
-        self.client.login(email='test@test.com', password='pass')
-
-        # a source assigned to the current user
-        assigned_source = make_fake_source()
-        self.user.sources_user_can_edit.add(assigned_source)
-        for i in range(5):
-            Chant.objects.create(source=assigned_source)
-        chant_in_assigned_source = Chant.objects.filter(source=assigned_source).order_by('?').first()
-
-        # a source created by the current user
-        source_created_by_contributor = make_fake_source()
-        source_created_by_contributor.created_by = self.user
-        source_created_by_contributor.save()
-        for i in range(5):
-            Chant.objects.create(source=source_created_by_contributor)
-        chant_in_source_created_by_contributor = Chant.objects.filter(source=source_created_by_contributor).order_by('?').first()
-
-        # did not create the source, was not assigned the source
-        restricted_source = Source.objects.filter(~Q(created_by=self.user)&~Q(id=assigned_source.id)).order_by('?').first()
-        restricted_chant = Chant.objects.filter(source=restricted_source).order_by('?').first()
-        
-        # a random sequence
-        sequence = Sequence.objects.order_by('?').first()
-
-        # ChantCreateView
-        response = self.client.get(f'/chant-create/{restricted_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/chant-create/{source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/chant-create/{assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # ChantDeleteView
-        response = self.client.get(f'/chant-delete/{restricted_chant.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/chant-delete/{chant_in_source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/chant-delete/{chant_in_assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # ChantEditVolpianoView
-        response = self.client.get(f'/edit-volpiano/{restricted_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/edit-volpiano/{source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/edit-volpiano/{assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # SequenceEditView
-        response = self.client.get(f'/edit-sequence/{sequence.id}')
-        self.assertEqual(response.status_code, 403)
-
-        # SourceCreateView
-        response = self.client.get('/source-create/')
-        self.assertEqual(response.status_code, 200)
-
-        # SourceEditView
-        response = self.client.get(f'/edit-source/{restricted_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/edit-source/{source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/edit-source/{assigned_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-    def test_permissions_editor(self):
-        editor = Group.objects.get(name='editor') 
-        editor.user_set.add(self.user)
-        self.client.login(email='test@test.com', password='pass')
-
-        # a source assigned to the current user
-        assigned_source = make_fake_source()
-        self.user.sources_user_can_edit.add(assigned_source)
-        for i in range(5):
-            Chant.objects.create(source=assigned_source)
-        chant_in_assigned_source = Chant.objects.filter(source=assigned_source).order_by('?').first()
-
-        # a source created by the current user
-        source_created_by_contributor = make_fake_source()
-        source_created_by_contributor.created_by = self.user
-        source_created_by_contributor.save()
-        for i in range(5):
-            Chant.objects.create(source=source_created_by_contributor)
-        chant_in_source_created_by_contributor = Chant.objects.filter(source=source_created_by_contributor).order_by('?').first()
-
-        # did not create the source, was not assigned the source
-        restricted_source = Source.objects.filter(~Q(created_by=self.user)&~Q(id=assigned_source.id)).order_by('?').first()
-        restricted_chant = Chant.objects.filter(source=restricted_source).order_by('?').first()
-        
-        # a random sequence
-        sequence = Sequence.objects.order_by('?').first()
-
-        # ChantCreateView
-        response = self.client.get(f'/chant-create/{restricted_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/chant-create/{source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/chant-create/{assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # ChantDeleteView
-        response = self.client.get(f'/chant-delete/{restricted_chant.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/chant-delete/{chant_in_source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/chant-delete/{chant_in_assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # ChantEditVolpianoView
-        response = self.client.get(f'/edit-volpiano/{restricted_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/edit-volpiano/{source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/edit-volpiano/{assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-        # SequenceEditView
-        response = self.client.get(f'/edit-sequence/{sequence.id}')
-        self.assertEqual(response.status_code, 403)
-
-        # SourceCreateView
-        response = self.client.get('/source-create/')
-        self.assertEqual(response.status_code, 200)
-
-        # SourceEditView
-        response = self.client.get(f'/edit-source/{restricted_source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        response = self.client.get(f'/edit-source/{source_created_by_contributor.id}')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get(f'/edit-source/{assigned_source.id}')
-        self.assertEqual(response.status_code, 200)
-
-    def test_permissions_default(self):
-        self.client.login(email='test@test.com', password='pass')
-
-        # get random source, chant and sequence
-        source = Source.objects.order_by('?').first()
-        chant = Chant.objects.order_by('?').first()
-        sequence = Sequence.objects.order_by('?').first()
-
-        # ChantCreateView
-        response = self.client.get(f'/chant-create/{source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        # ChantDeleteView
-        response = self.client.get(f'/chant-delete/{chant.id}')
-        self.assertEqual(response.status_code, 403)
-
-        # ChantEditVolpianoView
-        response = self.client.get(f'/edit-volpiano/{source.id}')
-        self.assertEqual(response.status_code, 403)
-
-        # SequenceEditView
-        response = self.client.get(f'/edit-sequence/{sequence.id}')
-        self.assertEqual(response.status_code, 403)
-
-        # SourceCreateView
-        response = self.client.get('/source-create/')
-        self.assertEqual(response.status_code, 403)
-
-        # SourceEditView
-        response = self.client.get(f'/edit-source/{source.id}')
-        self.assertEqual(response.status_code, 403)
-
-
-class SequenceEditViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        Group.objects.create(name="project manager")
-
-    def setUp(self):
-        self.user = get_user_model().objects.create(email='test@test.com')
-        self.user.set_password('pass')
-        self.user.save()
-        self.client = Client()
-        project_manager = Group.objects.get(name='project manager') 
-        project_manager.user_set.add(self.user)
-        self.client.login(email='test@test.com', password='pass')
-
-    def test_context(self):
-        sequence = make_fake_sequence()
-        response = self.client.get(reverse("sequence-edit", args=[sequence.id]))
-        self.assertEqual(sequence, response.context["object"])
-
-    def test_url_and_templates(self):
-        sequence = make_fake_sequence()
-
-        response = self.client.get(reverse("sequence-edit", args=[sequence.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "sequence_edit.html")
-
-        response = self.client.get(reverse("sequence-edit", args=[sequence.id + 100]))
-        self.assertEqual(response.status_code, 404)
-        self.assertTemplateUsed(response, "404.html")
-
-    def test_update_sequence(self):
-        sequence = make_fake_sequence(incipit="test_update_sequence")
-        sequence_id = str(sequence.id)
-        response = self.client.post(
-            reverse('sequence-edit', args=[sequence_id]), 
-            {'title': 'test', 'source': sequence.source.id})
-        self.assertEqual(response.status_code, 302)
-        sequence.refresh_from_db()
-        self.assertEqual(sequence.title, 'test')
-
-
-class SourceCreateViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        Group.objects.create(name="project manager")
-
-    def setUp(self):
-        self.user = get_user_model().objects.create(email='test@test.com')
-        self.user.set_password('pass')
-        self.user.save()
-        self.client = Client()
-        project_manager = Group.objects.get(name='project manager') 
-        project_manager.user_set.add(self.user)
-        self.client.login(email='test@test.com', password='pass')
-        # unless a segment is specified when a source is created, the source is automatically assigned
-        # to the segment with the name "CANTUS Database" - to prevent errors, we must make sure that
-        # such a segment exists
-        Segment.objects.create(name="CANTUS Database")
-
-    def test_url_and_templates(self):
-        response = self.client.get(reverse("source-create"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "source_create_form.html")
-
-    def test_create_source(self):
-        response = self.client.post(
-            reverse('source-create'), 
-            {'title': 'test'})
-
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse('source-create'))       
-
-        source = Source.objects.first()
-        self.assertEqual(source.title, 'test')
-
-
-class SourceEditViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        Group.objects.create(name="project manager")
-
-    def setUp(self):
-        self.user = get_user_model().objects.create(email='test@test.com')
-        self.user.set_password('pass')
-        self.user.save()
-        self.client = Client()
-        project_manager = Group.objects.get(name='project manager') 
-        project_manager.user_set.add(self.user)
-        self.client.login(email='test@test.com', password='pass')
-
-    def test_context(self):
-        source = make_fake_source()
-        response = self.client.get(reverse("source-edit", args=[source.id]))
-        self.assertEqual(source, response.context["object"])
-
-    def test_url_and_templates(self):
-        source = make_fake_source()
-
-        response = self.client.get(reverse("source-edit", args=[source.id]))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "source_edit.html")
-
-        response = self.client.get(reverse("source-edit", args=[source.id + 100]))
-        self.assertEqual(response.status_code, 404)
-        self.assertTemplateUsed(response, "404.html")
-
-    def test_edit_source(self):
-        source = make_fake_source()
-
-        response = self.client.post(
-            reverse('source-edit', args=[source.id]), 
-            {'title': 'test'})
-
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse('source-detail', args=[source.id]))       
-        source.refresh_from_db()
-        self.assertEqual(source.title, 'test')
 
 
 class CISearchViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1045,6 +1045,56 @@ class ChantEditVolpianoViewTest(TestCase):
         self.assertEqual(chant.manuscript_full_text_std_spelling, 'test')
 
 
+class ChantProofreadViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email='test@test.com')
+        self.user.set_password('pass')
+        self.user.save()
+        self.client = Client()
+        project_manager = Group.objects.get(name='project manager') 
+        project_manager.user_set.add(self.user)
+        self.client.login(email='test@test.com', password='pass')
+
+    def test_view_url_and_templates(self):
+        source = make_fake_source()
+        source_id = source.id
+
+        for i in range(3):
+            chant = make_fake_chant(source=source, folio="001r", sequence_number=i)
+            sample_folio = chant.folio
+            sample_pk = chant.sequence_number
+        nonexistent_folio = "001v"
+
+        response_1 = self.client.get(f"/proofread-chant/{source_id}")
+        self.assertEqual(response_1.status_code, 200)
+        self.assertTemplateUsed(response_1, "base.html")
+        self.assertTemplateUsed(response_1, "chant_proofread.html")
+
+        response_2 = self.client.get(reverse("chant-proofread", args=[source_id]))
+        self.assertEqual(response_2.status_code, 200)
+
+        response_3 = self.client.get(f"/proofread-chant/{source_id}?folio={sample_folio}")
+        self.assertEqual(response_3.status_code, 200)
+
+        response_4 = self.client.get(f"/proofread-chant/{source_id}?folio={nonexistent_folio}")
+        self.assertEqual(response_4.status_code, 404)
+
+        response_5 = self.client.get(f"/proofread-chant/{source_id}?pk={sample_pk}&folio={sample_folio}")
+        self.assertEqual(response_5.status_code, 200)
+
+        self.client.logout()
+        response_6 = self.client.get(reverse("chant-proofread", args=[source_id]))
+        self.assertEqual(response_6.status_code, 302) # redirect to login page
+    
+    def test_proofread_chant(self):
+        pass
+
+
+
 class FeastListViewTest(TestCase):
     def test_view_url_path(self):
         response = self.client.get("/feasts/")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1139,6 +1139,16 @@ class ChantEditSyllabificationViewTest(TestCase):
         response_3 = self.client.get(reverse("source-edit-syllabification", args=[chant_id]))
         self.assertEqual(response_3.status_code, 302) # 302: redirect to login page
 
+    def test_edit_syllabification(self):
+        chant = make_fake_chant(
+            manuscript_syllabized_full_text="lorem ipsum"
+        )
+        self.assertIs(chant.manuscript_syllabized_full_text, "lorem ipsum")
+        response = self.client.post(f"/edit-syllabification/{chant.id}", {"manuscript_syllabized_full_text": "lo-rem ip-sum"})
+        self.assertEqual(response.status_code, 302) # 302 Found
+        chant.refresh_from_db()
+        self.assertEqual(chant.manuscript_syllabized_full_text, "lo-rem ip-sum")
+
 
 class FeastListViewTest(TestCase):
     def test_view_url_path(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -734,7 +734,6 @@ class ChantSearchMSViewTest(TestCase):
         response = self.client.get(reverse("chant-search-ms", args=[source.id]))
         self.assertEqual(response.status_code, 403)
 
-
     def test_search_by_office(self):
         # source = Source.objects.create(public=True,published, title="a source")
         source = make_fake_source()
@@ -835,6 +834,19 @@ class ChantIndexViewTest(TestCase):
         response = self.client.get(reverse("chant-index"), {"source": source.id})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "full_index.html")
+
+    def test_published_vs_unpublished(self):
+        source = make_fake_source()
+
+        source.published = True
+        source.save()
+        response = self.client.get(reverse("chant-index"), {"source": source.id})
+        self.assertEqual(response.status_code, 200)
+
+        source.published = False
+        source.save()
+        response = self.client.get(reverse("chant-index"), {"source": source.id})
+        self.assertEqual(response.status_code, 403)
 
     def test_chant_source_queryset(self):
         chant_source = make_fake_source()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -355,7 +355,7 @@ class ChantListViewTest(TestCase):
         published_source = make_fake_source(published=True)
         response_1 = self.client.get(reverse("chant-list"), {"source": published_source.id})
         self.assertEqual(response_1.status_code, 200)
-        
+
         unpublished_source = make_fake_source(published=False)
         response_2 = self.client.get(reverse("chant-list"), {"source": unpublished_source.id})
         self.assertEqual(response_2.status_code, 403)
@@ -535,6 +535,24 @@ class ChantDetailViewTest(TestCase):
         )
         self.assertEqual(response.context["previous_folio"], "001v")
         self.assertIsNone(response.context["next_folio"])
+
+    def test_published_vs_unpublished(self):
+        source = make_fake_source()
+        chant = make_fake_chant(source=source)
+
+        source.published=True
+        source.save()
+        response = self.client.get(
+            reverse("chant-detail", args=[chant.id])
+        )
+        self.assertEqual(response.status_code, 200)
+
+        source.published=False
+        source.save()
+        response = self.client.get(
+            reverse("chant-detail", args=[chant.id])
+        )
+        self.assertEqual(response.status_code, 403)
 
 
 class ChantByCantusIDViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -721,6 +721,20 @@ class ChantSearchMSViewTest(TestCase):
         self.assertTemplateUsed(response, "base.html")
         self.assertTemplateUsed(response, "chant_search.html")
 
+    def test_published_vs_unpublished(self):
+        source = make_fake_source()
+
+        source.published = True
+        source.save()
+        response = self.client.get(reverse("chant-search-ms", args=[source.id]))
+        self.assertEqual(response.status_code, 200)
+
+        source.published = False
+        source.save()
+        response = self.client.get(reverse("chant-search-ms", args=[source.id]))
+        self.assertEqual(response.status_code, 403)
+
+
     def test_search_by_office(self):
         # source = Source.objects.create(public=True,published, title="a source")
         source = make_fake_source()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2521,11 +2521,19 @@ class ChangePasswordViewTest(TestCase):
         self.client.login(email='test@test.com', password='pass')
 
     def test_url_and_templates(self):
-        response_2 = self.client.get("/change-password/")
-        self.assertEqual(response_2.status_code, 200)
-        self.assertTemplateUsed(response_2, "base.html")
-        self.assertTemplateUsed(response_2, "registration/change_password.html")
         response_1 = self.client.get(reverse("change-password"))
         self.assertEqual(response_1.status_code, 200)
         self.assertTemplateUsed(response_1, "base.html")
         self.assertTemplateUsed(response_1, "registration/change_password.html")
+        response_2 = self.client.get("/change-password/")
+        self.assertEqual(response_2.status_code, 200)
+        self.assertTemplateUsed(response_2, "base.html")
+        self.assertTemplateUsed(response_2, "registration/change_password.html")
+
+    def test_change_password(self):
+        response_1 = self.client.post(reverse("change-password"), {"old_password": "pass", "new_password1": "updated_pass", "new_password2": "updated_pass"})
+        self.assertEqual(response_1.status_code, 200)
+        self.client.logout()
+        self.client.login(email='test@test.com', password='updated_pass')
+        response_2 = self.client.get(reverse("change-password"))
+        self.assertEqual(response_2.status_code, 200) # if login failed, status code will be 302

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1052,6 +1052,21 @@ class ChantEditVolpianoViewTest(TestCase):
         self.assertRedirects(response, reverse('source-edit-volpiano', args=[source.id]))  
         chant.refresh_from_db()
         self.assertEqual(chant.manuscript_full_text_std_spelling, 'test')
+    
+    def test_provide_suggested_fulltext(self):
+        source = make_fake_source()
+        chant = make_fake_chant(source=source, manuscript_full_text_std_spelling="",
+        cantus_id="007450")
+        response = self.client.get(
+            reverse('source-edit-volpiano', args=[source.id]), 
+            {'pk': chant.id}
+        )
+        # expected_suggestion is copied from Cantus Index. If this test is failing,
+        # it could be because the value stored in Cantus Index has changed.
+        # To verify, visit http://cantusindex.org/id/007450.
+        expected_suggestion = "Puer natus est nobis alleluia alleluia"
+        suggested_fulltext = response.context["suggested_fulltext"]
+        self.assertEqual(suggested_fulltext, expected_suggestion)
 
 
 class ChantProofreadViewTest(TestCase):


### PR DESCRIPTION
This pull request adds tests for all features introduced since about July 19, with two small exceptions:
- #232 is not included - I was having difficulty figuring out how to make `User.changed_initial_password` to toggle from `False` to `True`, and testing the login view to see whether it redirects to the change-password page
- we've done some work in `main_app/signals.py` lately; tests for those are not included