### PR TITLE
Improve spacing of sections in footer

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -241,7 +241,7 @@
 
     <!-- Footer in every page -->
     <footer class="footer">
-        <hr style="opacity: 0%">
+        <hr style="opacity: 0%"> <!-- hr necessary to create spacing between <main> and <footer> -->
         <div class="p-3 bg-white small">
             <div class="container">
                 <div class="row">

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -98,6 +98,10 @@
             text-decoration: none;
         }
 
+        .footer h5 {
+            margin: 25px 0px 10px
+        }
+
         /* this class is used for displaying results under the global search bar */
         .list-group-item-action:hover {
             color: black;
@@ -237,7 +241,7 @@
 
     <!-- Footer in every page -->
     <footer class="footer">
-        <hr>
+        <hr style="opacity: 0%">
         <div class="p-3 bg-white small">
             <div class="container">
                 <div class="row">
@@ -394,7 +398,6 @@
                                     </li>
                                 {% endif %}
                             </ul>
-                            <br>
                             <h5>User Profile</h5>
                             <a href="{% url 'user-detail' request.user.id %}">{{ request.user }}</a>
                             |

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -40,6 +40,7 @@
         body {
             margin-bottom: 30px;
             /* Margin bottom by footer height */
+            background-image: url('{% static "background.jpg" %}');
         }
 
         .footer {
@@ -69,10 +70,6 @@
 
         hr.color {
             border-top: 1px solid lightblue !important;
-        }
-
-        body {
-            background-image: url('{% static "background.jpg" %}');
         }
 
         .nav-link {


### PR DESCRIPTION
When the window is relatively narrow and all the sections in the footer are stacked on top of each other, some sections in the footer currently run right up against each other:
![Screen Shot 2022-09-30 at 11 42 06](https://user-images.githubusercontent.com/58090591/193307567-7235df88-aaa0-43f9-9aef-b7c4b7d7501c.png)
(note the hardcoded <br> above "User Profile", which improves things when things are in their own columns, but creates inconsistency when everything is displayed in a single column.)
This PR adds additional margin to the top of h5s at the beginning of sections, improving the spacing:
![Screen Shot 2022-09-30 at 11 42 27](https://user-images.githubusercontent.com/58090591/193307658-20f68bcc-0193-41c5-9ac9-b69ac39dd5ca.png)
This PR also includes a little bit of refactoring and the addition of comments.