### PR TITLE
Improve proofread page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -27,6 +27,7 @@
                 {% if user.is_authenticated %}
                     <p>
                         Proofreading chant: {{ chant.incipit }} (<a href="{% url 'chant-detail' chant.id %}" target="_blank">View chant</a>)
+                    </p>
                 {% endif %}
                 <form method="post" style="line-height: normal">{% csrf_token %}
                     <div class="form-row">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -26,8 +26,7 @@
             {% if pk_specified %}
                 {% if user.is_authenticated %}
                     <p>
-                        <a href="{% url 'chant-detail' chant.id %}">View</a> | Edit
-                    </p>
+                        Proofreading chant: {{ chant.incipit }} (<a href="{% url 'chant-detail' chant.id %}" target="_blank">View chant</a>)
                 {% endif %}
                 <form method="post" style="line-height: normal">{% csrf_token %}
                     <div class="form-row">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -247,10 +247,10 @@
                         </select>             
                         
                         {% if previous_folio %}
-                            <a href="{% url "source-edit-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
+                            <a href="{% url "chant-proofread" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
                         {% endif %}
                         {% if next_folio %}
-                            &nbsp;<a href="{% url "source-edit-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
+                            &nbsp;<a href="{% url "chant-proofread" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
                         {% endif %}             
 
                         <br>


### PR DESCRIPTION
This PR fixes several things on the proofread chant page:

The "View | Edit" toggle is replaced with a message saying "Proofreading chant: <incipit>" followed by a link to view the chant detail page.

At the top of the right sidebar, there are links to previous/next folios in the source. Previously, these had linked to the corresponding chant-edit page, but now they link to the corresponding proofread page as they should. (Fixes #380)