### PR TITLE
Fix bug on content-overview page

### DIFF
--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -42,6 +42,10 @@
                         <td class="text-wrap" style="text-align:center">
                             <a href="{{ object.get_absolute_url }}"><b>{{ object.first_name }} {{ object.family_name }}</b></a>
                         </td>
+                    {% else %}
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
+                        </td>
                     {% endif %}
                     <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
                     <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>


### PR DESCRIPTION
This PR fixes a bug on the content-overview page, which caused columns to be offset if a row's object didn't have a `title`, `manuscript_full_text_std_spelling`, `name` or `first_name`:

![Screen Shot 2022-09-08 at 14 57 52](https://user-images.githubusercontent.com/58090591/189209738-e30f15ac-fa17-4925-a589-482db2cb6b4b.png)
