### PR TITLE
Fix bug on sequence-detail page for sequences without sources

### DIFF
--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -21,7 +21,7 @@ class SequenceDetailView(DetailView):
         source = sequence.source
         # if the sequence's source isn't published, 
         # only logged-in users should be able to view the sequence's detail page
-        if (source.published is False) and (not self.request.user.is_authenticated):
+        if (source is not None) and (source.published is False) and (not self.request.user.is_authenticated):
             raise PermissionDenied()
         
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
This PR fixes the bug where we would see an Attribute Error when a user tried to load a sequence-detail page for a sequence without a source. Now, sequences without sources can be accessed, and are visible by default (relevant because we decide what's publicly visible by looking at a sequence/chant's source's published status)