### PR TITLE
Add function to signals.py to automatically populate Feast.prefix field

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/add_prefix.py
+++ b/django/cantusdb_project/main_app/management/commands/add_prefix.py
@@ -15,4 +15,6 @@ class Command(BaseCommand):
             if feast.feast_code:
                 feast.prefix = str(feast.feast_code)[0:2]
                 feast.save()
-                print(feast.prefix)
+            else: # feast_code is None, ""
+                feast.prefix = ""
+                feast.save()

--- a/django/cantusdb_project/main_app/models/feast.py
+++ b/django/cantusdb_project/main_app/models/feast.py
@@ -18,7 +18,7 @@ class Feast(BaseModel):
     )
 
     # the `prefix` field can be automatically populated by running `python manage.py add_prefix`
-    prefix = models.CharField(max_length=2, blank=True, null=True)
+    prefix = models.CharField(max_length=2, blank=True, null=True, editable=False)
 
     class Meta:
         constraints = [

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -178,7 +178,12 @@ def update_volpiano_fields(instance):
 def update_prefix_field(instance):
     pk = instance.pk
 
-    prefix = str(instance.feast_code)[0:2]
-    instance.__class__.objects.filter(pk=pk).update(
-        prefix=prefix
-    )
+    if instance.feast_code:
+        prefix = str(instance.feast_code)[0:2]
+        instance.__class__.objects.filter(pk=pk).update(
+            prefix=prefix
+        )
+    else: # feast_code is None, ""
+        instance.__class__.objects.filter(pk=pk).update(
+            prefix=""
+        )

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -11,6 +11,7 @@ import re
 
 from main_app.models import Chant
 from main_app.models import Sequence
+from main_app.models import Feast
 
 @receiver(post_save, sender=Chant)
 def on_chant_save(instance, **kwargs):
@@ -32,6 +33,10 @@ def on_sequence_save(instance, **kwargs):
 @receiver(post_delete, sender=Sequence)
 def on_sequence_delete(instance, **kwargs):
     update_source_chant_count(instance)
+
+@receiver(post_save, sender=Feast)
+def on_feast_save(instance, **kwargs):
+    update_prefix_field(instance)
 
 
 def update_chant_search_vector(instance):
@@ -170,3 +175,10 @@ def update_volpiano_fields(instance):
         volpiano_intervals=volpiano_intervals,
     )
 
+def update_prefix_field(instance):
+    pk = instance.pk
+
+    prefix = str(instance.feast_code)[0:2]
+    instance.__class__.objects.filter(pk=pk).update(
+        prefix=prefix
+    )

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -126,6 +126,28 @@ class FeastModelTest(TestCase):
         absolute_url = reverse("feast-detail", args=[str(feast.id)])
         self.assertEqual(feast.get_absolute_url(), absolute_url)
 
+    def test_update_prefix_field_signal(self):
+        feast = make_fake_feast()
+        feast_code = "12345678"
+        expected_prefix = feast_code[:2]
+        feast.feast_code = feast_code
+        feast.save()
+        feast.refresh_from_db()
+        self.assertEqual(feast.feast_code, feast_code)
+        self.assertEqual(feast.prefix, expected_prefix)
+
+        feast.feast_code = None
+        feast.save()
+        feast.refresh_from_db()
+        self.assertIs(feast.feast_code, None)
+        self.assertEqual(feast.prefix, "")
+
+        feast.feast_code = ""
+        feast.save()
+        feast.refresh_from_db()
+        self.assertIs(feast.feast_code, "")
+        self.assertEqual(feast.prefix, "")
+
 
 class GenreModelTest(TestCase):
     @classmethod


### PR DESCRIPTION
This PR adds a function to `signals.py` that automatically populates feasts' `prefix` field when a feast is changed.

In addition, the `prefix` field is not set to `editable=False` - this means that the field is not displayed in the admin panel.