### PR TITLE
Implement sorting in ChantSearchMS view

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -875,6 +875,8 @@ class ChantSearchMSView(ListView):
         context = super().get_context_data(**kwargs)
         # Add to context a QuerySet of dicts with id and name of each Genre
         context["genres"] = Genre.objects.all().order_by("name").values("id", "name")
+        context["order"] = self.request.GET.get("order")
+        context["sort"] = self.request.GET.get("sort")
         # This is searching in a specific source, pass the source into context
         source_id = self.kwargs["source_pk"]
         try:
@@ -885,6 +887,45 @@ class ChantSearchMSView(ListView):
         display_unpublished = self.request.user.is_authenticated
         if (source.published == False) and (not display_unpublished):
             raise PermissionDenied
+        
+        current_url = self.request.path
+        search_parameters = []
+
+        search_op = self.request.GET.get('op')
+        if search_op:
+            search_parameters.append(f"op={search_op}")
+        search_keyword = self.request.GET.get('keyword')
+        if search_keyword:
+            search_parameters.append(f"keyword={search_keyword}")
+        search_office = self.request.GET.get('office')
+        if search_office:
+            search_parameters.append(f'office={search_office}')
+        search_genre = self.request.GET.get('genre')
+        if search_genre:
+            search_parameters.append(f'genre={search_genre}')
+        search_cantus_id = self.request.GET.get('cantus_id')
+        if search_cantus_id:
+            search_parameters.append(f'cantus_id={search_cantus_id}')
+        search_mode = self.request.GET.get('mode')
+        if search_mode:
+            search_parameters.append(f'mode={search_mode}')
+        search_feast = self.request.GET.get('feast')
+        if search_feast:
+            search_parameters.append(f'feast={search_feast}')
+        search_position = self.request.GET.get('position')
+        if search_position:
+            search_parameters.append(f'position={search_position}')
+        search_melodies = self.request.GET.get('melodies')
+        if search_melodies:
+            search_parameters.append(f'melodies={search_melodies}')
+
+        if search_parameters:
+            joined_search_parameters = "&".join(search_parameters)
+            url_with_search_params = current_url + "?" + joined_search_parameters
+        else:
+            url_with_search_params = current_url + "?"
+            
+        context["url_with_search_params"] = url_with_search_params
         return context
 
     def get_queryset(self) -> QuerySet:
@@ -918,6 +959,34 @@ class ChantSearchMSView(ListView):
             # as a substring
             feasts = Feast.objects.filter(name__icontains=feast)
             q_obj_filter &= Q(feast__in=feasts)
+        if self.request.GET.get('order'):
+            if self.request.GET.get('order') == 'siglum':
+                order = 'siglum'
+            elif self.request.GET.get('order') == 'incipit':
+                order = 'incipit'
+            elif self.request.GET.get('order') == 'office':
+                order = 'office'
+            elif self.request.GET.get('order') == 'genre':
+                order = 'genre'
+            elif self.request.GET.get('order') == 'cantus_id':
+                order = 'cantus_id'
+            elif self.request.GET.get('order') == 'mode':
+                order = 'mode'
+            elif self.request.GET.get('order') == 'has_fulltext':
+                order = 'manuscript_full_text'
+            elif self.request.GET.get('order') == 'has_melody':
+                order = 'volpiano'
+            elif self.request.GET.get('order') == 'has_image':
+                order = 'image_link'
+            else:
+                order = 'siglum'
+        else:
+            order = 'siglum'
+        if self.request.GET.get('sort'):
+            if self.request.GET.get('sort') == "asc":
+                order = order
+            elif self.request.GET.get('sort') == 'desc':
+                order = "-" + order
 
         source_id = self.kwargs["source_pk"]
         source = Source.objects.get(id=source_id)
@@ -937,7 +1006,7 @@ class ChantSearchMSView(ListView):
         # ordering with the folio string gives wrong order
         # old cantus is also not strictly ordered by folio (there are outliers)
         # so we order by id for now, which is the order that the chants are entered into the DB
-        queryset = queryset.order_by("siglum", "id")
+        queryset = queryset.order_by(order, "id")
         return queryset
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -708,7 +708,6 @@ class ChantSearchView(ListView):
             url_with_search_params = current_url + "?"
             
         context["url_with_search_params"] = url_with_search_params
-        print(self.request)
 
         return context
 


### PR DESCRIPTION
In implementing sorting on the normal ChantSearchView, it caused knock-on effects for the ChantSearchMSView, which shares a template with the normal ChantSearchView. This PR add logic to the ChantSearchMSView allowing the results to be sorted just as on the normal ChantSearchView.

Initially, I attempted to do this by creating a BaseChantSearchView for ChantSearchView and ChantSearchMSView to inherit from; it caused failing tests and error messages, so I went for the copy-and-paste approach. Eventually, this might be a good thing to go back and refactor.