### PR TITLE
on Chant Detail page: add links to Provenance, Century, Notation detail pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -326,14 +326,16 @@
                         <div class=" card-body">
                             <small>
                                 {% if source.provenance.name %}
-                                    Provenance: <b>{{ source.provenance.name }}</b>
+                                    Provenance: <b><a href="{{ source.provenance.get_absolute_url }}">{{source.provenance.name}}</a></b>
                                     <br>
                                 {% endif %}
 
                                 {% if source.date %}
                                     Date: 
                                     {% for century in source.century.all %}
-                                        <b>{{ century.name }}</b>
+                                        <b>
+                                            <a href="{{ century.get_absolute_url }}">{{ century.name }}</a>
+                                        </b>
                                     {% endfor %}
                                     |
                                     <b>{{ source.date|default_if_none:"" }}</b>
@@ -346,7 +348,9 @@
                                 {% endif %}
 
                                 {% if source.notation.all %}
-                                    Notation: <b>{{ source.notation.all.first.name }}</b>
+                                    <b>
+                                        <a href="{{ source.notation.all.first.get_absolute_url }}">{{ source.notation.all.first.name }}</a>
+                                    </b>
                                     <br>
                                 {% endif %}
 


### PR DESCRIPTION
Further to #360, This PR adds links to Provenance, Century and Notation detail pages on the Chant Detail Page. Thus the Chant's right sidebar, which includes information on the chant's source, now includes the same links that the Source Detail page does.