### PR TITLE
fix 'feasts that follow' links

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -123,12 +123,16 @@
                         {% if previous_chant %}
                             Feasts that follow:
                                {% for feast, count in suggested_feasts.items %}
-                                   <a href="" onclick="return false;">{{ feast.name }}</a> ({{ count }}x) |
+                                    <a href="javascript:" onclick="autoFillFeast{{ feast.id }}();">{{ feast.name }}</a> ({{ count }}x) |
+                                    <script>
+                                        function autoFillFeast{{ feast.id }}() {
+                                            console.log({{ feast.id }})
+                                            document.getElementById('id_feast').value = "{{ feast.id }}";
+                                        }
+                                    </script>
                                {% endfor %}                                                                                                      
                             
-                            <strong>
-                                <a href="" onclick="return false;">Revert Changes</a>
-                            </strong>
+                            <!-- eventually, perhaps: implement a "Reverse Changes" button -->
                         {% endif %}
 
                     </small>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -126,7 +126,6 @@
                                     <a href="javascript:" onclick="autoFillFeast{{ feast.id }}();">{{ feast.name }}</a> ({{ count }}x) |
                                     <script>
                                         function autoFillFeast{{ feast.id }}() {
-                                            console.log({{ feast.id }})
                                             document.getElementById('id_feast').value = "{{ feast.id }}";
                                         }
                                     </script>


### PR DESCRIPTION
This PR fixes #342, properly implementing the "feasts that follow" links.

A bug still remains in the "Suggestions based on the previous chant:" buttons - there is code to populate the feast selector, but it doesn't work. Though I mentioned it in a comment on the issue linked above, I'll open a new issue for it.

In creating this fix, I removed the "Revert Changes" link (and left a comment saying we may want to re-implement it) - it's something that would interact in interesting ways with the suggested chant buttons (once we get them working), and it would be worth talking through how best to implement it.