### PR TITLE
Improve Chant Index view

### DIFF
--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -50,7 +50,7 @@
                         `default`: use the given default if the value evaluates to False
                         `default_if_none`: use the given default only if the value is None
                     {% endcomment %}
-                    <td>{{ chant.siglum|default_if_none:"" }}</td>
+                    <td>{{ chant.source.siglum|default_if_none:"" }}</td>
                     <td>{{ chant.marginalia|default_if_none:"" }}</td>
                     <td>{{ chant.folio|default_if_none:"" }}</td>
                     <td>{{ chant.sequence_number|default_if_none:"" }}</td>

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1206,9 +1206,9 @@ class ChantIndexView(TemplateView):
 
         # 4064 is the id for the sequence database
         if source.segment.id == 4064:
-            queryset = source.sequence_set.order_by("id")
+            queryset = source.sequence_set.order_by("folio", "sequence_number")
         else:
-            queryset = source.chant_set.order_by("id")
+            queryset = source.chant_set.order_by("folio", "sequence")
 
         context["source"] = source
         context["chants"] = queryset


### PR DESCRIPTION
This PR makes two changes to the Chant Index view:

First, it changes the value displayed in the siglum column - whereas we had previously been using chants' `siglum` fields, we now use chants' sources' `siglum` fields, which should be standardized and generally more up-to-date.

Second, it changes the sorting of the records on the page. Whereas previously, chants had been ordered by `id`, they are now ordered first by `folio`, and then by `sequence_number`.