### PR TITLE
fix logic to check whether gregorien.info page is valid

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -348,7 +348,6 @@ class ChantDetailView(DetailView):
                         </td>
                     </tr>
                 """
-                print(gregorien_response)
 
             if concordances_count:
                 context["concordances_summary"] += "</table><br>"

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -335,7 +335,7 @@ class ChantDetailView(DetailView):
             # check to see if the corresponding page exists. If it does, display
             # links to gregorien.info in summary
             gregorien_response = requests.get(
-                "http://cantusindex.org/json-con/{}".format(chant.cantus_id)
+                "https://gregorien.info/chant/cid/{}/en".format(chant.cantus_id)
             )
             if gregorien_response.status_code == 200:
                 context["concordances_summary"] += f"""
@@ -348,6 +348,7 @@ class ChantDetailView(DetailView):
                         </td>
                     </tr>
                 """
+                print(gregorien_response)
 
             if concordances_count:
                 context["concordances_summary"] += "</table><br>"


### PR DESCRIPTION
This PR fixes the logic in the concordances section on the chant detail page - whereas previously (and erroneously), the gregorien.info link only displayed if the CI json-con API returned a 200 status code, it now (correctly) checks whether the relevant gregorien.info link returns a 200.