### PR TITLE
write tests for get_next_chant(), and fix related bug

### DIFF
--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -106,7 +106,7 @@ class Chant(BaseChant):
             )
         except Chant.DoesNotExist: # i.e. no chant with the subsequent sequence number on same folio
             
-            # check to see whether there are more chants on this folio after a gap that must be skipped
+            # check to see whether there are more chants on this folio after a gap in the numbering
             # e.g. situation with several sequential chants on a folio, followed by a lacuna with sequence_number 99
             subsequent_chants_this_folio = Chant.objects.filter(
                 source=self.source,

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -104,7 +104,7 @@ class Chant(BaseChant):
                 folio=self.folio,
                 sequence_number=self.sequence_number + 1,
             )
-        except Chant.DoesNotExist: # i.e. no chant with the subsequent sequence number
+        except Chant.DoesNotExist: # i.e. no chant with the subsequent sequence number on same folio
             
             # check to see whether there are more chants on this folio after a gap that must be skipped
             # e.g. situation with several sequential chants on a folio, followed by a lacuna with sequence_number 99

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -199,13 +199,12 @@ class ChantModelTest(TestCase):
         )
         self.assertIsNone(chant41.get_next_chant())
 
-    def test_get_next_chant__lacuna_full_page(self):
-        # if a page is illegible, the lacuna (gap) is often given a sequence_number of 99.
-        # if the lacuna is the first "chant" on next_folio, get_next_chant() should find it. 
+    def test_get_next_chant__lacuna(self):
+        # if pages from a manuscript have been lost, the lacuna (gap) is often
+        # assigned to the previous folio and given a sequence_number of 99.
         source = make_fake_source()
-        first_folio = "500r"
-        second_folio = "500v"
-        third_folio = "501r"
+        first_folio = "500v"
+        second_folio = "501r"
         chant1 = make_fake_chant(
             source=source,
             folio=first_folio,
@@ -213,13 +212,13 @@ class ChantModelTest(TestCase):
         )
         lacuna = make_fake_chant(
             source=source,
-            folio=second_folio,
+            folio=first_folio,
             sequence_number=99,
             manuscript_full_text_std_spelling="LACUNA",
         )
         chant3 = make_fake_chant(
             source=source,
-            folio=third_folio,
+            folio=second_folio,
             sequence_number=1
         )
         self.assertEqual(chant1.get_next_chant(), lacuna)

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -129,17 +129,17 @@ class ChantModelTest(TestCase):
         source2 = make_fake_source()
         current_folio = "555v"
         next_folio = "556r"
-        chant21 = make_fake_chant(
+        chant1 = make_fake_chant(
             source=source2,
             folio=current_folio,
             sequence_number=1,
         )
-        chant22 = make_fake_chant(
+        chant2 = make_fake_chant(
             source=source2,
             folio=next_folio,
             sequence_number=1,
         )
-        self.assertEqual(chant21.get_next_chant(), chant22)
+        self.assertEqual(chant1.get_next_chant(), chant2)
     
     def test_get_next_chant__one_numbered_page_to_the_next(self):
         source = make_fake_source()
@@ -180,24 +180,24 @@ class ChantModelTest(TestCase):
     def test_get_next_chant__collision(self):
         # if there are multiple chants with the same source, folio and sequence_number,
         # someone has messed up their data entry, and we should set next_chant to None
-        source4 = make_fake_source()
+        source = make_fake_source()
         current_folio = "444"
-        chant41 = make_fake_chant(
-            source=source4,
+        chant1 = make_fake_chant(
+            source=source,
             folio=current_folio,
             sequence_number=1,
         )
-        chant42a = make_fake_chant(
-            source=source4,
+        chant2a = make_fake_chant(
+            source=source,
             folio=current_folio,
             sequence_number=2,
         )
-        chant42b = make_fake_chant(
-            source=source4,
+        chant2b = make_fake_chant(
+            source=source,
             folio=current_folio,
             sequence_number=2,
         )
-        self.assertIsNone(chant41.get_next_chant())
+        self.assertIsNone(chant1.get_next_chant())
 
     def test_get_next_chant__lacuna(self):
         # if pages from a manuscript have been lost, the lacuna (gap) is often

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -145,37 +145,27 @@ class ChantModelTest(TestCase):
         source = make_fake_source()
         current_folio = "004"
         next_folio = "005"
-        chant1 = make_fake_chant(
-            source=source,
-            folio=current_folio,
-            sequence_number=1,
-        )
-        chant2 = make_fake_chant(
+        end_of_page_chant = make_fake_chant(
             source=source,
             folio=current_folio,
             sequence_number=2,
         )
-        chant3 = make_fake_chant(
+        beginning_of_next_page_chant = make_fake_chant(
             source=source,
             folio=next_folio,
             sequence_number=1,
         )
-        self.assertEqual(chant2.get_next_chant(), chant3)
+        self.assertEqual(end_of_page_chant.get_next_chant(), beginning_of_next_page_chant)
     
     def test_get_next_chant__last_chant_in_manuscript(self):
         source = make_fake_source()
-        current_folio = "999r"
-        chant1 = make_fake_chant(
+        last_folio_in_ms = "999r"
+        last_chant_in_ms = make_fake_chant(
             source=source,
-            folio=current_folio,
-            sequence_number=97,
-        )
-        chant2 = make_fake_chant(
-            source=source,
-            folio=current_folio,
+            folio=last_folio_in_ms,
             sequence_number=98,
         )
-        self.assertIsNone(chant2.get_next_chant())
+        self.assertIsNone(last_chant_in_ms.get_next_chant())
 
     def test_get_next_chant__collision(self):
         # if there are multiple chants with the same source, folio and sequence_number,

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -94,6 +94,119 @@ class ChantModelTest(TestCase):
         seq_fields = Sequence.get_fields_and_properties()
         self.assertEqual(chant_fields, seq_fields)
 
+    def test_get_next_chant(self):
+        source0 = make_fake_source()
+        current_folio = "001"
+        next_folio = "002"
+        chant01 = make_fake_chant(
+            source=source0,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant02 = make_fake_chant(
+            source=source0,
+            folio=current_folio,
+            sequence_number=2,
+        )
+        chant03 = make_fake_chant(
+            source=source0,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant01.get_next_chant(), chant02)
+        self.assertEqual(chant02.get_next_chant(), chant03)
+        self.assertIsNone(chant03.get_next_chant()) # i.e. last chant in source
+
+        source1 = make_fake_source()
+        current_folio = "001r"
+        next_folio = "001v"
+        chant11 = make_fake_chant(
+            source=source1,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant12 = make_fake_chant(
+            source=source1,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant11.get_next_chant(), chant12)
+
+        source2 = make_fake_source()
+        current_folio = "555v"
+        next_folio = "556r"
+        chant21 = make_fake_chant(
+            source=source2,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant22 = make_fake_chant(
+            source=source2,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant21.get_next_chant(), chant22)
+
+        source3 = make_fake_source()
+        current_folio = "555"
+        next_folio = "556"
+        chant31 = make_fake_chant(
+            source=source3,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant32 = make_fake_chant(
+            source=source3,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant31.get_next_chant(), chant32)
+
+        source4 = make_fake_source()
+        current_folio = "444"
+        chant41 = make_fake_chant(
+            source=source4,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant42a = make_fake_chant(
+            source=source4,
+            folio=current_folio,
+            sequence_number=2,
+        )
+        chant42a = make_fake_chant(
+            source=source4,
+            folio=current_folio,
+            sequence_number=2,
+        )
+        # if there are multiple chants with the same source, folio and sequence_number,
+        # someone has messed up their data entry, and we should set next_chant to None
+        self.assertIsNone(chant41.get_next_chant())
+
+        source5 = make_fake_source()
+        first_folio = "500r"
+        second_folio = "500v"
+        third_folio = "501r"
+        chant51 = make_fake_chant(
+            source=source4,
+            folio=first_folio,
+            sequence_number=51,
+        )
+        lacuna = make_fake_chant(
+            source=source4,
+            folio=second_folio,
+            sequence_number=99,
+        )
+        chant53 = make_fake_chant(
+            source=source5,
+            folio=third_folio,
+            sequence_number=1
+        )
+        # if a page is illegible, the lacuna (gap) is often given a sequence_number of 99.
+        # if the lacuna is the first "chant" on next_folio, get_next_chant() should find it. 
+        self.assertEqual(chant51.get_next_chant(), lacuna)
+        self.assertEqual(lacuna.get_next_chant(), chant53)
+
 
 class FeastModelTest(TestCase):
     @classmethod

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -199,7 +199,7 @@ class ChantModelTest(TestCase):
         )
         self.assertIsNone(chant41.get_next_chant())
 
-    def test_get_next_chant__lacuna(self):
+    def test_get_next_chant__lacuna_full_page(self):
         # if a page is illegible, the lacuna (gap) is often given a sequence_number of 99.
         # if the lacuna is the first "chant" on next_folio, get_next_chant() should find it. 
         source = make_fake_source()
@@ -215,6 +215,7 @@ class ChantModelTest(TestCase):
             source=source,
             folio=second_folio,
             sequence_number=99,
+            manuscript_full_text_std_spelling="LACUNA",
         )
         chant3 = make_fake_chant(
             source=source,

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -94,44 +94,74 @@ class ChantModelTest(TestCase):
         seq_fields = Sequence.get_fields_and_properties()
         self.assertEqual(chant_fields, seq_fields)
 
-    def test_get_next_chant(self):
-        source0 = make_fake_source()
+    def test_get_next_chant__same_folio_next_sequence_number(self):
+        source = make_fake_source()
         current_folio = "001"
-        next_folio = "002"
-        chant01 = make_fake_chant(
-            source=source0,
+        chant1 = make_fake_chant(
+            source=source,
             folio=current_folio,
             sequence_number=1,
         )
-        chant02 = make_fake_chant(
-            source=source0,
+        chant2 = make_fake_chant(
+            source=source,
             folio=current_folio,
             sequence_number=2,
         )
-        chant03 = make_fake_chant(
-            source=source0,
-            folio=next_folio,
-            sequence_number=1,
-        )
-        self.assertEqual(chant01.get_next_chant(), chant02)
-        self.assertEqual(chant02.get_next_chant(), chant03)
-        self.assertIsNone(chant03.get_next_chant()) # i.e. last chant in source
-
-        source1 = make_fake_source()
-        current_folio = "001r"
-        next_folio = "001v"
-        chant11 = make_fake_chant(
-            source=source1,
+        self.assertEqual(chant1.get_next_chant(), chant2)
+    
+    def test_get_next_chant__one_numbered_page_to_the_next(self):
+        source = make_fake_source()
+        current_folio = "004"
+        next_folio = "005"
+        chant1 = make_fake_chant(
+            source=source,
             folio=current_folio,
             sequence_number=1,
         )
-        chant12 = make_fake_chant(
-            source=source1,
+        chant2 = make_fake_chant(
+            source=source,
+            folio=current_folio,
+            sequence_number=2,
+        )
+        chant3 = make_fake_chant(
+            source=source,
             folio=next_folio,
             sequence_number=1,
         )
-        self.assertEqual(chant11.get_next_chant(), chant12)
+        self.assertEqual(chant2.get_next_chant(), chant3)
+    
+    def test_get_next_chant__last_chant_in_manuscript(self):
+        source = make_fake_source()
+        current_folio = "999r"
+        chant1 = make_fake_chant(
+            source=source,
+            folio=current_folio,
+            sequence_number=97,
+        )
+        chant2 = make_fake_chant(
+            source=source,
+            folio=current_folio,
+            sequence_number=98,
+        )
+        self.assertIsNone(chant2.get_next_chant())
+    
+    def test_get_next_chant__recto_to_verso(self):
+        source = make_fake_source()
+        current_folio = "001r"
+        next_folio = "001v"
+        chant1 = make_fake_chant(
+            source=source,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant2 = make_fake_chant(
+            source=source,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant1.get_next_chant(), chant2)
 
+    def test_get_next_chant__verso_to_recto(self):
         source2 = make_fake_source()
         current_folio = "555v"
         next_folio = "556r"
@@ -147,21 +177,9 @@ class ChantModelTest(TestCase):
         )
         self.assertEqual(chant21.get_next_chant(), chant22)
 
-        source3 = make_fake_source()
-        current_folio = "555"
-        next_folio = "556"
-        chant31 = make_fake_chant(
-            source=source3,
-            folio=current_folio,
-            sequence_number=1,
-        )
-        chant32 = make_fake_chant(
-            source=source3,
-            folio=next_folio,
-            sequence_number=1,
-        )
-        self.assertEqual(chant31.get_next_chant(), chant32)
-
+    def test_get_next_chant__collision(self):
+        # if there are multiple chants with the same source, folio and sequence_number,
+        # someone has messed up their data entry, and we should set next_chant to None
         source4 = make_fake_source()
         current_folio = "444"
         chant41 = make_fake_chant(
@@ -174,38 +192,37 @@ class ChantModelTest(TestCase):
             folio=current_folio,
             sequence_number=2,
         )
-        chant42a = make_fake_chant(
+        chant42b = make_fake_chant(
             source=source4,
             folio=current_folio,
             sequence_number=2,
         )
-        # if there are multiple chants with the same source, folio and sequence_number,
-        # someone has messed up their data entry, and we should set next_chant to None
         self.assertIsNone(chant41.get_next_chant())
 
-        source5 = make_fake_source()
+    def test_get_next_chant__lacuna(self):
+        # if a page is illegible, the lacuna (gap) is often given a sequence_number of 99.
+        # if the lacuna is the first "chant" on next_folio, get_next_chant() should find it. 
+        source = make_fake_source()
         first_folio = "500r"
         second_folio = "500v"
         third_folio = "501r"
-        chant51 = make_fake_chant(
-            source=source4,
+        chant1 = make_fake_chant(
+            source=source,
             folio=first_folio,
             sequence_number=51,
         )
         lacuna = make_fake_chant(
-            source=source4,
+            source=source,
             folio=second_folio,
             sequence_number=99,
         )
-        chant53 = make_fake_chant(
-            source=source5,
+        chant3 = make_fake_chant(
+            source=source,
             folio=third_folio,
             sequence_number=1
         )
-        # if a page is illegible, the lacuna (gap) is often given a sequence_number of 99.
-        # if the lacuna is the first "chant" on next_folio, get_next_chant() should find it. 
-        self.assertEqual(chant51.get_next_chant(), lacuna)
-        self.assertEqual(lacuna.get_next_chant(), chant53)
+        self.assertEqual(chant1.get_next_chant(), lacuna)
+        self.assertEqual(lacuna.get_next_chant(), chant3)
 
 
 class FeastModelTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -109,6 +109,38 @@ class ChantModelTest(TestCase):
         )
         self.assertEqual(chant1.get_next_chant(), chant2)
     
+    def test_get_next_chant__recto_to_verso(self):
+        source = make_fake_source()
+        current_folio = "001r"
+        next_folio = "001v"
+        chant1 = make_fake_chant(
+            source=source,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant2 = make_fake_chant(
+            source=source,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant1.get_next_chant(), chant2)
+
+    def test_get_next_chant__verso_to_recto(self):
+        source2 = make_fake_source()
+        current_folio = "555v"
+        next_folio = "556r"
+        chant21 = make_fake_chant(
+            source=source2,
+            folio=current_folio,
+            sequence_number=1,
+        )
+        chant22 = make_fake_chant(
+            source=source2,
+            folio=next_folio,
+            sequence_number=1,
+        )
+        self.assertEqual(chant21.get_next_chant(), chant22)
+    
     def test_get_next_chant__one_numbered_page_to_the_next(self):
         source = make_fake_source()
         current_folio = "004"
@@ -144,38 +176,6 @@ class ChantModelTest(TestCase):
             sequence_number=98,
         )
         self.assertIsNone(chant2.get_next_chant())
-    
-    def test_get_next_chant__recto_to_verso(self):
-        source = make_fake_source()
-        current_folio = "001r"
-        next_folio = "001v"
-        chant1 = make_fake_chant(
-            source=source,
-            folio=current_folio,
-            sequence_number=1,
-        )
-        chant2 = make_fake_chant(
-            source=source,
-            folio=next_folio,
-            sequence_number=1,
-        )
-        self.assertEqual(chant1.get_next_chant(), chant2)
-
-    def test_get_next_chant__verso_to_recto(self):
-        source2 = make_fake_source()
-        current_folio = "555v"
-        next_folio = "556r"
-        chant21 = make_fake_chant(
-            source=source2,
-            folio=current_folio,
-            sequence_number=1,
-        )
-        chant22 = make_fake_chant(
-            source=source2,
-            folio=next_folio,
-            sequence_number=1,
-        )
-        self.assertEqual(chant21.get_next_chant(), chant22)
 
     def test_get_next_chant__collision(self):
         # if there are multiple chants with the same source, folio and sequence_number,


### PR DESCRIPTION
This PR adds several tests for the Chant model's `.get_next_chant()` method.

In writing them, I found a bug in the implementation of `.get_next_chant()`, which this PR also fixes:
- In situations where one or several pages of the manuscript have been lost, this is usually indicated by a "LACUNA" chant record, with a `sequence_number` of `99` on the last folio before the lacuna. `.get_next_chant` now accounts for gaps in the numbering such as this.

This bug fix is necessary for a future to the `populate_next_chant_fields` admin command, PR forthcoming in the next couple of days.

The code for `.get_next_chant` is starting to become a bit complicated, so it should probably be refactored sometime soon.