### PR TITLE
Improve navbar

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -14,8 +14,8 @@
     <link rel="icon" href="{% static "favicon.ico" %}">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
-        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT" crossorigin="anonymous">
+
 
     <!-- font-awesome CSS for icons -->
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -113,7 +113,7 @@
     <header>
         <!-- Navbar -->
         <div class="container">
-            <nav class="navbar navbar-expand-xl navbar-light bg-light border-top col-12">
+            <nav class="navbar navbar-expand-xl navbar-light bg-white border-top col-12">
                 <a class="navbar-brand" href="/">
                     <img src="{% static "CantusLogoSmall.gif" %}"
                         alt="Cantus Database: A Database for Latin Ecclesiastical Chant" loading="lazy">


### PR DESCRIPTION
This PR fixes #352, by updating bootstrap from 5.2.0 to 5.2.1. The relative sizes of things still change in Safari as the zoom level changes, but it seems no longer to spill over the edge of the div.

This PR also changes the colour of the navbar to white (from light grey). Previously, the CantusDB logo's background stood out against the navbar (as can be seen in screenshot in #352). Now, the logo blends cleanly into the background.