### PR TITLE
Add signals to precompute Chant and Source fields

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/populate_chant_fields.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_chant_fields.py
@@ -1,0 +1,27 @@
+from main_app.models import Chant
+from django.core.management.base import BaseCommand
+
+# This management command opens every chant in the database
+# and saves it. In doing so, it triggers the on_chant_save()
+# function for each chant, which populates several fields used
+# to optimizing site performance including
+# Chant.search_vectors, Chant.next_chant, Chant.is_last_chant_in_feast,
+# Chant.volpiano_notes, Chant.volpiano_intervals,
+# Source.number_of_chants and Source.number_of_melodies.
+
+# Run with `python manage.py populate_chant_fields`.
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        CHUNK_SIZE = 1_000
+        chants = Chant.objects.all()
+        chants_count = chants.count()
+        start_index = 0
+        while start_index <= chants_count:
+            print("processing chunk with start_index of", start_index)
+            chunk = chants[start_index:start_index+CHUNK_SIZE]
+            
+            for chant in chunk:
+                chant.save()
+            del chunk # make sure we don't use too much RAM
+            start_index += CHUNK_SIZE

--- a/django/cantusdb_project/main_app/management/commands/populate_chant_fields.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_chant_fields.py
@@ -5,8 +5,7 @@ from django.core.management.base import BaseCommand
 # and saves it. In doing so, it triggers the on_chant_save()
 # function for each chant, which populates several fields used
 # to optimizing site performance including
-# Chant.search_vectors, Chant.next_chant, Chant.is_last_chant_in_feast,
-# Chant.volpiano_notes, Chant.volpiano_intervals,
+# Chant.search_vectors, Chant.volpiano_notes, Chant.volpiano_intervals,
 # Source.number_of_chants and Source.number_of_melodies.
 
 # Run with `python manage.py populate_chant_fields`.

--- a/django/cantusdb_project/main_app/models/genre.py
+++ b/django/cantusdb_project/main_app/models/genre.py
@@ -9,3 +9,8 @@ class Genre(BaseModel):
 
     def __str__(self):
         return f"[{self.name}] {self.description}"
+
+    @property
+    def display_name(self) -> str:
+        """Alias for the __str()__ method, useful for templates."""
+        return self.__str__()

--- a/django/cantusdb_project/main_app/models/office.py
+++ b/django/cantusdb_project/main_app/models/office.py
@@ -8,3 +8,8 @@ class Office(BaseModel):
 
     def __str__(self):
         return f"[{self.name}] {self.description}"
+
+    @property
+    def display_name(self) -> str:
+        """Alias for the __str()__ method, useful for templates."""
+        return self.__str__()

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -7,13 +7,39 @@ from django.db.models import Value
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
+import re
+
 from main_app.models import Chant
 from main_app.models import Sequence
 
-
 @receiver(post_save, sender=Chant)
-def update_chant_search_vector(instance, **kwargs):
-    """When saving an instance of Chant, update its search vector field."""
+def on_chant_save(instance, **kwargs):
+    update_chant_search_vector(instance)
+    update_source_chant_count(instance)
+    update_source_melody_count(instance)
+    update_next_chant_fields(instance)
+    update_volpiano_fields(instance)
+
+@receiver(post_delete, sender=Chant)
+def on_chant_delete(instance, **kwargs):
+    update_source_chant_count(instance)
+    update_source_melody_count(instance)
+    update_next_chant_fields(instance)
+
+@receiver(post_save, sender=Sequence)
+def on_sequence_save(instance, **kwargs):
+    update_source_chant_count(instance)
+
+@receiver(post_delete, sender=Sequence)
+def on_sequence_delete(instance, **kwargs):
+    update_source_chant_count(instance)
+
+
+def update_chant_search_vector(instance):
+    """When saving an instance of Chant, update its search vector field.
+    
+    Called in on_chant_save()
+    """
     index_components = instance.index_components()
     pk = instance.pk
     search_vectors = []
@@ -28,32 +54,133 @@ def update_chant_search_vector(instance, **kwargs):
         search_vector=reduce(operator.add, search_vectors)
     )
 
-@receiver(post_save, sender=Chant)
-@receiver(post_save, sender=Sequence)
-@receiver(post_delete, sender=Chant)
-@receiver(post_delete, sender=Sequence)
-def update_source_chant_count(instance, **kwargs):
-    """When saving or deleting a Chant or Sequence, update its Source's number_of_chants field"""
+def update_source_chant_count(instance):
+    """When saving or deleting a Chant or Sequence, update its Source's number_of_chants field
+    
+    Called in on_chant_save(), on_chant_delete(), on_sequence_save() and on_sequence_delete()
+    """
+
     source = instance.source
     source.number_of_chants = source.chant_set.count() + source.sequence_set.count()
     source.save()
 
-@receiver(post_save, sender=Chant)
-@receiver(post_delete, sender=Chant)
-def update_source_melody_count(instance, **kwargs):
-    """When saving or deleting a Chant, update its Source's number_of_melodies field"""
+def update_source_melody_count(instance):
+    """When saving or deleting a Chant, update its Source's number_of_melodies field
+    
+    Called in on_chant_save() and on_chant_delete()
+    """
     source = instance.source
     source.number_of_melodies = source.chant_set.filter(volpiano__isnull=False).count()
     source.save()
 
-@receiver(post_save, sender=Chant)
-@receiver(post_delete, sender=Chant)
-def update_next_chant_fields(instance, **kwargs):
-    """When saving or deleting a Chant, make sure the next_chant of each chant in the source is up-to-date"""
+def update_next_chant_fields(instance):
+    """When saving or deleting a Chant, make sure the next_chant of each chant in the source is up-to-date
+    
+    Called in on_chant_save() and on_chant_delete()
+    """
     source = instance.source
     for chant in source.chant_set.all():
         next_chant = chant.get_next_chant()
         # use .update() instead of .save() to prevent RecursionError
         # (otherwise, saving would trigger @receiver(post_save, ...) again)
         Chant.objects.filter(id=chant.id).update(next_chant=next_chant)
+
+def update_volpiano_fields(instance):
+    """When saving a Chant, make sure the chant's volpiano_notes and volpiano_intervals are up-to-date
+    
+    Called in on_chant_save()
+    """
+    def generate_volpiano_notes(volpiano):
+        """
+        Populate the ``volpiano_notes`` field of the ``Chant`` model
+
+        This field is used for melody search
+
+        Args:
+            volpiano (str): The content of ``chant.volpiano``
+
+        Returns:
+            str: Volpiano str with non-note chars and duplicate consecutive notes removed
+        """
+        # unwanted_chars are non-note chars, including the clefs, barlines, and accidentals etc.
+        # the `searchMelody.js` on old cantus makes no reference to the b-flat accidentals ("y", "i", "z")
+        # so put them in unwanted chars for now
+        unwanted_chars = [
+            "-",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "?",
+            ".",
+            " ",
+            "y",
+            "i",
+            "z",
+        ]
+        # convert all charactors to lower-case, upper-case letters stand for liquescent of the same pitch
+        volpiano_lower = volpiano.lower()
+        # `)` stands for the lowest `g` note liquescent in volpiano, its 'lower case' is `9`
+        volpiano_notes = volpiano_lower.replace(")", "9")
+        # remove none-note charactors
+        for unwanted_char in unwanted_chars:
+            volpiano_notes = volpiano_notes.replace(unwanted_char, "")
+        # remove duplicate consecutive chars
+        volpiano_notes = re.sub(r"(.)\1+", r"\1", volpiano_notes)
+        return volpiano_notes
+
+    def generate_volpiano_intervals(volpiano_notes):
+        """
+        Populate the ``volpiano_intervals`` field of the ``Chant`` model
+
+        This field is used for melody search when searching for transpositions
+
+        Args:
+            volpiano_notes (str): The content of ``chant.volpiano_notes``,
+            populated by the ``generate_volpiano_notes`` function
+
+        Returns:
+            str: A str of digits, recording the intervals between adjacent notes
+        """
+        # replace '9' (the note G) with the char corresponding to (ASCII(a) - 1), because 'a' denotes the note A
+        volpiano_notes = volpiano_notes.replace("9", chr(ord("a") - 1))
+        # we model the interval between notes using the difference between the ASCII codes of corresponding letters
+        # the letter for the note B is "j" (106), note A is "h" (104), the letter "i" (105) is skipped
+        # move all notes above A down by one letter
+        volpiano_notes = list(volpiano_notes)
+        for j, note in enumerate(volpiano_notes):
+            if ord(note) >= 106:
+                volpiano_notes[j] = chr(ord(note) - 1)
+
+        # `intervals` records the difference between two adjacent notes.
+        # Note that intervals are encoded by counting the number of scale
+        # steps between adjacent notes: an ascending second is thus encoded
+        # as "1"; a descending third is encoded "-2", and so on.
+        intervals = []
+        for j in range(1, len(volpiano_notes)):
+            intervals.append(ord(volpiano_notes[j]) - ord(volpiano_notes[j - 1]))
+        # convert `intervals` to str
+        volpiano_intervals = "".join([str(interval) for interval in intervals])
+        return volpiano_intervals
+
+    if instance.volpiano is None:
+        return
+
+    volpiano_notes = generate_volpiano_notes(
+        instance.volpiano
+    )
+    Chant.objects.filter(id=instance.id).update(
+        volpiano_notes=volpiano_notes
+    )
+
+    volpiano_intervals = generate_volpiano_intervals(
+        volpiano_notes
+    )
+    Chant.objects.filter(id=instance.id).update(
+        volpiano_intervals=volpiano_intervals
+    )
+
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -159,14 +159,12 @@ def update_volpiano_fields(instance):
     volpiano_notes = generate_volpiano_notes(
         instance.volpiano
     )
-    Chant.objects.filter(id=instance.id).update(
-        volpiano_notes=volpiano_notes
-    )
-
     volpiano_intervals = generate_volpiano_intervals(
         volpiano_notes
     )
+
     Chant.objects.filter(id=instance.id).update(
-        volpiano_intervals=volpiano_intervals
+        volpiano_notes=volpiano_notes,
+        volpiano_intervals=volpiano_intervals,
     )
 

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -125,9 +125,7 @@ def make_fake_chant(source=None,
         manuscript_full_text_std_proofread=manuscript_full_text_std_proofread,
         manuscript_full_text=manuscript_full_text_std_spelling,
         manuscript_full_text_proofread=faker.boolean(),
-        volpiano=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        volpiano=volpiano,
         volpiano_proofread=faker.boolean(),
         image_link=faker.image_url(),
         cao_concordances=make_fake_text(SHORT_CHAR_FIELD_MAX),

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -132,9 +132,9 @@ class GenreModelTest(TestCase):
     def setUpTestData(cls):
         make_fake_genre()
 
-    def test_object_name(self):
+    def test_string_representation(self):
         genre = Genre.objects.first()
-        self.assertEqual(str(genre), genre.name)
+        self.assertEqual(str(genre), f"[{genre.name}] {genre.description}")
 
     def test_display_name(self):
         genre = Genre.objects.first()
@@ -214,9 +214,12 @@ class OfficeModelTest(TestCase):
     def setUpTestData(cls):
         make_fake_office()
 
-    def test_object_name(self):
+    def test_object_string_representation(self):
         office = Office.objects.first()
-        self.assertEqual(str(office), office.name)
+        self.assertEqual(
+            str(office),
+            f"[{office.name}] {office.description}"
+        )
 
     def test_display_name(self):
         office = Office.objects.first()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1050,7 +1050,16 @@ class ChantCreateViewTest(TestCase):
         source = make_fake_source()
         self.client.post(
             reverse("chant-create", args=[source.id]), 
-            {"manuscript_full_text_std_spelling": "ut queant lactose", "folio": "001r", "sequence_number": "1", "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"}
+            {
+                "manuscript_full_text_std_spelling": "ut queant lactose",
+                "folio": "001r",
+                "sequence_number": "1",
+                # liquescents, to be converted to lowercase
+                #                    vv v v v v v v  
+                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"
+                #                      ^ ^ ^ ^ ^ ^ ^^^^^^^^
+                # clefs, accidentals, etc., to be deleted
+            }
         )
         chant_1 = Chant.objects.get(manuscript_full_text_std_spelling="ut queant lactose")
         self.assertEqual(chant_1.volpiano, "9abcdefg)A-B1C2D3E4F5G67?. yiz")
@@ -1183,12 +1192,16 @@ class ChantEditVolpianoViewTest(TestCase):
             sequence_number=1
         )
         self.client.post(
-            reverse('source-edit-volpiano', args=[source.id]),  
+            reverse('source-edit-volpiano', args=[source.id]),
             {
                 "manuscript_full_text_std_spelling": "ut queant lactose",
                 "folio": "001r",
                 "sequence_number": "1",
-                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz",
+                # liquescents, to be converted to lowercase
+                #                    vv v v v v v v  
+                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"
+                #                      ^ ^ ^ ^ ^ ^ ^^^^^^^^
+                # clefs, accidentals, etc., to be deleted
             }
         )
         chant_1 = Chant.objects.get(

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1045,16 +1045,6 @@ class ChantCreateViewTest(TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertTemplateUsed(response, "base.html")
             self.assertTemplateUsed(response, "chant_create.html")
-
-    def test_next_chant_signal(self):
-        source = make_fake_source()
-        chant_1 = make_fake_chant(source=source, folio="001r", sequence_number=1)
-        response = self.client.post(
-            reverse("chant-create", args=[source.id]), 
-            {"manuscript_full_text_std_spelling": "cantus secundus", "folio": "001r", "sequence_number": "2"})
-        chant_2 = Chant.objects.get(manuscript_full_text_std_spelling="cantus secundus")
-        chant_1.refresh_from_db()
-        self.assertEqual(chant_1.next_chant, chant_2)
     
     def test_volpiano_signal(self):
         source = make_fake_source()
@@ -1072,36 +1062,6 @@ class ChantCreateViewTest(TestCase):
         chant_2 = Chant.objects.get(manuscript_full_text_std_spelling="resonare foobaz")
         self.assertEqual(chant_2.volpiano, "abacadaeafagahaja")
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
-    
-    def test_is_last_chant_in_feast_signal(self):
-        source = make_fake_source()
-        feast = make_fake_feast()
-
-        chant_1 = make_fake_chant(
-            source=source,
-            folio="001r",
-            sequence_number=1,
-            feast=feast,
-        )
-        chant_2 = make_fake_chant(
-            source=source,
-            feast=feast,
-            folio="001r",
-            sequence_number=2
-        )
-
-        chant_2.refresh_from_db()
-        self.assertIs(chant_2.is_last_chant_in_feast, True)
-
-        self.client.post(
-            reverse("chant-create", args=[source.id]), 
-            {"manuscript_full_text_std_spelling": "test", "folio": "001r", "sequence_number": "3", "feast": feast.id}
-        )
-
-        chant_2.refresh_from_db()
-        self.assertIs(chant_2.is_last_chant_in_feast, False)
-
-
 
 
 class ChantDeleteViewTest(TestCase):
@@ -1143,18 +1103,6 @@ class ChantDeleteViewTest(TestCase):
         chant = make_fake_chant()
         response = self.client.post(reverse("chant-delete", args=[chant.id + 100]))
         self.assertEqual(response.status_code, 404)
-
-    def test_next_chant_signal(self):
-        chant_1 = make_fake_chant()
-        chant_2 = make_fake_chant(source=chant_1.source, folio=chant_1.folio, sequence_number=chant_1.sequence_number + 1)
-
-        chant_1.refresh_from_db()
-        self.assertEqual(chant_1.next_chant, chant_2)
-
-        response = self.client.post(reverse("chant-delete", args=[chant_2.id]))
-
-        chant_1.refresh_from_db()
-        self.assertIs(chant_1.next_chant, None)
 
 
 class ChantEditVolpianoViewTest(TestCase):
@@ -1225,25 +1173,6 @@ class ChantEditVolpianoViewTest(TestCase):
         expected_suggestion = "Puer natus est nobis alleluia alleluia"
         suggested_fulltext = response.context["suggested_fulltext"]
         self.assertEqual(suggested_fulltext, expected_suggestion)
-
-    def test_next_chant_signal(self):
-        source = make_fake_source()
-        chant_1 = make_fake_chant(source=source, folio="001r", sequence_number=1, manuscript_full_text_std_spelling="chant_1")
-        chant_2 = make_fake_chant(source=source, folio="002r", sequence_number=1, manuscript_full_text_std_spelling="chant_2")
-
-        response = self.client.post(
-            f"/edit-volpiano/{source.id}?pk={chant_2.id}&folio={chant_2.folio}",
-            {
-                "manuscript_full_text_std_spelling": "chant_2",
-                "folio": "001v",
-                "sequence_number": "1"
-            }
-        )
-
-        chant_1.refresh_from_db()
-
-        chant_2_updated = Chant.objects.get(manuscript_full_text_std_spelling="chant_2")
-        self.assertEqual(chant_1.next_chant, chant_2_updated)
     
     def test_volpiano_signal(self):
         source = make_fake_source()
@@ -2786,15 +2715,23 @@ class JsonNextChantsTest(TestCase):
         fake_source_1 = make_fake_source()
         fake_source_2 = make_fake_source()
 
+        fake_chant_2 = Chant.objects.create(
+            source = fake_source_1,
+            cantus_id = "2000",
+            folio="001r",
+            sequence_number=2,
+        )
+
         fake_chant_1 = Chant.objects.create(
             source = fake_source_1,
             cantus_id = "1000",
             folio="001r",
             sequence_number=1,
+            next_chant=fake_chant_2,
         )
 
-        fake_chant_2 = Chant.objects.create(
-            source = fake_source_1,
+        fake_chant_4 = Chant.objects.create(
+            source = fake_source_2,
             cantus_id = "2000",
             folio="001r",
             sequence_number=2,
@@ -2805,13 +2742,7 @@ class JsonNextChantsTest(TestCase):
             cantus_id = "1000",
             folio="001r",
             sequence_number=1,
-        )
-
-        fake_chant_4 = Chant.objects.create(
-            source = fake_source_2,
-            cantus_id = "2000",
-            folio="001r",
-            sequence_number=2,
+            next_chant=fake_chant_4,
         )
 
         path = reverse("json-nextchants", args=["1000"])
@@ -2850,15 +2781,23 @@ class JsonNextChantsTest(TestCase):
         fake_source_1 = make_fake_source(published=True)
         fake_source_2 = make_fake_source(published=False)
 
+        fake_chant_2 = Chant.objects.create(
+            source = fake_source_1,
+            cantus_id = "2000",
+            folio="001r",
+            sequence_number=2,
+        )
+
         fake_chant_1 = Chant.objects.create(
             source = fake_source_1,
             cantus_id = "1000",
             folio="001r",
             sequence_number=1,
+            next_chant=fake_chant_2
         )
 
-        fake_chant_2 = Chant.objects.create(
-            source = fake_source_1,
+        fake_chant_4 = Chant.objects.create(
+            source = fake_source_2,
             cantus_id = "2000",
             folio="001r",
             sequence_number=2,
@@ -2869,13 +2808,7 @@ class JsonNextChantsTest(TestCase):
             cantus_id = "1000",
             folio="001r",
             sequence_number=1,
-        )
-
-        fake_chant_4 = Chant.objects.create(
-            source = fake_source_2,
-            cantus_id = "2000",
-            folio="001r",
-            sequence_number=2,
+            next_chant=fake_chant_4,
         )
 
         path = reverse("json-nextchants", args=["1000"])

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1072,6 +1072,36 @@ class ChantCreateViewTest(TestCase):
         chant_2 = Chant.objects.get(manuscript_full_text_std_spelling="resonare foobaz")
         self.assertEqual(chant_2.volpiano, "abacadaeafagahaja")
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
+    
+    def test_is_last_chant_in_feast_signal(self):
+        source = make_fake_source()
+        feast = make_fake_feast()
+
+        chant_1 = make_fake_chant(
+            source=source,
+            folio="001r",
+            sequence_number=1,
+            feast=feast,
+        )
+        chant_2 = make_fake_chant(
+            source=source,
+            feast=feast,
+            folio="001r",
+            sequence_number=2
+        )
+
+        chant_2.refresh_from_db()
+        self.assertIs(chant_2.is_last_chant_in_feast, True)
+
+        self.client.post(
+            reverse("chant-create", args=[source.id]), 
+            {"manuscript_full_text_std_spelling": "test", "folio": "001r", "sequence_number": "3", "feast": feast.id}
+        )
+
+        chant_2.refresh_from_db()
+        self.assertIs(chant_2.is_last_chant_in_feast, False)
+
+
 
 
 class ChantDeleteViewTest(TestCase):


### PR DESCRIPTION
This PR fixes #317, adding several functions to `main_app/signals.py` that pre-compute fields on Chant and Sequence models that are used to optimize page-load times.

It also adds a script (`populate_chant_fields.py`) that can be run when data is imported into the database from OldCantus, which opens each chant and then saves it, thus triggering the receivers in signals.py and making sure all these fields are up-to-date.

In earlier commits within this PR, functions were written to populate Chants' `next_chant` and `is_last_chant_in_feast` fields. These functions were removed in later commits, as it was discovered that they cause the above script to take an inordinately long time to run. In a future pull request, the plan is to change the docker configuration to run, at regular intervals, several existing management commands that populate these fields in a more efficient manner.