### PR TITLE
improve formatting of navbar

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -79,8 +79,20 @@
             color: black;
         }
 
+        .nav-item {
+            margin: 0px 10px;
+        }
+
         .nav-item .nav-link .small {
             color: #5e5e5f;
+        }
+
+        .navbar-toggler {
+            margin: 0px 10px;
+        }
+
+        .navbar-brand {
+            margin: 0px 10px;
         }
 
         .border-top {


### PR DESCRIPTION
This PR improves the formatting of the navbar at the top of the page. Previously, items had been smushed up against the edge of the navbar div: 
![Screen Shot 2022-09-30 at 10 15 47](https://user-images.githubusercontent.com/58090591/193289948-70b6e5d8-eafc-40a9-b71c-c441bc7a6726.png)
Now, I've added a bit of margin to the left and right of the items, so things look a bit more comfortable:
![Screen Shot 2022-09-30 at 10 15 14](https://user-images.githubusercontent.com/58090591/193290100-466eac4a-5ffa-4406-b54d-4397b6c66490.png)
