### PR TITLE
Filter sources by published status in view instead of in template

### DIFF
--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -27,63 +27,55 @@
             </dd>
         {% endif %}
     </dl>
-    {% if user.inventoried_sources.all or user.entered_full_text_for_sources.all or user.entered_melody_for_sources.all or user.proofread_sources.all or user.edited_sources.all %}
+    {% if inventoried_sources or full_text_sources or melody_sources or proofread_sources or edited_sources %}
         <h4 id="sources">Sources</h4>
-        {% if user.inventoried_sources.all %}
+        {% if inventoried_sources %}
             <h5>Inventoried</h5>
             <ul>
-                {% for source in user.inventoried_sources.all|dictsort:"siglum" %}
+                {% for source in inventoried_sources %}
                     <li>
                         <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
                     </li>
                 {% endfor %}
             </ul>
         {% endif %}
-        {% if user.entered_full_text_for_sources.all %}
+        {% if full_text_sources %}
             <h5>Entered Full Text</h5>
             <ul>
-                {% for source in user.entered_full_text_for_sources.all|dictsort:"siglum" %}
-                    {% if source.published %}
-                        <li>
-                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                        </li>
-                    {% endif %}
+                {% for source in full_text_sources %}
+                    <li>
+                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                    </li>
                 {% endfor %}
             </ul>
         {% endif %}
-        {% if user.entered_melody_for_sources.all %}
+        {% if melody_sources %}
             <h5>Entered Melodies</h5>
             <ul>
-                {% for source in user.entered_melody_for_sources.all|dictsort:"siglum" %}
-                    {% if source.published %}
-                        <li>
-                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                        </li>
-                    {% endif %}
+                {% for source in melody_sources %}
+                    <li>
+                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                    </li>
                 {% endfor %}
             </ul>
         {% endif %}
-        {% if user.proofread_sources.all %}
+        {% if proofread_sources %}
             <h5>Proofread</h5>
             <ul>
-                {% for source in user.proofread_sources.all|dictsort:"siglum" %}
-                    {% if source.published %}
-                        <li>
-                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                        </li>
-                    {% endif %}
+                {% for source in proofread_sources %}
+                    <li>
+                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                    </li>
                 {% endfor %}
             </ul>
         {% endif %}
-        {% if user.edited_sources.all %}
+        {% if edited_sources %}
             <h5>Edited</h5>
             <ul>
-                {% for source in user.edited_sources.all|dictsort:"siglum" %}
-                    {% if source.published %}
-                        <li>
-                            <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
-                        </li>
-                    {% endif %}
+                {% for source in edited_sources %}
+                    <li>
+                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                    </li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -22,6 +22,56 @@ class UserDetailView(DetailView):
     context_object_name = "user"
     template_name = "user_detail.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        user = self.get_object()
+        display_unpublished = self.request.user.is_authenticated
+        sort_by_siglum = lambda source: source.siglum
+        if display_unpublished:
+            context["inventoried_sources"] = sorted(
+                user.inventoried_sources.all(),
+                key=sort_by_siglum
+            )
+            context["full_text_sources"] = sorted(
+                user.entered_full_text_for_sources.all(),
+                key=sort_by_siglum
+            )
+            context["melody_sources"] = sorted(
+                user.entered_melody_for_sources.all(),
+                key=sort_by_siglum
+            )
+            context["proofread_sources"] = sorted(
+                user.proofread_sources.all(),
+                key=sort_by_siglum
+            )
+            context["edited_sources"] = sorted(
+                user.edited_sources.all(),
+                key=sort_by_siglum
+            )
+        else:
+            context["inventoried_sources"] = sorted(
+                user.inventoried_sources.all().filter(published=True),
+                key=sort_by_siglum
+            )
+            context["full_text_sources"] = sorted(
+                user.entered_full_text_for_sources.all().filter(published=True),
+                key=sort_by_siglum
+            )
+            context["melody_sources"] = sorted(
+                user.entered_melody_for_sources.all().filter(published=True),
+                key=sort_by_siglum
+            )
+            context["proofread_sources"] = sorted(
+                user.proofread_sources.all().filter(published=True),
+                key=sort_by_siglum
+            )
+            context["edited_sources"] = sorted(
+                user.edited_sources.all().filter(published=True),
+                key=sort_by_siglum
+            )
+
+        return context
+
 class UserSourceListView(LoginRequiredMixin, ListView):
     model = Source
     context_object_name = "sources"


### PR DESCRIPTION
an improvement on #402 - sources are now filtered and sorted in the view, not in the template, so we don't get headers with no sources listed beneath them.