### PR TITLE
replace contact form with link to email Debra

### DIFF
--- a/django/cantusdb_project/main_app/templates/contact_form.html
+++ b/django/cantusdb_project/main_app/templates/contact_form.html
@@ -8,58 +8,8 @@
     </object>
 
     <h3>Contact</h3>
-    {% if messages %}
-        {% for message in messages %}
-            {% if 'success' in message.tags %}
-                <div class="alert alert-success alert-dismissible">{{ message }}</div>
-            {% elif 'error' in message.tags %}
-                <div class="alert alert-danger alert-dismissible">{{ message }}</div>
-            {% endif %}
-        {% endfor %}
-    {% endif %}
-
-    <form action="" method="post">
-        {% csrf_token %}
-        {{ form.non_field_errors }}
-        <div class="form-group col-lg-2">
-            {{ form.name.errors }}
-            <label for="{{ form.name.id_for_label }}"><small>Your name</small></label>
-            {{ form.name }}
-        </div>
-        <div class="form-group col-lg-2">
-            {{ form.sender_email.errors }}
-            <label for="{{ form.sender_email.id_for_label }}"><small>Your e-mail address</small></label>
-            {{ form.sender_email }}
-        </div>
-        <div class="form-group col-lg-2">
-            {{ form.subject.errors }}
-            <label for="{{ form.subject.id_for_label }}"><small>Subject</small></label>
-            {{ form.subject }}
-        </div>
-        <div class="form-group col-lg-2">
-            {{ form.message.errors }}
-            <label for="{{ form.message.id_for_label }}"><small>Message</small></label>
-            {{ form.message }}
-        </div>
-        <div class="form-group col-lg-2">
-            {{ form.send_yourself_copy.errors }}
-            <label for="{{ form.send_yourself_copy.id_for_label }}"><small>Send Yourself a Copy</small></label>
-            {{ form.send_yourself_copy }}
-        </div>
-        <div class="form-group col-lg-8">
-            {{ form.skill_testing_question.errors }}
-            <label for="{{ form.skill_testing_question.id_for_label }}">
-                <small>
-                    Enter the missing character from the following word:
-                    <br/><strong>{{ skill_testing_question }}</strong>
-                </small>
-            </label>
-            <br/>{{ form.skill_testing_response }}
-            <input type="hidden" name="hidden_skill_testing_question" value="{{ skill_testing_question }}">
-        </div>
-
-        <input type="submit" value="Send message">
-    </form>
+    
+    <p style="padding-top: 25px;">Please direct questions or comments about Cantus Database to Debra Lacoste at <a href="mailto:dlacoste@uwaterloo.ca" target="_blank">dlacoste@uwaterloo.ca</a>.</p>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR prevents people from using the contact form, and just provides a link to email Debra. This way, no one will press "Submit" and see a "Success" message after no email has been sent, which is the current state of affairs.