### PR TITLE
Fix links in footer

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -337,7 +337,7 @@
                                 </a>
                             </li>
                             <li class="list-group-item p-0">
-                                <a href="http://cantus.edu.pl" target="_blank">
+                                <a href="http://cantus.ispan.pl" target="_blank">
                                     Cantus Planus in Polonia
                                 </a>
                             </li>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -311,31 +311,51 @@
                     <div class="col-md-3" id="database-links">
                         <h5>Database Links</h5>
                         <ul class="list-group list-group-flush">
-                            <li class="list-group-item p-0"><a href="http://cantusindex.org/" target="_blank">Cantus Index
-                                    (all
-                                    chants
-                                    catalogue)</a></li>
-                            <li class="list-group-item p-0"><a href="http://pemdatabase.eu/" target="_blank">Portuguese
-                                    Early
-                                    Music
-                                    Database</a></li>
-                            <li class="list-group-item p-0"><a href="http://cantus.sk" target="_blank">Slovakian Early Music
-                                    Database</a></li>
-                            <li class="list-group-item p-0"><a href="http://hunchant.eu" target="_blank">Hungarian Chant
-                                    Database</a></li>
-                            <li class="list-group-item p-0"><a href="http://cantusbohemiae.cz" target="_blank">Fontes Cantus
-                                    Bohemiae</a></li>
-                            <li class="list-group-item p-0"><a href="http://cantus.edu.pl" target="_blank">Cantus Planus in
-                                    Polonia</a></li>
-                            <li class="list-group-item p-0"><a href="http://musicahispanica.eu" target="_blank">Spanish
-                                    Early
-                                    Music
-                                    Manuscript Database</a></li>
-                            <li class="list-group-item p-0"><a href="http://musmed.eu" target="_blank">Medieval Music
-                                    Manuscripts
-                                    Online</a></li>
-                            <li class="list-group-item p-0"><a href="http://comparatio.irht.cnrs.fr"
-                                    target="_blank">Comparatio</a></li>
+                            <li class="list-group-item p-0">
+                                <a href="http://cantusindex.org/" target="_blank">
+                                    Cantus Index (all chants catalogue)
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://pemdatabase.eu/" target="_blank">
+                                    Portuguese Early Music Database
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://cantus.sk" target="_blank">
+                                    Slovakian Early Music Database
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://hunchant.eu" target="_blank">
+                                    Hungarian Chant Database
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://cantusbohemiae.cz" target="_blank">
+                                    Fontes Cantus Bohemiae
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://cantus.edu.pl" target="_blank">
+                                    Cantus Planus in Polonia
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://musicahispanica.eu" target="_blank">
+                                    Spanish Early Music Manuscript Database
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://musmed.eu" target="_blank">
+                                    Medieval Music Manuscripts Online
+                                </a>
+                            </li>
+                            <li class="list-group-item p-0">
+                                <a href="http://comparatio.irht.cnrs.fr" target="_blank">
+                                    Comparatio
+                                </a>
+                            </li>
                         </ul>
                     </div>
                     <div class="col-md-3" id="login">

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -327,7 +327,7 @@
                                 </a>
                             </li>
                             <li class="list-group-item p-0">
-                                <a href="http://hunchant.eu" target="_blank">
+                                <a href="http://hun-chant.eu" target="_blank">
                                     Hungarian Chant Database
                                 </a>
                             </li>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -323,7 +323,7 @@
                             </li>
                             <li class="list-group-item p-0">
                                 <a href="http://cantus.sk" target="_blank">
-                                    Slovakian Early Music Database
+                                    Slovak Early Music Database
                                 </a>
                             </li>
                             <li class="list-group-item p-0">


### PR DESCRIPTION
In the footer, the links to Hungarian Chant Database and Cantus Planus in Polonia were broken. This PR updates/corrects these URLs.

"Slovakian Early Music Database" has also been renamed to "Slovak Early ...", as that's the name used on the organization's site.