### PR TITLE
Improve formatting, accessibility of Chant-by-cantus-ID view

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -49,7 +49,7 @@
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>
-                    <td class="text-wrap" style="font-family: volpiano; font-size:30px" title="Chant has volpiano melody">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none">1</a>{% endif %}</td>
+                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
                     <td class="text-wrap">{% if chant.image_link %}<a href="{{ chant.image_link }}" target="_blank">Image</a>{% endif %}</td>
                 </tr>
             {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -49,7 +49,7 @@
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>
-                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none">1</a>{% endif %}</td>
+                    <td class="text-wrap" style="font-family: volpiano; font-size:30px" title="Chant has volpiano melody">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none">1</a>{% endif %}</td>
                     <td class="text-wrap">{% if chant.image_link %}<a href="{{ chant.image_link }}" target="_blank">Image</a>{% endif %}</td>
                 </tr>
             {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -23,7 +23,7 @@
                 <th scope="col" class="text-wrap">Position</th>
                 <th scope="col" class="text-wrap">Feast</th>
                 <th scope="col" class="text-wrap">Mode</th>
-                <th scope="col" class="text-wrap" style="font-family: volpiano; font-size:30px">1</th>
+                <th scope="col" class="text-wrap" style="font-family: volpiano; font-size:30px; font-weight:normal;">1</th>
                 <th scope="col" class="text-wrap">Facsimile</th>
             </tr>
         </thead>


### PR DESCRIPTION
This PR improves the formatting of the Chant-by-Cantus-ID view, and add a simple accessibility feature.

Previously, the treble clef in the column header of the table appeared blobby because its `font-weight` had been set to `bold` (see the current state of affairs at http://206.12.93.196/id/002685). This PR sets the `font-weight` of just this column header to `normal` to correct this.

In addition, treble clefs appearing in the rows of the table now have title/mouseover text explaining that the treble clef indicates that that particular chat record has volpiano melody attached to it.