### PR TITLE
Negotiate with bootstrap

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -117,7 +117,7 @@
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v14.0" nonce="ILOxiQ1O"></script>
     <header>
         <!-- Navbar -->
-        <div class="container-fluid">
+        <div class="container-fluid" style="padding: 0px">
             <nav class="navbar navbar-expand-xl navbar-light bg-white border-top col-12">
                 <a class="navbar-brand" href="/">
                     <img src="{% static "CantusLogoSmall.gif" %}"

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -14,23 +14,15 @@
     <link rel="icon" href="{% static "favicon.ico" %}">
 
     <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT" crossorigin="anonymous">
-
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
 
     <!-- font-awesome CSS for icons -->
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
     <!-- JS, Popper.js, and jQuery -->
-    {% comment %} <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-        integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
-        crossorigin="anonymous"></script> {% endcomment %}
-    <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-        integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-        crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
-        integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
-        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
     <style>
         html {
             position: relative;

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -117,7 +117,7 @@
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v14.0" nonce="ILOxiQ1O"></script>
     <header>
         <!-- Navbar -->
-        <div class="container">
+        <div class="container-fluid">
             <nav class="navbar navbar-expand-xl navbar-light bg-white border-top col-12">
                 <a class="navbar-brand" href="/">
                     <img src="{% static "CantusLogoSmall.gif" %}"


### PR DESCRIPTION
This PR rolls bootstrap back from 5.2.1 to 4.6.2, and in so doing re-adds the spacing between the main panel and the right sidebar. It also changes the header so it stretches across the entire top of the screen (thus matching the footer), getting rid of the text-spilling-beyond-navbar-div bug (i.e. fixes #352). (I think the header would look better if it was the same width as the content + sidebar [when the window is wide, the Cantus logo ends up waaay off on the left side of the window], but this at least looks more tidy than it did)

PREVIOUSLY:
![Screen Shot 2022-10-14 at 13 40 01](https://user-images.githubusercontent.com/58090591/195909118-e6d5cefb-d6de-43f8-8879-2b7ca0073552.png)

NOW:
![Screen Shot 2022-10-14 at 13 39 40](https://user-images.githubusercontent.com/58090591/195909135-6c7a36ce-fed2-45bc-9800-ffa540f1ab9c.png)
