### PR TITLE
Improve import statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ django/cantusdb_project/Drupal_scripts
 # django/cantusdb_project/chant_list.txt
 # django/cantusdb_project/feast_list.txt
 # django/cantusdb_project/error_log.txt
+
+# in case you're working on importing data from a database dump
+*.sql

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
 from main_app.models import *
-from django.contrib.auth import get_user_model
 # Register your models here.
 
 class BaseModelAdmin(admin.ModelAdmin):

--- a/django/cantusdb_project/main_app/management/commands/add_prefix.py
+++ b/django/cantusdb_project/main_app/management/commands/add_prefix.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 # from pprint import pprint
 from main_app.models import Feast

--- a/django/cantusdb_project/main_app/management/commands/merge_indexer_user.py
+++ b/django/cantusdb_project/main_app/management/commands/merge_indexer_user.py
@@ -1,4 +1,3 @@
-from operator import index
 from django.core.management.base import BaseCommand
 from main_app.models import Indexer
 from users.models import User

--- a/django/cantusdb_project/main_app/management/commands/update_differentia_new.py
+++ b/django/cantusdb_project/main_app/management/commands/update_differentia_new.py
@@ -1,6 +1,5 @@
 from main_app.models import Chant
 from django.core.management.base import BaseCommand
-import json
 
 # In the past, the BaseChant model had a `.differentia` field and a `.differentia_id` field.
 # There was no data stored in the `differentia_id` field for any Chant or Sequence.

--- a/django/cantusdb_project/main_app/models/feast.py
+++ b/django/cantusdb_project/main_app/models/feast.py
@@ -1,6 +1,6 @@
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models import CheckConstraint, Q
+from django.db.models import Q
 
 from main_app.models import BaseModel
 

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -1,6 +1,5 @@
 import calendar
 from typing import Union, Optional
-from django.utils.http import urlencode
 from django import template
 from main_app.models import Source
 from articles.models import Article

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -1,4 +1,3 @@
-import unittest
 from django.test import TestCase
 from latin_syllabification import (
         clean_transcript,

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from latin_syllabification import (
         clean_transcript,
         syllabify_word,
-        syllabify_text,
     )
 
 # run with `python -Wa manage.py test main_app.tests.test_functions`

--- a/django/cantusdb_project/main_app/tests/test_input.py
+++ b/django/cantusdb_project/main_app/tests/test_input.py
@@ -1,6 +1,4 @@
 import unittest
-from main_app.tests.make_fakes import make_fake_text
-import random
 
 from django.test import TestCase
 from django.urls import reverse

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -1,7 +1,24 @@
 from django.forms import ValidationError
 from django.test import TestCase
 from django.urls import reverse
-from .make_fakes import *
+from main_app.models import (
+    Century,
+    Chant,
+    Feast,
+    Genre,
+    Office,
+    Sequence,
+    Source,
+)
+from .make_fakes import (
+    make_fake_century,
+    make_fake_chant,
+    make_fake_feast,
+    make_fake_genre,
+    make_fake_office,
+    make_fake_sequence,
+    make_fake_source,
+)
 
 # run with `python -Wa manage.py test main_app.tests.test_models`
 # the -Wa flag tells Python to display deprecation warnings

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -16,24 +16,19 @@ from .make_fakes import (make_fake_text,
     make_fake_chant,
     make_fake_feast,
     make_fake_genre,
-    make_fake_notation,
     make_fake_office,
     make_fake_provenance,
     make_fake_rism_siglum,
     make_fake_segment,
     make_fake_sequence,
     make_fake_source,
-    make_fake_user,
 )
 
 from main_app.models import Century
 from main_app.models import Chant
 from main_app.models import Feast
 from main_app.models import Genre
-from main_app.models import Notation
 from main_app.models import Office
-from main_app.models import Provenance
-from main_app.models import RismSiglum
 from main_app.models import Segment
 from main_app.models import Sequence
 from main_app.models import Source

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -1,13 +1,59 @@
 from django.urls import path
-from main_app.views import *
 from main_app.views import views
-from main_app.views.century import CenturyDetailView
-from main_app.views.sequence import SequenceEditView
-from main_app.views.source import SourceCreateView, SourceEditView
-from main_app.views.chant import SourceEditChantsView, ChantProofreadView, ChantEditSyllabificationView
-from main_app.views.notation import NotationDetailView
-from main_app.views.provenance import ProvenanceDetailView
-from main_app.views.user import UserDetailView, UserSourceListView, CustomLogoutView, UserListView, CustomLoginView
+from main_app.views.century import (
+    CenturyDetailView,
+)
+from main_app.views.chant import (
+    ChantByCantusIDView,
+    ChantCreateView,
+    ChantDeleteView,
+    ChantDetailView,
+    ChantEditSyllabificationView,
+    ChantIndexView,
+    ChantListView,
+    ChantProofreadView, 
+    ChantSearchView,
+    ChantSearchMSView,
+    CISearchView,
+    MelodySearchView,
+    SourceEditChantsView,)
+from main_app.views.feast import (
+    FeastDetailView,
+    FeastListView,
+)
+from main_app.views.genre import (
+    GenreDetailView,
+    GenreListView,
+)
+from main_app.views.notation import (
+    NotationDetailView,
+)
+from main_app.views.office import (
+    OfficeListView,
+    OfficeDetailView,
+)
+from main_app.views.provenance import (
+    ProvenanceDetailView,
+)
+from main_app.views.sequence import (
+    SequenceDetailView,
+    SequenceEditView,
+    SequenceListView,
+)
+from main_app.views.source import (
+    SourceCreateView,
+    SourceDetailView,
+    SourceEditView,
+    SourceListView,
+)
+from main_app.views.user import (
+    CustomLoginView,
+    CustomLogoutView,
+    IndexerListView,
+    UserDetailView,
+    UserListView,
+    UserSourceListView,
+)
 
 urlpatterns = [
     path("contact/", views.contact, name="contact"),

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F, Q, QuerySet
 from django.shortcuts import get_object_or_404
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse
 from django.views.generic import (
     CreateView,
     DeleteView,

--- a/django/cantusdb_project/main_app/views/feast.py
+++ b/django/cantusdb_project/main_app/views/feast.py
@@ -1,4 +1,3 @@
-from django.db.models import query
 from django.views.generic import DetailView, ListView
 from main_app.models import Feast, Source
 from extra_views import SearchableListMixin

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1,7 +1,7 @@
 import csv
 from django.http.response import JsonResponse
 from django.http import HttpResponse, HttpResponseNotFound
-from django.shortcuts import render, redirect
+from django.shortcuts import render
 from django.urls.base import reverse
 from main_app.models import (
     Century,

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1,5 +1,5 @@
 import csv
-from django.http.response import HttpResponseRedirect, JsonResponse
+from django.http.response import JsonResponse
 from django.http import HttpResponse, HttpResponseNotFound
 from django.shortcuts import render, redirect
 from django.urls.base import reverse
@@ -16,11 +16,9 @@ from main_app.models import (
     Sequence,
     Source
 )
-from django.core.mail import send_mail, get_connection
 from django.contrib.auth.decorators import login_required, user_passes_test
 from next_chants import next_chants
 from django.contrib import messages
-import random
 from django.http import Http404
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import PasswordChangeForm

--- a/django/cantusdb_project/users/tests.py
+++ b/django/cantusdb_project/users/tests.py
@@ -2,8 +2,8 @@ from django.test import TestCase
 from django.test import Client
 from django.contrib.auth import get_user_model
 from django.urls import reverse
-from main_app.models import Segment
-from main_app.tests.make_fakes import *
+from main_app.models import Segment, Source
+from main_app.tests.make_fakes import make_fake_user
 from main_app.tests.test_views import get_random_search_term
 
 # run with `python -Wa manage.py test users.tests`


### PR DESCRIPTION
This PR cleans up import statements at the top of several files. It:

- removes a number of import statements that were not being used
- reflectors a number of instances of `import *`, replacing them with explicit import statements
- improves and standardizes the formatting and ordering of the import statements in several files

There's not much to review here; all tests are passing, and I clicked through the homepage and a handful of list, detail and search views (this portion of the testing was not exhaustive) and nothing seems to have broken.