### PR TITLE
Add login prompt to 403 page if user is not authenticated

### DIFF
--- a/django/cantusdb_project/main_app/templates/403.html
+++ b/django/cantusdb_project/main_app/templates/403.html
@@ -8,6 +8,9 @@
             <br>
             <dl>
                 <dd>You are not authorized to access this page.</dd>
+                {% if not user.is_authenticated %}
+                <dd>This could be because you are not currently logged in. If you want, you can try <a href="{% url 'login' %}?next={{ request.path }}">logging in</a>.</dd>
+                {% endif %}
             </dl> 
         </div>
     </div>

--- a/django/cantusdb_project/main_app/templates/403.html
+++ b/django/cantusdb_project/main_app/templates/403.html
@@ -9,7 +9,7 @@
             <dl>
                 <dd>You are not authorized to access this page.</dd>
                 {% if not user.is_authenticated %}
-                    <dd>This could be because you are not currently logged in. If you want, you can try <a href="{% url 'login' %}?next={{ request.path }}">logging in</a>.</dd>
+                    <dd>This could be because you are not currently logged in. If you are a contributor and believe you should be able to see this page, try <a href="{% url 'login' %}?next={{ request.path }}">logging in</a>.</dd>
                 {% endif %}
             </dl> 
         </div>

--- a/django/cantusdb_project/main_app/templates/403.html
+++ b/django/cantusdb_project/main_app/templates/403.html
@@ -9,7 +9,7 @@
             <dl>
                 <dd>You are not authorized to access this page.</dd>
                 {% if not user.is_authenticated %}
-                <dd>This could be because you are not currently logged in. If you want, you can try <a href="{% url 'login' %}?next={{ request.path }}">logging in</a>.</dd>
+                    <dd>This could be because you are not currently logged in. If you want, you can try <a href="{% url 'login' %}?next={{ request.path }}">logging in</a>.</dd>
                 {% endif %}
             </dl> 
         </div>


### PR DESCRIPTION
fixes #300 

Turns out that getting django to raise a 401 error is not trivial, so this PR simply adds the text to the 403 page if the user is not logged in. In any case, it clarifies the situation where a user tries to visit a bookmarked page while they're logged out, which is the most important one I think.