### PR TITLE
Ensure unpublished sources do not appear in user detail sources list

### DIFF
--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -43,9 +43,11 @@
             <h5>Entered Full Text</h5>
             <ul>
                 {% for source in user.entered_full_text_for_sources.all|dictsort:"siglum" %}
-                    <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                    </li>
+                    {% if source.published %}
+                        <li>
+                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         {% endif %}
@@ -53,9 +55,11 @@
             <h5>Entered Melodies</h5>
             <ul>
                 {% for source in user.entered_melody_for_sources.all|dictsort:"siglum" %}
-                    <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                    </li>
+                    {% if source.published %}
+                        <li>
+                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         {% endif %}
@@ -63,9 +67,11 @@
             <h5>Proofread</h5>
             <ul>
                 {% for source in user.proofread_sources.all|dictsort:"siglum" %}
-                    <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                    </li>
+                    {% if source.published %}
+                        <li>
+                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         {% endif %}
@@ -73,9 +79,11 @@
             <h5>Edited</h5>
             <ul>
                 {% for source in user.edited_sources.all|dictsort:"siglum" %}
-                    <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                    </li>
+                    {% if source.published %}
+                        <li>
+                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
Fixes oversight in #399

Occasionally, an h5 will appear with no sources beneath it - this can occur when a user, for example, is listed as an "other editor" for one or more sources and every one of those sources is not published. I don't think this is a big issue, but if we'd like to ensure this doesn't happen, I can go back and filter things in the view instead of in the template.