### PR TITLE
next_chant signals

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/populate_next_chant_fields.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_next_chant_fields.py
@@ -2,6 +2,17 @@ from main_app.models import Chant
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 
+# This script memoizes the result of Chant.get_next_chant(), which is expensive
+# to calculate on the fly, saving it as the Chant's .next_chant property.
+# This script populates the next_chant field for all chants in the database.
+# Once it has been calculated once (for example, after importing data
+# from OldCantus), it shouldn't need to be run again - whenever chants are
+# created, updated or deleted, the field should be recalculated for all chants
+# in the source by update_next_chant_fields() in main_app/signals.py.
+
+# to calculate all chants' next_chants from scratch: `python manage.py populate_next_chant_fields --overwrite`
+# to calculate next_chants for all chants that don't already have a next_chant specified: `python manage.py populate_next_chant_fields`
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -4,7 +4,6 @@ from functools import reduce
 from django.contrib.postgres.search import SearchVector
 from django.db import models
 from django.db.models import Value
-from django.db.models import F
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -45,3 +45,11 @@ def update_source_melody_count(instance, **kwargs):
     source = instance.source
     source.number_of_melodies = source.chant_set.filter(volpiano__isnull=False).count()
     source.save()
+
+@receiver(post_save, sender=Chant)
+@receiver(post_delete, sender=Chant)
+def update_next_chant_fields(instance, **kwargs):
+    """When saving or deleting a Chant, make sure the next_chant of each chant in the source is up-to-date"""
+    source = instance.source
+    for chant in source.chant_set.all():
+        chant.next_chant = chant.get_next_chant()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1718,8 +1718,6 @@ class ChantDeleteViewTest(TestCase):
         self.assertIs(chant_1.next_chant, None)
 
 
-
-
 class ChantEditVolpianoViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1653,6 +1653,15 @@ class ChantCreateViewTest(TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertTemplateUsed(response, "base.html")
             self.assertTemplateUsed(response, "chant_create.html")
+    
+    def test_next_chant_signal(self):
+        source = make_fake_source()
+        chant_1 = make_fake_chant(source=source, folio="001r", sequence_number=1)
+        response = self.client.post(
+            reverse("chant-create", args=[source.id]), 
+            {"manuscript_full_text_std_spelling": "cantus secundus", "folio": "001r", "sequence_number": "2"})
+        chant_2 = Chant.objects.get(manuscript_full_text_std_spelling="cantus secundus")
+        self.assertEqual(chant_1.next_chant, chant_2)
 
 
 class ChantDeleteViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1705,6 +1705,20 @@ class ChantDeleteViewTest(TestCase):
         response = self.client.post(reverse("chant-delete", args=[chant.id + 100]))
         self.assertEqual(response.status_code, 404)
 
+    def test_next_chant_signal(self):
+        chant_1 = make_fake_chant()
+        chant_2 = make_fake_chant(source=chant_1.source, folio=chant_1.folio, sequence_number=chant_1.sequence_number + 1)
+
+        chant_1.refresh_from_db()
+        self.assertEqual(chant_1.next_chant, chant_2)
+
+        response = self.client.post(reverse("chant-delete", args=[chant_2.id]))
+
+        chant_1.refresh_from_db()
+        self.assertIs(chant_1.next_chant, None)
+
+
+
 
 class ChantEditVolpianoViewTest(TestCase):
     @classmethod


### PR DESCRIPTION
This PR adds a function to `main_app/signals.py` that recalculates the `next_chant` field for each chant in a source whenever a chant in that source is created/updated/deleted.

It also includes tests for various Chant creating/updating/deleting views.