### PR TITLE
add `differentia_new` field to BaseChant model

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -48,7 +48,7 @@ class ChantCreateForm(forms.ModelForm):
             "feast",
             "mode",
             "differentia",
-            "differentia_id",
+            "differentia_new",
             "finalis",
             "extra",
             "chant_range",
@@ -73,7 +73,7 @@ class ChantCreateForm(forms.ModelForm):
             #'feast': SelectWidget(),
             "mode": TextInputWidget(),
             "differentia": TextInputWidget(),
-            "differentia_id": TextInputWidget(),
+            "differentia_new": TextInputWidget(),
             "finalis": TextInputWidget(),
             "extra": TextInputWidget(),
             "chant_range": VolpianoInputWidget(),
@@ -249,7 +249,7 @@ class ChantEditForm(forms.ModelForm):
             "mode",
             "finalis",
             "differentia",
-            "differentia_id",
+            "differentia_new",
             "extra",
             "image_link",
             "indexing_notes"
@@ -267,7 +267,7 @@ class ChantEditForm(forms.ModelForm):
             "mode": TextInputWidget(),
             "finalis": TextInputWidget(),
             "differentia": TextInputWidget(),
-            "differentia_id": TextInputWidget(),
+            "differentia_new": TextInputWidget(),
             "extra": TextInputWidget(),
             "image_link": TextInputWidget(),
             "indexing_notes": TextAreaWidget()
@@ -318,7 +318,7 @@ class ChantProofreadForm(forms.ModelForm):
             "chant_range",
             "siglum",
             "addendum",
-            "differentia_id"
+            "differentia_new"
         ]
         widgets = {
             "manuscript_full_text_std_spelling": TextAreaWidget(),
@@ -346,7 +346,7 @@ class ChantProofreadForm(forms.ModelForm):
             "chant_range": VolpianoAreaWidget(),
             "siglum": TextInputWidget(),
             "addendum": TextInputWidget(),
-            "differentia_id": TextInputWidget()
+            "differentia_new": TextInputWidget()
         }
     feast = forms.ModelChoiceField(
         queryset=Feast.objects.all().order_by("name"), required=False

--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -125,6 +125,11 @@ def get_new_chant(chant_id):
         differentia = None
 
     try:
+        differentia_new = json_response["field_differentia_new"]["und"][0]["value"]
+    except (KeyError, TypeError):
+        differentia_new = None
+
+    try:
         finalis = json_response["field_finalis"]["und"][0]["value"]
     except (KeyError, TypeError):
         finalis = None
@@ -277,6 +282,7 @@ def get_new_chant(chant_id):
             "feast": feast,
             "mode": mode,
             "differentia": differentia,
+            "differentia_new": differentia_new,
             "finalis": finalis,
             "extra": extra,
             "chant_range": chant_range,

--- a/django/cantusdb_project/main_app/management/commands/update_differentia_new.py
+++ b/django/cantusdb_project/main_app/management/commands/update_differentia_new.py
@@ -1,0 +1,37 @@
+from main_app.models import Chant
+from django.core.management.base import BaseCommand
+import json
+
+# In the past, the BaseChant model had a `.differentia` field and a `.differentia_id` field.
+# There was no data stored in the `differentia_id` field for any Chant or Sequence.
+# Then it was discovered that OldCantus has a `field_differentia` and a `field_differentia_new`
+# (but only for Chants, not for sequences).
+# This script takes the data stored in all Chants' `.json_info` fields and uses it to populate
+# those chants' `differentia_new` field (which has replaced the old `differentia_id` field.)
+
+# sync_chants.py has been updated to populate the `differentia_new` field. If you have run
+# sync_chants.py since September 15, 2022, you should not need to run this script.
+
+# run with `python manage.py update_differentia_new`
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **kwargs):
+        CHUNK_SIZE = 1_000
+        chants = Chant.objects.all()
+        chants_count = chants.count()
+        start_index = 0
+        while start_index <= chants_count:
+            print("processing chunk with start_index of", start_index)
+            chunk = chants[start_index:start_index+CHUNK_SIZE]
+            for chant in chunk:
+                try:
+                    differentia_new = chant.json_info["field_differentia_new"]["und"][0]["value"]
+                    chant.differentia_new = differentia_new
+                except TypeError: # json_info["field_differentia_new"] is empty
+                    chant.differentia_new = None
+                chant.save()
+            del chunk # make sure we don't use too much RAM
+            start_index += CHUNK_SIZE
+

--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -58,7 +58,7 @@ class BaseChant(BaseModel):
     feast = models.ForeignKey("Feast", on_delete=models.PROTECT, null=True, blank=True)
     mode = models.CharField(max_length=63, null=True, blank=True)
     differentia = models.CharField(blank=True, null=True, max_length=63)
-    differentia_id = models.CharField(blank=True, null=True, max_length=12)
+    differentia_new = models.CharField(blank=True, null=True, max_length=12)
     finalis = models.CharField(blank=True, null=True, max_length=63)
     extra = models.CharField(blank=True, null=True, max_length=63)
     chant_range = models.CharField(

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -60,8 +60,9 @@ def update_source_chant_count(instance):
     """
 
     source = instance.source
-    source.number_of_chants = source.chant_set.count() + source.sequence_set.count()
-    source.save()
+    if source is not None:
+        source.number_of_chants = source.chant_set.count() + source.sequence_set.count()
+        source.save()
 
 def update_source_melody_count(instance):
     """When saving or deleting a Chant, update its Source's number_of_melodies field
@@ -69,8 +70,9 @@ def update_source_melody_count(instance):
     Called in on_chant_save() and on_chant_delete()
     """
     source = instance.source
-    source.number_of_melodies = source.chant_set.filter(volpiano__isnull=False).count()
-    source.save()
+    if source is not None:
+        source.number_of_melodies = source.chant_set.filter(volpiano__isnull=False).count()
+        source.save()
 
 def update_volpiano_fields(instance):
     """When saving a Chant, make sure the chant's volpiano_notes and volpiano_intervals are up-to-date

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -152,8 +152,8 @@
                     </div>
 
                     <div class="form-group m-1 col-lg-3">
-                        <label for="{{ form.differentia_id.id_for_label }}"><small>Differentia Database</small></label>
-                        {{ form.differentia_id }}
+                        <label for="{{ form.differentia_new.id_for_label }}"><small>Differentia Database</small></label>
+                        {{ form.differentia_new }}
                         <p>
                             <small class="text-muted">Diff. IDs: <a href="https://differentiaedatabase.ca/">differentiaedatabase.ca</a></small>
                         </p>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -139,10 +139,10 @@
                             {{ form.differentia }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
-                            <label for="{{ form.differentia_id.id_for_label }}">
+                            <label for="{{ form.differentia_new.id_for_label }}">
                                 <small>Differentia DB:</small>
                             </label>
-                            {{ form.differentia_id }}
+                            {{ form.differentia_new }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
                             <small>{{ form.extra.label_tag }}</small>

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -90,8 +90,8 @@
                             {{ form.differentia }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.differentia_id.label_tag }}</small>
-                            {{ form.differentia_id }}
+                            <small>{{ form.differentia_new.label_tag }}</small>
+                            {{ form.differentia_new }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
                             <small>{{ form.extra.label_tag }}</small>


### PR DESCRIPTION
This pull request removes the `differentia_id` field from the BaseChant model and adds a `differentia_new` field in its place. It updates the `sync_chants` management command to populate this field, and includes a script that can be used to populate this field without sending requests to OldCantus.

It also fixes a bug in `signals.py` where certain functions would raise an exception in situations where a the `.source` of a chant/sequence is `None`.