### PR TITLE
Cache data from remote resources

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -220,43 +220,43 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for chant in concordances %}
+                        {% for c in concordances %}
                             <tr>
                                 <td>
-                                    <a href="{{ chant.srclink }}" target="_blank">
-                                    {{ chant.siglum }}
+                                    <a href="{{ c.srclink }}" target="_blank">
+                                    {{ c.siglum }}
                                     </a>
                                 </td>
                                 <td>
-                                    {{ chant.folio }}
+                                    {{ c.folio }}
                                 </td>
                                 <td>
-                                    <a href="{{ chant.chantlink }}" target="_blank">
-                                        {{ chant.incipit }}
+                                    <a href="{{ c.chantlink }}" target="_blank">
+                                        {{ c.incipit }}
                                     </a>
                                 </td>
                                 <td>
-                                    {{ chant.office }}
+                                    {{ c.office }}
                                 </td>
                                 <td>
-                                    {{ chant.genre }}
+                                    {{ c.genre }}
                                 </td>
                                 <td>
-                                    {{ chant.position }}
+                                    {{ c.position }}
                                 </td>
                                 <td>
-                                    {{ chant.feast }}
+                                    {{ c.feast }}
                                 </td>
                                 <td>
-                                    {{ chant.mode }}
+                                    {{ c.mode }}
                                 </td>
                                 <td>
-                                    {% if chant.image %}
-                                        <a href="{{ chant.image }}" target="_blank">Image</a>
+                                    {% if c.image %}
+                                        <a href="{{ c.image }}" target="_blank">Image</a>
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {{ chant.db }}
+                                    {{ c.db }}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -91,30 +91,14 @@ class ChantDetailView(DetailView):
             context["syllabized_text_with_melody"] = word_zip
 
         # If chant has a cantus ID, Create table of concordances
-        if chant.cantus_id:
-            response = requests.get(
-                "http://cantusindex.org/json-con/{}".format(chant.cantus_id)
-            )
-            concordances = json.loads(response.text[2:])
-            
-            ######################################
-            ### create context["concordances"] ###
-            # (data to be unpacked in chant_detail.html to make concordances table)
-            
-            # response.text is an array of JSON objects. Each has a single
-            # key, ["chant"], pointing to a nested object. We only need the
-            # nested object. 
-            concordance_chants = [c["chant"] for c in concordances] 
-            context["concordances"] = concordance_chants
-
-            ##############################################
-            ### create context["concordances_summary"] ###
-            # (tally of how many concordances come from which databases)
+        concordances = chant.ci_concordances
+        context["concordances"] = concordances
+        if concordances:
             context["concordances_summary"] = ""
 
             # tally from all databases
             concordances_count = len(
-                concordance_chants
+                concordances
             )
             if concordances_count:
                 if concordances_count > 1:
@@ -127,7 +111,7 @@ class ChantDetailView(DetailView):
             # Cantus Database
             cd_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "CD"
                 ]
             )
@@ -150,7 +134,7 @@ class ChantDetailView(DetailView):
             # Fontes Cantus Bohemiae
             fcb_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "FCB"
                 ]
             )
@@ -173,7 +157,7 @@ class ChantDetailView(DetailView):
             # Medieval Music Manuscripts Online
             mmmo_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "MMMO"
                 ]
             )
@@ -196,7 +180,7 @@ class ChantDetailView(DetailView):
             # Portuguese Early Music Database
             pem_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "PEM"
                 ]
             )
@@ -219,7 +203,7 @@ class ChantDetailView(DetailView):
             # Spanish Early Music Manuscripts
             semm_count = len( 
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "SEMM"
                 ]
             )
@@ -242,7 +226,7 @@ class ChantDetailView(DetailView):
             # Cantus Planus in Polonia
             cpl_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "CPL"
                 ]
             )
@@ -265,7 +249,7 @@ class ChantDetailView(DetailView):
             # Hungarian Chant Database
             hcd_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "HCD"
                 ]
             )
@@ -288,7 +272,7 @@ class ChantDetailView(DetailView):
             # Slovak Early Music Database
             csk_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "CSK"
                 ]
             )
@@ -311,7 +295,7 @@ class ChantDetailView(DetailView):
             # Fragmenta Manuscriptorum Musicalium Hungariae
             frh_count = len(
                 [
-                    True for c in concordance_chants
+                    True for c in concordances
                     if c["db"] == "FRH"
                 ]
             )
@@ -346,19 +330,6 @@ class ChantDetailView(DetailView):
 
             if concordances_count:
                 context["concordances_summary"] += "</table><br>"
-
-            # http://cantusindex.org/json-con/{cantus_id} returns a cached
-            # copy of the concordances. Appending "/refresh" to the URL causes Cantus
-            # Index to recalculate the concordances, but this takes a few seconds.
-            # So, after fetching the cached version above, we make a call to
-            # http://cantusindex.org/json-con/{cantus_id}/refresh in a new thread,
-            # thus ensuring the current page doesn't take a long time to load, while also
-            # ensuring that concordances are up-to-date for future page loads.
-            t = threading.Thread(
-                target=requests.get,
-                args=[f"http://cantusindex.org/json-con/{chant.cantus_id}/refresh"]
-            )
-            t.start()
 
 
         # some chants don't have a source, for those chants, stop here without further calculating

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -332,12 +332,7 @@ class ChantDetailView(DetailView):
                 """
             
             # Gregorien.info
-            # check to see if the corresponding page exists. If it does, display
-            # links to gregorien.info in summary
-            gregorien_response = requests.get(
-                "https://gregorien.info/chant/cid/{}/en".format(chant.cantus_id)
-            )
-            if gregorien_response.status_code == 200:
+            if chant.has_gregorien_page:
                 context["concordances_summary"] += f"""
                     <tr>
                         <td>


### PR DESCRIPTION
This PR adds

- two new fields: `gregorien_cached` and `ci_concordances_cached`
- two new properties:`has_gregorien_page` and `ci_concordances`, and
- two new methods: `update_gregorien` and `update_ci_concordances`

to aid in quickly rendering the chant detail page.

When a request for the chant detail page is received, the view/template make use of new `has_gregorien_page` and `ci_concordances` properties, allowing the page to be loaded without having to wait for one response from gregorien.info and another from cantusindex.org.

- Previously, in order to render the "concordances" section of the chant detail page, the chant detail view would
  - check for a 200 response from the relevant gregorien.info page before creating the link to gregorien.info, and
  - pull information on concordances from Cantus Index's `json-con` API, waiting for a response from CI before sending context to the template
- Now, the Chant and Sequence models have
  - a `has_gregorien_page` property, which stores the result of the the 200-response check, and
  - a `ci_concordances` property, which stores the data from Cantus Index about concordances for the cantus_id in question.
  - both of these properties do the following:
    1. check to see whether there is a cached value in `gregorien_cached` or `ci_concordances_cached` respectively
    2. if there isn't, fetch that information, save it to `gregorien_cached` or `ci_concordances_cached`, and then return it
    3. if there is, fetch that value, then call the `update_gregorien` method or the `update_ci_concordances` method respectively in the background (i.e. in a new thread), and immediately return the value

The upsides are:

- faster load times for chant detail pages
- if Cantus Index is having a bad day, we can still display concordances

the downsides:

- if lots of changes have been made to CI since someone last visited a particular CantusDB chant detail page, the displayed results will be out-of-date
- more data has to be stored in our database. A future optimization might be to make a model to store information on individual Cantus IDs (the concordances and the gregorien page are both specific to a single cantus ID, so if we have 50 different chants with a given Cantus ID, we end up storing up to 50 copies of the concordances)

---

As this PR adds a couple of new fields to the BaseChant model, be sure to run `makemigrations` and `migrate` after pulling!

--- 

Also, thanks is in order to @ahankinson, whose recent comment on #401 suggested these changes.