### PR TITLE
Ensure all pages on the site print nicely

### DIFF
--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="mr-3 p-3 col-md-9 bg-white rounded">
+<div class="mr-3 p-3 col-md-12 bg-white rounded">
+    <object align="right" class="search-bar">
+        {% include "global_search_bar.html" %}
+    </object>
+    <h3>
+        {{article.title}}
+    </h3>
     <div class="row">
         <div class="col">
-            <h3>
-                {{article.title}}
-            </h3>
             <div class="container">
                 <div class="container text-wrap">
                     <small>Submitted by <a href="{{ article.author.get_absolute_url }}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="mr-3 p-3 col-md-10 mx-auto bg-white rounded">
+    <object align="right" class="search-bar">
+        {% include "global_search_bar.html" %}
+    </object>
     <h3>What's New</h3>
     {% for article in articles %}
     <div class="row">

--- a/django/cantusdb_project/main_app/templates/century_detail.html
+++ b/django/cantusdb_project/main_app/templates/century_detail.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>{{ century.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ century.name }}</h3>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -255,9 +255,10 @@
             </form>
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
                 <div class="card-header">

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -272,9 +272,10 @@
 
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             {% with source=chant.source %}
                 <div class="card mb-3 w-100">

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -231,9 +231,10 @@
             {% endif %}
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
                 <div class="card-header">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -5,7 +5,7 @@
 
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+        <div class="mr-3 p-3 col-lg-8 bg-white rounded main-content">
             <h3>Browse Chants</h3>
             <small>Displaying <b>{{ page_obj.start_index }}-{{ page_obj.end_index }}</b> of <b>{{ page_obj.paginator.count }}</b> chants</small>
             
@@ -109,9 +109,10 @@
             {% include "pagination.html" %}
         </div>
     
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
 

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -229,9 +229,10 @@
             {% endif %}
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
                 <div class="card-header">

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -4,8 +4,7 @@
 <script src="/static/js/chant_search.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>Search Chants</h3>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -3,7 +3,7 @@
 <title>Chants by Cantus ID: {{ cantus_id }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>

--- a/django/cantusdb_project/main_app/templates/contact.html
+++ b/django/cantusdb_project/main_app/templates/contact.html
@@ -3,7 +3,7 @@
 <title>Contact | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
 

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -3,8 +3,7 @@
 {% block content %}
 <title>{{ feast.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ feast.name }}</h3>

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -5,8 +5,7 @@
 <script src="/static/js/feast_list.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
 

--- a/django/cantusdb_project/main_app/templates/genre_detail.html
+++ b/django/cantusdb_project/main_app/templates/genre_detail.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>{{ genre.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
 

--- a/django/cantusdb_project/main_app/templates/genre_list.html
+++ b/django/cantusdb_project/main_app/templates/genre_list.html
@@ -4,8 +4,7 @@
 <script src="/static/js/genre_list.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>List of Genres</h3>

--- a/django/cantusdb_project/main_app/templates/indexer_list.html
+++ b/django/cantusdb_project/main_app/templates/indexer_list.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>List of Indexers | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>List of Indexers</h3>

--- a/django/cantusdb_project/main_app/templates/items_count.html
+++ b/django/cantusdb_project/main_app/templates/items_count.html
@@ -3,8 +3,7 @@
 {% block content %}
 <title>Content Statistics | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>Content Statistics</h3>

--- a/django/cantusdb_project/main_app/templates/melody_search.html
+++ b/django/cantusdb_project/main_app/templates/melody_search.html
@@ -88,9 +88,10 @@
             <div id="resultsDiv"></div>
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
 

--- a/django/cantusdb_project/main_app/templates/notation_detail.html
+++ b/django/cantusdb_project/main_app/templates/notation_detail.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>{{ notation.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ notation.name }}</h3>

--- a/django/cantusdb_project/main_app/templates/office_detail.html
+++ b/django/cantusdb_project/main_app/templates/office_detail.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>{{ office.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ office.name }}</h3>

--- a/django/cantusdb_project/main_app/templates/office_list.html
+++ b/django/cantusdb_project/main_app/templates/office_list.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>Office/Mass Abbereviations | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>Office/Mass abbreviations</h3>

--- a/django/cantusdb_project/main_app/templates/provenance_detail.html
+++ b/django/cantusdb_project/main_app/templates/provenance_detail.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>{{ provenance.name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ provenance.name }}</h3>

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -9,9 +9,8 @@
                 {{ message }}
             {% endfor %}
         </div>
-    {% endif %}          
-    <!-- global search bar-->
-    <object align="right">
+    {% endif %}
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ sequence.title }}</h3>

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>Clavis Sequentiarum (Calvin Bower) | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>Clavis Sequentiarum (Calvin Bower)</h3>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -134,9 +134,10 @@
             {% endif %}
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
                 <div class="card-header">

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -181,9 +181,10 @@
             </form>
         </div>
 
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mb-3 w-100">
                 <div class="card-header">

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -5,7 +5,7 @@
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>Browse Sources</h3>

--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -3,7 +3,7 @@
 <title>{{ user.full_name }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ user.full_name }}</h3>

--- a/django/cantusdb_project/main_app/templates/user_list.html
+++ b/django/cantusdb_project/main_app/templates/user_list.html
@@ -2,8 +2,7 @@
 {% block content %}
 <title>All Users | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
-    <!-- global search bar-->
-    <object align="right">
+    <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>All Users</h3>

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -32,9 +32,10 @@
             </table>
             {% include "pagination.html" %}
         </div>
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
             <div class="card mb-3 w-100">
                 <div class="card-header">
                     <h4>Sources created by user</h4>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -108,15 +108,7 @@
         }
 
         @media print {
-            header, footer {
-                display: none;
-            }
-
-            .search-bar {
-                display: none;
-            }
-
-            .sidebar {
+            header, footer, .search-bar, .sidebar {
                 display: none;
             }
         }

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -106,6 +106,12 @@
             transition: background-color .25s;
             background-color: #CC3333;
         }
+
+        @media print {
+            header, footer {
+                display: none;
+            }
+        }
     </style>
     <link href="{% static 'fonts/volpiano.css' %}" rel="stylesheet" media="screen">
 </head>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -111,6 +111,14 @@
             header, footer {
                 display: none;
             }
+
+            .search-bar {
+                display: none;
+            }
+
+            .sidebar {
+                display: none;
+            }
         }
     </style>
     <link href="{% static 'fonts/volpiano.css' %}" rel="stylesheet" media="screen">

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -9,9 +9,10 @@
             {{ flatpage.content }}
         </div>
         
-        <div class="col p-0">
-            <!-- global search bar-->
-            {% include "global_search_bar.html" %}
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
 
             <div class="card mt-3 w-100">
                 <div class="card-header">


### PR DESCRIPTION
This PR adds CSS to make all pages of the website display nicely when being printed. This obviates the need for a separate printer-friendly chant search view (see #421).

Lots of files have been changed in this PR, so here's a summary of what has happened:
- CSS has been added to `/templates/base.html` which hides the header, footer, sidebar and global search bar when a page is being printed
- classes have been added to relevant HTML elements in many of the templates:
  - in views with a sidebar, a `sidebar` class has been added to that `div`
  - in views with a search bar:
    - if the search bar is within a sidebar, this was previously implemented with `{% include "global_search_bar.html" %}`, without a containing element. In such instances, this has been wrapped in a `div` with `class="search-bar"`
    - if the search bar is not within a sidebar, it was previously contained in an `object` element. In such instances, a class of `search-bar` has been added to the object element.
    - all instances of `{% include "global_search_bar.html" %}` had a `<!-- global search bar-->` comment above them. With the addition of the `search-bar` class, this comment began to seem superfluous, so I removed it everywhere I saw it.
- also, the article detail and list pages did not include the global search bar. It has been added to both views.
  - The ordering of the elements in the article detail template has also been adjusted slightly to facilitate this change.

All views have been tested in Safari, and some views have been tested in Chrome and Firefox. Some screenshots of Safari, and of the .pdf files generated by Safari's print dialog, are included below for reference:

**Page with a sidebar, default and print:**
![with sidebar](https://user-images.githubusercontent.com/58090591/205128626-04be882b-8c0a-44b6-ac1f-59fb3109f756.png)
![with sidebar print](https://user-images.githubusercontent.com/58090591/205128632-ccdd02e6-3830-4b01-8feb-95867abf7fab.png)

**Page without a sidebar, default and print:**
![without sidebar](https://user-images.githubusercontent.com/58090591/205128715-6efa9174-d229-406c-b8eb-700cf9882484.png)
![without sidebar print](https://user-images.githubusercontent.com/58090591/205128718-99ea935d-10f4-4cac-9953-61bd883d8cdf.png)

**Article detail page, before and after:**
![article detail before](https://user-images.githubusercontent.com/58090591/205128768-f0fe9be1-d80e-46b0-8151-0f1bd861d672.png)

![article detail after](https://user-images.githubusercontent.com/58090591/205128766-f8f3cb5a-b4b5-4eff-b11c-22f6357a8a7c.png)
