### PR TITLE
remove unnecessary `{% load helper_tags %}` from templates

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Create Chant | Cantus Manuscript Database</title>
 <div class="container">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Browse Chants | Cantus Manuscript Database</title>
 <script src="/static/js/chant_list.js"></script>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Search Chants | Cantus Manuscript Database</title>
 <script src="/static/js/chant_search.js"></script>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Chants by Cantus ID: {{ cantus_id }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/contact_form.html
+++ b/django/cantusdb_project/main_app/templates/contact_form.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Contact | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %} {# classname, admin_url_name #}
+{% load helper_tags %} {# for classname, admin_url_name #}
 {% block content %}
 <title>Content Overview | Cantus Manuscript Database</title>
 

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %}
+{% load helper_tags %} {# classname, admin_url_name #}
 {% block content %}
 <title>Content Overview | Cantus Manuscript Database</title>
 

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %} {# month_to_string #}
+{% load helper_tags %} {# for month_to_string #}
 {% block content %}
 <title>{{ feast.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %}
+{% load helper_tags %} {# month_to_string #}
 {% block content %}
 <title>{{ feast.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %}
+{% load helper_tags %} {# month_to_string #}
 {% block content %}
 <title>List of Feasts | Cantus Manuscript Database</title>
 <script src="/static/js/feast_list.js"></script>

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %} {# month_to_string #}
+{% load helper_tags %} {# for month_to_string #}
 {% block content %}
 <title>List of Feasts | Cantus Manuscript Database</title>
 <script src="/static/js/feast_list.js"></script>

--- a/django/cantusdb_project/main_app/templates/genre_detail.html
+++ b/django/cantusdb_project/main_app/templates/genre_detail.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>{{ genre.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/genre_list.html
+++ b/django/cantusdb_project/main_app/templates/genre_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>List of Genres | Cantus Manuscript Database</title>
 <script src="/static/js/genre_list.js"></script>

--- a/django/cantusdb_project/main_app/templates/indexer_detail.html
+++ b/django/cantusdb_project/main_app/templates/indexer_detail.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>{{ indexer.given_name }} {{ indexer.family_name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/indexer_list.html
+++ b/django/cantusdb_project/main_app/templates/indexer_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>List of Indexers | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/items_count.html
+++ b/django/cantusdb_project/main_app/templates/items_count.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% load humanize %}
 {% block content %}
 <title>Content Statistics | Cantus Manuscript Database</title>

--- a/django/cantusdb_project/main_app/templates/office_list.html
+++ b/django/cantusdb_project/main_app/templates/office_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Office/Mass Abbereviations | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/pagination.html
+++ b/django/cantusdb_project/main_app/templates/pagination.html
@@ -1,4 +1,4 @@
-{% load helper_tags %}
+{% load helper_tags %} {# url_add_get_params #}
 
 <div class="pagination">
     <span class="step-links">

--- a/django/cantusdb_project/main_app/templates/pagination.html
+++ b/django/cantusdb_project/main_app/templates/pagination.html
@@ -1,4 +1,4 @@
-{% load helper_tags %} {# url_add_get_params #}
+{% load helper_tags %} {# for url_add_get_params #}
 
 <div class="pagination">
     <span class="step-links">

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Clavis Sequentiarum (Calvin Bower) | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/source_create_form.html
+++ b/django/cantusdb_project/main_app/templates/source_create_form.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Create Source | Cantus Manuscript Database</title>
 <div class="container">

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>Browse Sources | Cantus Manuscript Database</title>
 <script src="/static/js/source_list.js"></script>

--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>{{ user.first_name }} {{ user.last_name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/user_list.html
+++ b/django/cantusdb_project/main_app/templates/user_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load helper_tags %}
 {% block content %}
 <title>List of Users | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %} {# url_add_get_params #}
+{% load helper_tags %} {# for url_add_get_params #}
 {% block content %}
 <title>My Sources | Cantus Manuscript Database</title>
 <div class="container">

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %}
+{% load helper_tags %} {# url_add_get_params #}
 {% block content %}
 <title>My Sources | Cantus Manuscript Database</title>
 <div class="container">

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -12,6 +12,12 @@ register = template.Library()
 
 @register.simple_tag(takes_context=False)
 def recent_articles():
+    """
+    Generates a html unordered list of recent articles for display on the homepage
+
+    Used in:
+        templates/flatpages/default.html
+    """
     articles = Article.objects.order_by("-date_created")[:5]
     list_item_template = '<li style="padding-bottom: 0.5em;"><a href="{url}">{title}</a><br><small>{date}</small></li>'
     list_items = [
@@ -30,6 +36,12 @@ def recent_articles():
 
 @register.simple_tag(takes_context=False)
 def my_sources(user):
+    """
+    Generates a html unordered list of sources the currently logged-in user has access to edit, for display on the homepage
+
+    Used in:
+        templates/flatpages/default.html
+    """
     def make_source_detail_link_with_siglum(source):
         id = source.id
         siglum = source.rism_siglum
@@ -81,7 +93,13 @@ def my_sources(user):
 
 @register.filter(name="month_to_string")
 def month_to_string(value: Optional[Union[str, int]]) -> Optional[Union[str, int]]:
-    """Converts month number to textual representation, 3 letters (Jan, Mar, etc)"""
+    """
+    Converts month number to textual representation, 3 letters (Jan, Mar, etc)
+
+    used in:
+        main_app/templates/feast_detail.html
+        main_app/templates/feast_list.html
+    """
     if type(value) == int and value in range(1, 13):
         return calendar.month_abbr[value]
     else:
@@ -90,8 +108,14 @@ def month_to_string(value: Optional[Union[str, int]]) -> Optional[Union[str, int
 
 @register.simple_tag(takes_context=True)
 def url_add_get_params(context, **kwargs):
+    """
+    accounts for the situations where there may be two paginations in one page
+
+    Used in:
+        main_app/templates/pagination.html
+        main_app/templates/user_source_list.html
+    """
     query = context["request"].GET.copy()
-    # accounts for the situations where there may be two paginations in one page
     if "page" in kwargs:
         query.pop("page", None)
     if "page2" in kwargs:
@@ -102,6 +126,12 @@ def url_add_get_params(context, **kwargs):
 
 @register.simple_tag(takes_context=False)
 def source_links():
+    """
+    Generates a series of html option tags linking to sources in Cantus Dabase, for display on the homepage
+
+    Used in:
+        templates/flatpages/default.html
+    """
     sources = (
         Source.objects.filter(published=True, segment__id=4063)
         .exclude(siglum=None)
@@ -124,6 +154,9 @@ def classname(obj):
     """
     Returns the name of the object's class
     A use-case is: {% if object|classname == "Notation" %}
+
+    Used in:
+        main_app/templates/content_overview.html
     """
     return obj.__class__.__name__
 
@@ -132,6 +165,9 @@ def admin_url_name(class_name, action):
     """
     Accepts the name of a class in "main_app", and an action (either "change" or "delete") as arguments.
     Returns the name of the URL for changing/deleting an object in the admin interface.
+
+    Used in:
+        main_app/templates/content_overview.html
     """
     class_name = class_name.lower()
     action = action.lower()
@@ -140,4 +176,8 @@ def admin_url_name(class_name, action):
 
 @register.filter(name='has_group') 
 def has_group(user, group_name):
+    """
+    Used in:
+        templates/base.html
+    """
     return user.groups.filter(name=group_name).exists() 

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {% load static %}
-{% load helper_tags %} {# has_group #}
+{% load helper_tags %} {# for has_group #}
 <html lang="en">
 
 <head>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {% load static %}
-{% load helper_tags %}
+{% load helper_tags %} {# has_group #}
 <html lang="en">
 
 <head>

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %} {# source_links, recent_articles, my_sources #}
+{% load helper_tags %} {# for source_links, recent_articles, my_sources #}
 {% block content %}
 <div class="container">
     <title>{{ flatpage.title }} | Cantus Manuscript Database</title>

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load helper_tags %}
+{% load helper_tags %} {# source_links, recent_articles, my_sources #}
 {% block content %}
 <div class="container">
     <title>{{ flatpage.title }} | Cantus Manuscript Database</title>


### PR DESCRIPTION
This PR removes unnecessary instances of `{% load helper_tags %}` from all templates. 

For templates that use functions from helper_tags.py, a comment is added explaining which of the function(s) are being used.

In helper_tags.py, docstrings have been added that include a list of templates that make use of each function.