### PR TITLE
Add link to search cantusindex.org to chant search page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -13,6 +13,12 @@
         <p>
             <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
         </p>
+    {% elif cantus_index_link %}
+        <p>
+            <small>
+                » {{ cantus_index_link|safe }}
+            </small>
+        </p>
     {% endif %}
 
     {% if chants.all %}

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -10,12 +10,16 @@
     </object>
     <h3>Search Chants</h3>
     {% if source %}
-        <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
+        <p>
+            <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
+        </p>
     {% endif %}
 
     {% if chants.all %}
-        <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
-                chants</b></small>
+        <p>
+            <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
+                    chant{{ page_obj.paginator.count|pluralize }}</b></small>
+        </p>
     {% endif %}
 
     <form method="get">

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -13,10 +13,12 @@
         <p>
             <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
         </p>
-    {% elif cantus_index_link %}
+    {% elif keyword %}
         <p>
             <small>
-                » {{ cantus_index_link|safe }}
+                » <a href="http://cantusindex.org/search?t={{ keyword }}" title="Search {{ keyword }} on CantusIndex.org" target="_blank">
+                    Search <b>{{ keyword }}</b> on CantusIndex.org
+                </a>
             </small>
         </p>
     {% endif %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -709,6 +709,19 @@ class ChantSearchView(ListView):
             
         context["url_with_search_params"] = url_with_search_params
 
+        if search_keyword:
+            cantus_index_url = "http://cantusindex.org/search?t={k}".format(k=search_keyword)
+            cantus_index_inner_text = "Search <b>{k}</b> on CantusIndex.org".format(k=search_keyword)
+            cantus_index_title_text = "Search {k} on CantusIndex.org".format(k=search_keyword)
+            cantus_index_link = '<a href="{url}" title="{title}" target="_blank">{inner_text}</a>'.format(
+                url=cantus_index_url,
+                title=cantus_index_title_text,
+                inner_text=cantus_index_inner_text,
+            )
+            context['cantus_index_link'] = cantus_index_link
+        else:
+            context['cantus_index_link'] = ""
+
         return context
 
     def get_queryset(self) -> QuerySet:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -708,7 +708,6 @@ class ChantSearchView(ListView):
             url_with_search_params = current_url + "?"
             
         context["url_with_search_params"] = url_with_search_params
-        print(self.request)
 
         return context
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -679,6 +679,7 @@ class ChantSearchView(ListView):
         search_keyword = self.request.GET.get('keyword')
         if search_keyword:
             search_parameters.append(f"keyword={search_keyword}")
+            context["keyword"] = search_keyword
         search_office = self.request.GET.get('office')
         if search_office:
             search_parameters.append(f'office={search_office}')
@@ -708,19 +709,6 @@ class ChantSearchView(ListView):
             url_with_search_params = current_url + "?"
             
         context["url_with_search_params"] = url_with_search_params
-
-        if search_keyword:
-            cantus_index_url = "http://cantusindex.org/search?t={k}".format(k=search_keyword)
-            cantus_index_inner_text = "Search <b>{k}</b> on CantusIndex.org".format(k=search_keyword)
-            cantus_index_title_text = "Search {k} on CantusIndex.org".format(k=search_keyword)
-            cantus_index_link = '<a href="{url}" title="{title}" target="_blank">{inner_text}</a>'.format(
-                url=cantus_index_url,
-                title=cantus_index_title_text,
-                inner_text=cantus_index_inner_text,
-            )
-            context['cantus_index_link'] = cantus_index_link
-        else:
-            context['cantus_index_link'] = ""
 
         return context
 


### PR DESCRIPTION
This PR goes partway towards fixing #421, adding a link to the chant search page taking you to the corresponding search page on cantusindex.org.

Along the way, a missing pluralization template tag was added, the formatting was improved (previously, the pagination blurb had been on the same line as the name of the source when the template was being used to render the ChantSearchManuscript view) and an unnecessary print statement was removed.