### PR TITLE
Remove Cantus ID column from Sequence Detail concordances

### DIFF
--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -122,6 +122,14 @@ class BaseChant(BaseModel):
     # dact = models.CharField(blank=True, null=True, max_length=64)
     # also a second differentia field
     
+    def get_ci_url(self) -> str:
+        """Construct the url to the entry in Cantus Index correponding to the chant.
+
+        Returns:
+            str: The url to the Cantus Index page
+        """
+        return f"http://cantusindex.org/id/{self.cantus_id}"
+    
     def __str__(self):
         incipit = ""
         if self.incipit:

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -14,15 +14,6 @@ class Chant(BaseChant):
     models harmonized, even if only one of the two models uses a particular field.
     """
 
-
-    def get_ci_url(self) -> str:
-        """Construct the url to the entry in Cantus Index correponding to the chant.
-
-        Returns:
-            str: The url to the Cantus Index page
-        """
-        return f"http://cantusindex.org/id/{self.cantus_id}"
-
     def index_components(self) -> dict:
         """Constructs a dictionary of weighted lists of search terms.
 

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -169,7 +169,7 @@
     </dl>
 
     <h4>Concordances</h4>
-    <small>Displaying 1 - {{ concordances.count }} of {{ concordances.count }}</small>
+    <small>Concordances for Cantus ID <a href="{{ sequence.get_ci_url }}" target=_blank>{{ sequence.cantus_id }}</a>: Displaying 1 - {{ concordances.count }} of {{ concordances.count }}</small>
     <table class="table table-sm small table-bordered">
         <thead>
             <tr>
@@ -177,7 +177,6 @@
                 <th scope="col" class="text-wrap" style="text-align:center">Incipit</th>
                 <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
                 <th scope="col" class="text-wrap" style="text-align:center">AH</th>
-                <th scope="col" class="text-wrap" style="text-align:center">CantusID</th>
                 <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
                 <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
                 <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
@@ -199,10 +198,6 @@
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         {{ sequence.analecta_hymnica|default:"" }}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
-                        <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         {{ sequence.col1|default:"" }}


### PR DESCRIPTION
Related to comment three on #370, this PR removes the Cantus ID column from the concordances table on the Sequence Detail page—every item in the column was the same—and adds a link to the relevant CantusIndex page at the top of the concordances table.

The link goes directly to the CI page because all information that would be displayed on the Chants-by-Cantus-ID view is already present in the concordances in the table.

To facilitate this, the `get_ci_url` method was moved from the `Chant` model to `BaseChant`.