### PR TITLE
Add links to column headers on Chant Search page to allow sorting of results

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -84,7 +84,7 @@
             <table class="table table-sm small table-bordered">
                 <thead>
                     <tr>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Unique identifier for the manuscript that contains the chant">
+                        <th scope="col" class="text-wrap" style="text-align:center">
                             {% if order == "siglum" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
@@ -159,7 +159,7 @@
                                 <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record includes Manuscript Full Text">
+                        <th scope="col" class="text-wrap" style="text-align:center">
                             {% if order == "has_fulltext" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
@@ -170,7 +170,7 @@
                                 <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record has Volpiano melody">
+                        <th scope="col" class="text-wrap" style="text-align:center">
                             {% if order == "has_volpiano" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=has_volpiano&sort=asc">Mel</a> ▼
@@ -239,12 +239,12 @@
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {% if chant.manuscript_full_text %}
-                                    ✔
+                                    <span title="Chant record includes Manuscript Full Text">✔</span>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {% if chant.volpiano %}
-                                    ♫
+                                    <span title="Chant record has Volpiano melody">♫</span>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -8,7 +8,7 @@
     <object align="right">
         {% include "global_search_bar.html" %}
     </object>
-    <h3>Search Chants - {{ url_with_search_params }} - Order: {{ order }}; Sort: {{ sort }}</h3>
+    <h3>Search Chants</h3>
     {% if source %}
         <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
     {% endif %}
@@ -171,14 +171,14 @@
                             {% endif %}
                         </th>
                         <th scope="col" class="text-wrap" style="text-align:center">
-                            {% if order == "has_volpiano" %}
+                            {% if order == "has_melody" %}
                                 {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=has_volpiano&sort=asc">Mel</a> ▼
+                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
                                 {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_volpiano&sort=desc">Mel</a> ▲
+                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=desc">Mel</a> ▲
                                 {% endif %}
                             {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_volpiano&sort=asc">Mel</a>
+                                <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
                             {% endif %}
                         </th>
                         <th scope="col" class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -8,7 +8,7 @@
     <object align="right">
         {% include "global_search_bar.html" %}
     </object>
-    <h3>Search Chants</h3>
+    <h3>Search Chants - {{ url_with_search_params }} - Order: {{ order }}; Sort: {{ sort }}</h3>
     {% if source %}
         <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
     {% endif %}
@@ -84,18 +84,114 @@
             <table class="table table-sm small table-bordered">
                 <thead>
                     <tr>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Unique identifier for the manuscript that contains the chant">Siglum</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Folio</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Incipit/Full Text</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Feast</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Office<br>/Mass</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Genre</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Position</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Mode</th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record includes Manuscript Full Text">MsFt</th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record has Volpiano melody">Mel</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Image</th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Unique identifier for the manuscript that contains the chant">
+                            {% if order == "siglum" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=siglum&sort=desc">Siglum</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            Folio
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            {% if order == "incipit" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            Feast
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            {% if order == "office" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=office&sort=desc">Office<br>/Mass</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            {% if order == "genre" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=genre&sort=desc">Genre</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            Position
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            {% if order == "cantus_id" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=desc">Cantus ID</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            {% if order == "mode" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=mode&sort=desc">Mode</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record includes Manuscript Full Text">
+                            {% if order == "has_fulltext" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">MsFt</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record has Volpiano melody">
+                            {% if order == "has_volpiano" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=has_volpiano&sort=asc">Mel</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_volpiano&sort=desc">Mel</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=has_volpiano&sort=asc">Mel</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center">
+                            {% if order == "has_image" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_image&sort=desc">Image</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a>
+                            {% endif %}
+                        </th>
                     </tr>
                 </thead>
                 <tbody>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -80,85 +80,87 @@
     </form>
 
     {% if chants.all %}
-        <table class="table table-sm small table-bordered">
-            <thead>
-                <tr>
-                    <th scope="col" class="text-wrap" style="text-align:center" title="Unique identifier for the manuscript that contains the chant">Siglum</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Folio</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Incipit/Full Text</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Feast</th>
-                    <th scope="col" class="text-wrap" style="text-align:center"></th>
-                    <th scope="col" class="text-wrap" style="text-align:center"></th>
-                    <th scope="col" class="text-wrap" style="text-align:center"></th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Mode</th>
-                    <th scope="col" class="text-wrap" style="text-align:center" title="Chant record includes Manuscript Full Text">MsFt</th>
-                    <th scope="col" class="text-wrap" style="text-align:center" title="Chant record has Volpiano melody">Mel</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Image</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for chant in chants %}
+        <small>
+            <table class="table table-sm small table-bordered">
+                <thead>
                     <tr>
-                        <td class="text-wrap" style="text-align:left">
-                            <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {{ chant.folio|default:""|truncatechars_html:140 }}
-                        </td>
-
-                        <td class="text-wrap" style="text-align:left">
-                            {% comment %} this is used for distinguishing chants from sequences,
-                            if the object is chant, use chant.get_absolute_url,
-                            otherwise, use sequence.get_absolute_url
-                            the combined queryset turned all objects into chants
-                            so this is the only way to make the distinction {% endcomment %}
-                            {% if chant.search_vector %}
-                                <a href="{{chant.get_absolute_url}}">{{ chant.incipit|default:"" }}</a>
-                            {% else %}
-                                <a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a>
-                            {% endif %}
-                            <p>
-                                {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
-                            </p>           
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name|default:"" }}</a>
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name|default:"" }}</a>
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {{ chant.position|default:"" }}
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.get_ci_url }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {{ chant.mode|default:"" }}
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {% if chant.manuscript_full_text %}
-                                ✔
-                            {% endif %}
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {% if chant.volpiano %}
-                                ♫
-                            {% endif %}
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {% if chant.image_link %}
-                                <a href="{{ chant.image_link }}" target="_blank">Image</a>
-                            {% endif %}
-                        </td>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Unique identifier for the manuscript that contains the chant">Siglum</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Folio</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Incipit/Full Text</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Feast</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Office<br>/Mass</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Genre</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Position</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Mode</th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record includes Manuscript Full Text">MsFt</th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Chant record has Volpiano melody">Mel</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Image</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for chant in chants %}
+                        <tr>
+                            <td class="text-wrap" style="text-align:left">
+                                <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {{ chant.folio|default:""|truncatechars_html:140 }}
+                            </td>
+
+                            <td class="text-wrap" style="text-align:left">
+                                {% comment %} this is used for distinguishing chants from sequences,
+                                if the object is chant, use chant.get_absolute_url,
+                                otherwise, use sequence.get_absolute_url
+                                the combined queryset turned all objects into chants
+                                so this is the only way to make the distinction {% endcomment %}
+                                {% if chant.search_vector %}
+                                    <b><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default:"" }}</a></b>
+                                {% else %}
+                                    <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                {% endif %}
+                                <p>
+                                    {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
+                                </p>           
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name|default:"" }}</a>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name|default:"" }}</a>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {{ chant.position|default:"" }}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ chant.get_ci_url }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {{ chant.mode|default:"" }}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.manuscript_full_text %}
+                                    ✔
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.volpiano %}
+                                    ♫
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.image_link %}
+                                    <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </small>
 
         {% include "pagination.html" %}
     {% endif %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -664,6 +664,52 @@ class ChantSearchView(ListView):
         context = super().get_context_data(**kwargs)
         # Add to context a QuerySet of dicts with id and name of each Genre
         context["genres"] = Genre.objects.all().order_by("name").values("id", "name")
+        context["order"] = self.request.GET.get("order")
+        context["sort"] = self.request.GET.get("sort")
+
+        # build a url containing all the search parameters, excluding ordering parameters.
+        # this way, when someone clicks on a column heading, we can append the ordering parameters
+        # while retaining the search parameters
+        current_url = self.request.path
+        search_parameters = []
+
+        search_op = self.request.GET.get('op')
+        if search_op:
+            search_parameters.append(f"op={search_op}")
+        search_keyword = self.request.GET.get('keyword')
+        if search_keyword:
+            search_parameters.append(f"keyword={search_keyword}")
+        search_office = self.request.GET.get('office')
+        if search_office:
+            search_parameters.append(f'office={search_office}')
+        search_genre = self.request.GET.get('genre')
+        if search_genre:
+            search_parameters.append(f'genre={search_genre}')
+        search_cantus_id = self.request.GET.get('cantus_id')
+        if search_cantus_id:
+            search_parameters.append(f'cantus_id={search_cantus_id}')
+        search_mode = self.request.GET.get('mode')
+        if search_mode:
+            search_parameters.append(f'mode={search_mode}')
+        search_feast = self.request.GET.get('feast')
+        if search_feast:
+            search_parameters.append(f'feast={search_feast}')
+        search_position = self.request.GET.get('position')
+        if search_position:
+            search_parameters.append(f'position={search_position}')
+        search_melodies = self.request.GET.get('melodies')
+        if search_melodies:
+            search_parameters.append(f'melodies={search_melodies}')
+
+        if search_parameters:
+            joined_search_parameters = "&".join(search_parameters)
+            url_with_search_params = current_url + "?" + joined_search_parameters
+        else:
+            url_with_search_params = current_url + "?"
+            
+        context["url_with_search_params"] = url_with_search_params
+        print(self.request)
+
         return context
 
     def get_queryset(self) -> QuerySet:
@@ -743,7 +789,7 @@ class ChantSearchView(ListView):
                 elif self.request.GET.get('order') == 'has_fulltext':
                     order = 'manuscript_full_text'
                 elif self.request.GET.get('order') == 'has_melody':
-                    order = 'volpiano'
+                    order = 'volpiano__isnull'
                 elif self.request.GET.get('order') == 'has_image':
                     order = 'image_link'
                 else:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -789,7 +789,7 @@ class ChantSearchView(ListView):
                 elif self.request.GET.get('order') == 'has_fulltext':
                     order = 'manuscript_full_text'
                 elif self.request.GET.get('order') == 'has_melody':
-                    order = 'volpiano__isnull'
+                    order = 'volpiano'
                 elif self.request.GET.get('order') == 'has_image':
                     order = 'image_link'
                 else:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -705,6 +705,7 @@ class ChantSearchView(ListView):
             if self.request.GET.get("genre"):
                 genre_id = int(self.request.GET.get("genre"))
                 q_obj_filter &= Q(genre__id=genre_id)
+
             if self.request.GET.get("cantus_id"):
                 cantus_id = self.request.GET.get("cantus_id")
                 q_obj_filter &= Q(cantus_id__icontains=cantus_id)
@@ -726,6 +727,34 @@ class ChantSearchView(ListView):
                 # as a substring
                 feasts = Feast.objects.filter(name__icontains=feast)
                 q_obj_filter &= Q(feast__in=feasts)
+            if self.request.GET.get('order'):
+                if self.request.GET.get('order') == 'siglum':
+                    order = 'siglum'
+                elif self.request.GET.get('order') == 'incipit':
+                    order = 'incipit'
+                elif self.request.GET.get('order') == 'office':
+                    order = 'office'
+                elif self.request.GET.get('order') == 'genre':
+                    order = 'genre'
+                elif self.request.GET.get('order') == 'cantus_id':
+                    order = 'cantus_id'
+                elif self.request.GET.get('order') == 'mode':
+                    order = 'mode'
+                elif self.request.GET.get('order') == 'has_fulltext':
+                    order = 'manuscript_full_text'
+                elif self.request.GET.get('order') == 'has_melody':
+                    order = 'volpiano'
+                elif self.request.GET.get('order') == 'has_image':
+                    order = 'image_link'
+                else:
+                    order = 'siglum'
+            else:
+                order = 'siglum'
+            if self.request.GET.get('sort'):
+                if self.request.GET.get('sort') == "asc":
+                    order = order
+                elif self.request.GET.get('sort') == 'desc':
+                    order = "-" + order
             if not display_unpublished:
                 chant_set = Chant.objects.filter(source__published=True)
                 sequence_set = Sequence.objects.filter(source__published=True)
@@ -748,10 +777,7 @@ class ChantSearchView(ListView):
 
             # once unioned, the queryset cannot be filtered/annotated anymore, so we put union to the last
             queryset = chant_set.union(sequence_set)
-            # ordering with the folio string gives wrong order
-            # old cantus is also not strictly ordered by folio (there are outliers)
-            # so we order by id for now, which is the order that the chants are entered into the DB
-            queryset = queryset.order_by("siglum", "id")
+            queryset = queryset.order_by(order, "id")
 
         return queryset
 


### PR DESCRIPTION
fixes #414

There are some small differences between OldCantus's implementation of this and NewCantus's.

- in the URL query parameters, NewCantus uses less-technical terms than OldCantus does (e.g. `?order=has_melody` instead of `?order=field_volpiano_1`)
- For the columns that can contain empty cells (mostly relevant for MsFt, Mel and Image): whereas on OldCantus, clicking on MsFt once causes all the records _without_ melodies to be displayed at the top, on NewCantus, clicking on MsFt once causes all the records _with_ melodies to be displayed at the top. This tiny improvement required no extra work to implement - it seems that Django treats None values differently when sorting than Drupal does.