### PR TITLE
on chant detail page, ensure sequence_number displays even when it is 0

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -49,7 +49,7 @@
                         </div>
                     {% endif %}
 
-                    {% if chant.sequence_number is not None %}
+                    {% if chant.sequence_number is not None %} {# check that it isn't None, since sometimes sequence_number is 0 #}
                         <div class="col">
                             <dt>Sequence</dt>
                             <dd>{{ chant.sequence_number }}</dd>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -49,7 +49,7 @@
                         </div>
                     {% endif %}
 
-                    {% if chant.sequence_number %}
+                    {% if chant.sequence_number is not None %}
                         <div class="col">
                             <dt>Sequence</dt>
                             <dd>{{ chant.sequence_number }}</dd>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -43,14 +43,14 @@
 
                 <div class="row">
                     {% if chant.folio %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Folio</dt>
                             <dd>{{ chant.folio }}</dd>
                         </div>
                     {% endif %}
 
                     {% if chant.sequence_number is not None %} {# check that it isn't None, since sometimes sequence_number is 0 #}
-                        <div class="col">
+                        <div class="col-10">
                             <dt>Sequence</dt>
                             <dd>{{ chant.sequence_number }}</dd>
                         </div>
@@ -59,7 +59,7 @@
                 
                 <div class="row">
                     {% if chant.feast %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Feast</dt>
                             <dd>
                                 <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name }}</a>
@@ -68,7 +68,7 @@
                     {% endif %}
 
                     {% if chant.office %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Office/Mass</dt>
                             <dd>
                                 <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name }}</a>
@@ -77,7 +77,7 @@
                     {% endif %}
 
                     {% if chant.genre %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Genre</dt>
                             <dd>
                                 <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name }}</a>
@@ -86,14 +86,14 @@
                     {% endif %}
 
                     {% if chant.position %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Position</dt>
                             <dd>{{ chant.position }}</dd>
                         </div>
                     {% endif %}
 
                     {% if chant.cantus_id %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Cantus ID</dt>
                             <dd>
                                 <a href="{{ chant.get_ci_url }}" target="_blank">
@@ -104,7 +104,7 @@
                     {% endif %}
 
                     {% if chant.mode %}
-                        <div class="col">
+                        <div class="col-2">
                             <dt>Mode</dt>
                             <dd>{{ chant.mode }}</dd>
                         </div>

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -74,7 +74,7 @@
                     <tr>
                         <td class="text-wrap" style="text-align:center">{{ chant.siglum|default:"" }}</td>
                         <td class="text-wrap" style="text-align:center"><b>{{ chant.folio|default:"" }}</b></td>
-                        <td class="text-wrap" style="text-align:center">{{ chant.sequence_number|default:"" }}</td>
+                        <td class="text-wrap" style="text-align:center">{{ chant.sequence_number|default_if_none:"" }}</td> {# default_if_none: sometimes, sequence_number is 0, and should still be displayed #}
                         <td class="text-wrap">
                             <a href="{{ chant.get_absolute_url }}"><b>{{ chant.incipit|default:"" }}</b></a>
                             <p>{{ chant.manuscript_full_text_std_spelling|default:"" }}<br>

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1071,7 +1071,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             }
         latest_folio = latest_chant.folio if latest_chant.folio else "001r"
         latest_feast = latest_chant.feast.id if latest_chant.feast else ""
-        latest_seq = latest_chant.sequence_number if latest_chant.sequence_number else 0
+        latest_seq = latest_chant.sequence_number if latest_chant.sequence_number is not None else 0 # "is not None": sequence_number is sometimes 0
         latest_image = latest_chant.image_link if latest_chant.image_link else ""
         return {
             "folio": latest_folio,

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1071,7 +1071,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             }
         latest_folio = latest_chant.folio if latest_chant.folio else "001r"
         latest_feast = latest_chant.feast.id if latest_chant.feast else ""
-        latest_seq = latest_chant.sequence_number if latest_chant.sequence_number is not None else 0 # "is not None": sequence_number is sometimes 0
+        latest_seq = latest_chant.sequence_number if latest_chant.sequence_number is not None else 0
         latest_image = latest_chant.image_link if latest_chant.image_link else ""
         return {
             "folio": latest_folio,


### PR DESCRIPTION
fixes #440

Also ensures Folio and Sequence columns stay close to each other.

Also changes a couple of other places where there was `if sequence_number` check was occurring.