### PR TITLE
Ensure view-edit toggle on chant detail pages is only shown if user has edit permissions for that chant

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -17,7 +17,7 @@
             {% endif %}          
             
             <h3>{{ chant.incipit }}</h3>
-            {% if user.is_authenticated %}
+            {% if user_can_edit_chant %}
                 <p>
                     View | <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}">Edit</a>
                 </p>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -14,14 +14,16 @@
                         {{ message }}
                     {% endfor %}
                 </div>
-            {% endif %}          
+            {% endif %}
             
-            <h3>{{ chant.incipit }}</h3>
             {% if user_can_edit_chant %}
                 <p>
                     View | <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}">Edit</a>
                 </p>
             {% endif %}
+            
+            <h3>{{ chant.incipit }}</h3>
+
             <dl>
                 <div class="row">
                     {% if chant.source %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1648,6 +1648,8 @@ class ChantProofreadView(SourceEditChantsView):
 
     def test_func(self):
         user = self.request.user
+        if user.is_anonymous:
+            return False
         source_id = self.kwargs.get(self.pk_url_kwarg)
 
         assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
@@ -1720,6 +1722,9 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
         return self.request.get_full_path()
 
 def user_can_edit_chants_in_source(user, source):
+    if user.is_anonymous:
+        return False
+    
     source_id = source.id
     user_is_assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -71,7 +71,7 @@ class ChantDetailView(DetailView):
         if (source.published is False) and (not display_unpublished):
             raise PermissionDenied()
         
-        ### check whether user has edit access for this chant ##3
+        # check whether user has edit access for this chant - logic should match that in SourceEditChantsView.test_func
         source_id = source.id
         is_assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
         # checks if the user is a project manager
@@ -1383,6 +1383,9 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     pk_url_kwarg = "source_id"
 
     def test_func(self):
+        # if the logic in this function is changed,
+        # it should also be updated in ChantDetailView.get_context, in order to properly choose
+        # whether to display the View/Edit toggle on chant-detail pages
         user = self.request.user
         source_id = self.kwargs.get(self.pk_url_kwarg)
         source = get_object_or_404(Source, id=source_id)


### PR DESCRIPTION
fixes #448 

In doing so, this PR also refactors permission checks for a number of chant views - these views' `test_func`s had repeated code, which has now been pulled out into a separate `user_can_edit_chants_in_source` at the bottom of the `views/chant.py` file.