### PR TITLE
Add links to source-detail page in relevant places

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -237,7 +237,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4>{{ source.siglum }}</h4>
+                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -112,7 +112,7 @@
             <div class="card mb-3 w-100">
 
                 <div class="card-header">
-                    <h4>{{ source.siglum }}</h4>
+                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
                 </div>
 
                 <div class="card-body">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -235,7 +235,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4>{{ source.siglum }}</h4>
+                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>


### PR DESCRIPTION
This PR adds source-detail links to the h4 at the top of the right sidebar on the chant-list view, the chant-edit view, and the chant-proofread view.