### PR TITLE
Make dropdown menus in header opaque

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -49,10 +49,6 @@
             background-color: #CC3333;
         }
 
-        .dropdown .dropdown-menu {
-            opacity: 0.85 !important;
-        }
-
         /* Change dropdown selected background to blue */
         .dropdown .dropdown-menu .dropdown-item:active,
         .dropdown .dropdown-menu .dropdown-item:hover {
@@ -267,7 +263,7 @@
                     </div>
                     <div class="col-md" id="facebook">
                         <h5>Facebook</h5>
-                        <div class="fb-page" data-href="https://www.facebook.com/CantusDatabase/" data-width="" data-height="" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false"><blockquote cite="https://www.facebook.com/CantusDatabase/" class="fb-xfbml-parse-ignore"><a href="hhttps://www.facebook.com/CantusDatabase/">Cantus Database</a></blockquote></div>
+                        <div class="fb-page" data-href="https://www.facebook.com/CantusDatabase/" data-width="" data-height="" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false" data-lazy="true"><blockquote cite="https://www.facebook.com/CantusDatabase/" class="fb-xfbml-parse-ignore"><a href="hhttps://www.facebook.com/CantusDatabase/">Cantus Database</a></blockquote></div>
                     </div>
                     <div class="col-md" id="license">
                         <h5>Creative Commons License</h5>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -40,9 +40,10 @@
             bottom: 0;
             width: 100%;
             height: 30px;
-            /* Set the fixed height of the footer here */
-            line-height: 30px;
-            /* Vertically center the text there */
+        }
+
+        .footer li {
+            padding: 5px 0px !important
         }
 
         .bg-footer {
@@ -110,7 +111,6 @@
 </head>
 
 <body>
-    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v14.0" nonce="ILOxiQ1O"></script>
     <header>
         <!-- Navbar -->
         <div class="container-fluid" style="padding: 0px">
@@ -261,16 +261,12 @@
                             <li class="list-group-item p-0"><a href="/indexers">&nbsp;&nbsp; ⇨ List of contributors</a></li>
                         </ul>
                     </div>
-                    <div class="col-md" id="facebook">
-                        <h5>Facebook</h5>
-                        <div class="fb-page" data-href="https://www.facebook.com/CantusDatabase/" data-width="" data-height="" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false" data-lazy="true"><blockquote cite="https://www.facebook.com/CantusDatabase/" class="fb-xfbml-parse-ignore"><a href="hhttps://www.facebook.com/CantusDatabase/">Cantus Database</a></blockquote></div>
-                    </div>
                     <div class="col-md" id="license">
                         <h5>Creative Commons License</h5>
                         <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">
                             <img src="{% static "creative-commons-logo.png" %}" alt="Creative Commons Logo" loading="lazy">
                         </a>
-                        <p>
+                        <p style="line-height: 22px">
                             This work is licensed under a <a
                                 href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons
                                 Attribution-NonCommercial-ShareAlike 4.0 International License.</a>
@@ -278,13 +274,18 @@
                     </div>
                     <div class="col-md" id="contact">
                         <h5>Contact Us</h5>
-                        <a href="{% url 'contact' %}">      
-                            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-envelope" viewBox="0 0 16 16">
-                                <!-- draw the envelope icon -->
-                                <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4Zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2Zm13 2.383-4.708 2.825L15 11.105V5.383Zm-.034 6.876-5.64-3.471L8 9.583l-1.326-.795-5.64 3.47A1 1 0 0 0 2 13h12a1 1 0 0 0 .966-.741ZM1 11.105l4.708-2.897L1 5.383v5.722Z"/>
-                            </svg>
-                            Contact Form
-                        </a>
+                        <div>
+                            <a href="{% url 'contact' %}">      
+                                <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-envelope" viewBox="0 0 16 16">
+                                    <!-- draw the envelope icon -->
+                                    <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4Zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2Zm13 2.383-4.708 2.825L15 11.105V5.383Zm-.034 6.876-5.64-3.471L8 9.583l-1.326-.795-5.64 3.47A1 1 0 0 0 2 13h12a1 1 0 0 0 .966-.741ZM1 11.105l4.708-2.897L1 5.383v5.722Z"/>
+                                </svg>
+                                Contact Form
+                            </a>
+                        </div>
+                        <div>
+                            <a href="https://www.facebook.com/CantusDatabase" target="_blank">Cantus Database on Facebook</a>
+                        </div>
                     </div>
                 </div>
                 <div class="row">

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -266,7 +266,7 @@
                         <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">
                             <img src="{% static "creative-commons-logo.png" %}" alt="Creative Commons Logo" loading="lazy">
                         </a>
-                        <p style="line-height: 22px">
+                        <p>
                             This work is licensed under a <a
                                 href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons
                                 Attribution-NonCommercial-ShareAlike 4.0 International License.</a>


### PR DESCRIPTION
This PR does several things:
- makes the dropdown menus in the header opaque (their previous translucent state seems to have been inherited from OldCantus - I have no idea why that choice was made in the first place)
- remove the Facebook widget and script, and add a link under "Contact" in the footer to the facebook page.
- improve the formatting of the footer - add padding around list items, but ensure that individual lines of multi-line bullet points are not spaced super wide apart (previously, vertical "padding" had been achieved via a large line-height value)