### PR TITLE
Add printer-friendly chant search view

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -12,26 +12,26 @@
     {% if source %}
         <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
     {% else %}
-        <p>
-            <small>
-                » <a href="{{ printer_friendly_url }}">Printer-friendly version</a>
-        <p>
-            <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
-        </p>
-    {% elif keyword %}
-        <p>
-            <small>
-                » <a href="http://cantusindex.org/search?t={{ keyword }}" title="Search {{ keyword }} on CantusIndex.org" target="_blank">
-                    Search <b>{{ keyword }}</b> on CantusIndex.org
-                </a>
-            </small>
-        </p>
+        {% if keyword %}
+            <p style="margin-bottom: 0px;">
+                <small>
+                    » <a href="http://cantusindex.org/search?t={{ keyword }}" title="Search {{ keyword }} on CantusIndex.org" target="_blank">
+                        Search <b>{{ keyword }}</b> on CantusIndex.org
+                    </a>
+                </small>
+            </p>
+        {% endif %}
+    <p style="margin-bottom: 0px;">
+        <small>
+            » <a href="{{ printer_friendly_url }}">Printer-friendly version</a>
+        </small>
+    </p>
     {% endif %}
 
     {% if chants.all %}
         <p>
             <small>
-                Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }} chants</b>
+                Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}</b> chants
             </small>
         </p>
     {% endif %}

--- a/django/cantusdb_project/main_app/templates/chant_search_printer_friendly.html
+++ b/django/cantusdb_project/main_app/templates/chant_search_printer_friendly.html
@@ -1,30 +1,76 @@
-{% extends "base.html" %}
-{% block content %}
-<title>Search Chants | Cantus Manuscript Database</title>
-<script src="/static/js/chant_search.js"></script>
+<!DOCTYPE html>
+{% load static %}
+<html lang="en">
+<head>
+    <title>Search Chants (Printer-Friendly) | Cantus Manuscript Database</title>
+    
+    <!-- Required meta tags -->
+    <meta name="robots" content="noindex">
+    <meta name="google-site-verification" content="EwxpNpZ_ZOQnetVVLELGn5-aD_beT3EQqUuI6glkArI" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, 
+    initial-scale=1, shrink-to-fit=no">
+
+    <link rel="icon" href="{% static "favicon.ico" %}">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
+
+    <!-- font-awesome CSS for icons -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+
+    <!-- JS, Popper.js, and jQuery -->
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+
+    <script src="/static/js/chant_search.js"></script>
+    <style>
+        html {
+            position: relative;
+            min-height: 90%;
+        }
+
+        body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 15px;
+            height: 100%;
+        }
+
+        a {
+            color: rgb(100,100,100);
+        }
+
+        a:hover {
+            color: rgb(200,200,200);
+            text-decoration: none;
+        }
+
+        table {
+            padding: 0px;
+            font-size: 70%;
+            line-height: normal;
+        }
+
+        table, th, td {
+            border: 1px solid;
+        }
+    </style>
+    <link href="{% static 'fonts/volpiano.css' %}" rel="stylesheet" media="screen">
+</head>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
-        {% include "global_search_bar.html" %}
-    </object>
-    <h3>Search Chants</h3>
+    <p>
+        « <a href="{{ main_chant_search_url }}">Return to main search page</a>
+    </p>
     {% if source %}
         <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
-    {% else %}
-        <p>
-            <small>
-                » <a href="{{ printer_friendly_url }}">Printer-friendly version</a>
-            </small>
-        </p>
     {% endif %}
 
     {% if chants.all %}
-        <p>
-            <small>
-                Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }} chants</b>
-            </small>
-        </p>
+        <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
+                chants</b></small>
     {% endif %}
 
     <form method="get">
@@ -90,7 +136,7 @@
 
     {% if chants.all %}
         <small>
-            <table class="table table-sm small table-bordered">
+            <table>
                 <thead>
                     <tr>
                         <th scope="col" class="text-wrap" style="text-align:center">
@@ -110,12 +156,12 @@
                         <th scope="col" class="text-wrap" style="text-align:center">
                             {% if order == "incipit" %}
                                 {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit</a> ▼
                                 {% else %}
-                                    <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit</a> ▲
                                 {% endif %}
                             {% else %}
-                                <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
+                                <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit</a>
                             {% endif %}
                         </th>
                         <th scope="col" class="text-wrap" style="text-align:center">
@@ -210,7 +256,7 @@
                                 <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                {{ chant.folio|default:""|truncatechars_html:140 }}
+                                {{ chant.folio|default:"" }}
                             </td>
 
                             <td class="text-wrap" style="text-align:left">
@@ -224,9 +270,6 @@
                                 {% else %}
                                     <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
                                 {% endif %}
-                                <p>
-                                    {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
-                                </p>           
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
@@ -270,5 +313,4 @@
         {% include "pagination.html" %}
     {% endif %}
 </div>
-        
-{% endblock %}
+</html>

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -4,26 +4,48 @@ from main_app.views import views
 from main_app.views.century import CenturyDetailView
 from main_app.views.sequence import SequenceEditView
 from main_app.views.source import SourceCreateView, SourceEditView
-from main_app.views.chant import SourceEditChantsView, ChantProofreadView, ChantEditSyllabificationView
+from main_app.views.chant import (
+    SourceEditChantsView,
+    ChantProofreadView,
+    ChantEditSyllabificationView,
+    ChantSearchPrinterFriendlyView,
+)
 from main_app.views.notation import NotationDetailView
 from main_app.views.provenance import ProvenanceDetailView
-from main_app.views.user import UserDetailView, UserSourceListView, CustomLogoutView, UserListView, CustomLoginView
+from main_app.views.user import (
+    UserDetailView,
+    UserSourceListView,
+    CustomLogoutView,
+    UserListView,
+    CustomLoginView,
+)
 
 urlpatterns = [
     path("contact/", views.contact, name="contact"),
     # login/logout/user
-    path('login/', CustomLoginView.as_view(redirect_authenticated_user=True), name="login"),
-    path('logout/', CustomLogoutView.as_view(), name="logout"),
+    path(
+        "login/",
+        CustomLoginView.as_view(redirect_authenticated_user=True),
+        name="login",
+    ),
+    path("logout/", CustomLogoutView.as_view(), name="logout"),
     path("my-sources/", UserSourceListView.as_view(), name="my-sources"),
     path("user/<int:pk>", UserDetailView.as_view(), name="user-detail"),
     path("users/", UserListView.as_view(), name="user-list"),
     path("change-password/", views.change_password, name="change-password"),
     # century
-    path("century/<int:pk>", CenturyDetailView.as_view(), name="century-detail"),    
+    path("century/<int:pk>", CenturyDetailView.as_view(), name="century-detail"),
     # chant
-    path("chants/", ChantListView.as_view(), name="chant-list"), # /chants/?source={source id}
+    path(
+        "chants/", ChantListView.as_view(), name="chant-list"
+    ),  # /chants/?source={source id}
     path("chant/<int:pk>", ChantDetailView.as_view(), name="chant-detail"),
     path("chant-search/", ChantSearchView.as_view(), name="chant-search"),
+    path(
+        "chant-search-print/",
+        ChantSearchPrinterFriendlyView.as_view(),
+        name="chant-search-print",
+    ),
     path(
         "chant-create/<int:source_pk>", ChantCreateView.as_view(), name="chant-create"
     ),
@@ -32,21 +54,23 @@ urlpatterns = [
     ),
     path("chant-delete/<int:pk>", ChantDeleteView.as_view(), name="chant-delete"),
     path(
-        "edit-chants/<int:source_id>", 
-        SourceEditChantsView.as_view(), 
-        name="source-edit-chants"
+        "edit-chants/<int:source_id>",
+        SourceEditChantsView.as_view(),
+        name="source-edit-chants",
     ),
     path(
-        "proofread-chant/<int:source_id>", 
-        ChantProofreadView.as_view(), 
-        name="chant-proofread"
+        "proofread-chant/<int:source_id>",
+        ChantProofreadView.as_view(),
+        name="chant-proofread",
     ),
-        path(
+    path(
         "edit-syllabification/<int:chant_id>",
         ChantEditSyllabificationView.as_view(),
-        name="source-edit-syllabification"
+        name="source-edit-syllabification",
     ),
-    path("index/", ChantIndexView.as_view(), name="chant-index"), # /index/?source={source id}
+    path(
+        "index/", ChantIndexView.as_view(), name="chant-index"
+    ),  # /index/?source={source id}
     # feast
     path("feasts/", FeastListView.as_view(), name="feast-list"),
     path("feast/<int:pk>", FeastDetailView.as_view(), name="feast-detail"),
@@ -61,32 +85,40 @@ urlpatterns = [
     path("offices/", OfficeListView.as_view(), name="office-list"),
     path("office/<int:pk>", OfficeDetailView.as_view(), name="office-detail"),
     # provenance
-    path("provenance/<int:pk>", ProvenanceDetailView.as_view(), name="provenance-detail"),
+    path(
+        "provenance/<int:pk>", ProvenanceDetailView.as_view(), name="provenance-detail"
+    ),
     # sequence
     path("sequences/", SequenceListView.as_view(), name="sequence-list"),
-    path("sequence/<int:pk>", SequenceDetailView.as_view(), name="sequence-detail",),
-    path("edit-sequence/<int:sequence_id>", SequenceEditView.as_view(), name="sequence-edit",),
+    path(
+        "sequence/<int:pk>",
+        SequenceDetailView.as_view(),
+        name="sequence-detail",
+    ),
+    path(
+        "edit-sequence/<int:sequence_id>",
+        SequenceEditView.as_view(),
+        name="sequence-edit",
+    ),
     # source
     path("sources/", SourceListView.as_view(), name="source-list"),
     path("source/<int:pk>", SourceDetailView.as_view(), name="source-detail"),
-    path(
-        "source-create/", 
-        SourceCreateView.as_view(), 
-        name="source-create"
-    ),
-    path(
-        "edit-source/<int:source_id>", 
-        SourceEditView.as_view(), 
-        name="source-edit"
-    ),
+    path("source-create/", SourceCreateView.as_view(), name="source-create"),
+    path("edit-source/<int:source_id>", SourceEditView.as_view(), name="source-edit"),
     # melody
     path("melody/", MelodySearchView.as_view(), name="melody-search"),
     path("ajax/melody/<str:cantus_id>", views.ajax_melody_list, name="ajax-melody"),
-    path("ajax/melody-search/", views.ajax_melody_search, name="ajax-melody-search",),
+    path(
+        "ajax/melody-search/",
+        views.ajax_melody_search,
+        name="ajax-melody-search",
+    ),
     # json api
     path("json-sources/", views.json_sources_export, name="json-sources-export"),
     path("json-node/<str:id>", views.json_node_export, name="json-node-export"),
-    path("json-nextchants/<str:cantus_id>", views.json_nextchants, name="json-nextchants"),
+    path(
+        "json-nextchants/<str:cantus_id>", views.json_nextchants, name="json-nextchants"
+    ),
     path(
         "json-melody/<str:cantus_id>",
         views.json_melody_export,
@@ -120,4 +152,4 @@ urlpatterns = [
     ),
 ]
 
-handler404 = 'main_app.views.views.handle404'
+handler404 = "main_app.views.views.handle404"

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -716,6 +716,8 @@ class ChantSearchView(ListView):
             joined_sorting_parameters = "&".join(sorting_parameters)
             joined_search_and_sorting_parameters = "&".join((joined_search_parameters, joined_sorting_parameters))
             printer_friendly_url = printer_friendly_url + "?" + joined_search_and_sorting_parameters
+        else:
+            url_with_search_params = current_url + "?"
             
         context["url_with_search_params"] = url_with_search_params
         context["printer_friendly_url"] = printer_friendly_url


### PR DESCRIPTION
This PR goes partway towards fixing #421, adding a printer-friendly version of the chant search page. Some notes:

- the existing `chant_search.html` template was duplicated and adapted to create this page. The `ChantSearchView` in `views/chant.py` was similarly copied and adapted
- Some differences in behavior between New and OldCantus:
  - in addition to preserving search parameters, as OldCantus does, this implementation preserves ordering parameters as well. In addition, the column headers can be clicked on to re-order the page just as in the main chant search view.
    - but switching from the printer-friendly page to the normal page and back does not preserve pagination query parameters (this is a similarity between Old and New Cantus)
  - column headers are clickable in this implementation (they weren't in OldCantus's), and display the small arrow icon that indicates what field the results are being ordered by as well as the direction of their ordering
- at some point in the process, I evidently told Serenade to format `urls.py`, so a bunch of lines have been tweaked so as to standardize them. There shouldn't be any substantial difference, only reallocated whitespace 