### PR TITLE
Add Cantus Index link to list of concordances on Chant Detail page

### DIFF
--- a/django/cantusdb_project/static/js/chant_detail.js
+++ b/django/cantusdb_project/static/js/chant_detail.js
@@ -42,7 +42,7 @@ function loadConcordances(cantusId) {
     xhttp.open("GET", url);
     xhttp.onload = function () {
         const data = JSON.parse(this.response);
-        concordanceDiv.innerHTML = `Displaying <b>${data.concordance_count}</b> concordances from the following databases (Cantus ID <b>${cantusId}</b>)`;
+        concordanceDiv.innerHTML = `Displaying <b>${data.concordance_count}</b> concordances from the following databases (Cantus ID <b><a href="http://cantusindex.org/id/${cantusId}" target="_blank">${cantusId}</a></b>)`;
         concordanceDiv.innerHTML += `<table id="concordanceTable" class="table table-bordered table-sm small" style="table-layout: fixed; width: 100%;">
                                     <thead>
                                         <tr>


### PR DESCRIPTION
related somewhat tangentially to #370, this PR adds a link to the relevant Cantus Index page at the top of the list of concordances on the Chant Detail page.

Once merged, this one will require a `python manage.py collectstatic` after `git pull`ing.