### PR TITLE
Chant required fields

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -63,8 +63,6 @@ class ChantCreateForm(forms.ModelForm):
         ]
         widgets = {
             "marginalia": TextInputWidget(),
-            "folio": TextInputWidget(),
-            "c_sequence": TextInputWidget(),
             # the widgets dictionary is ignored for a model field with a non-empty choices attribute.
             # In this case, you must override the form field to use a different widget.
             # this goes for all foreignkey fields here, which are written explicitly below to override form field

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -329,14 +329,14 @@ class ChantProofreadForm(forms.ModelForm):
             "differentia_new"
         ]
         widgets = {
-            # manuscript_full_text_std_spelling: defined below
+            # manuscript_full_text_std_spelling: defined below (required)
             "manuscript_full_text": TextAreaWidget(),
             "volpiano": VolpianoAreaWidget(),
             "marginalia": TextInputWidget(),
-            # folio: defined below
-            # c_sequence: defined below
-            # "office": TextInputWidget(),
-            # "genre": TextInputWidget(),
+            # folio: defined below (required)
+            # c_sequence: defined below (required)
+            # "office": defined below (foreignkey)
+            # "genre": defined below (foreignkey)
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
             "melody_id": TextInputWidget(),

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -247,9 +247,14 @@ class ChantEditForm(forms.ModelForm):
             "indexing_notes"
         ]
         widgets = {
+            # manuscript_full_text_std_spelling: defined below (required)
             "manuscript_full_text": TextAreaWidget(),
             "volpiano": VolpianoAreaWidget(),
             "marginalia": TextInputWidget(),
+            # folio: defined below (required)
+            # feast: defined below (foreignkey)
+            # office: defined below (foreignkey)
+            # genre: defined below (foreignkey)
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
             "melody_id": TextInputWidget(),
@@ -272,6 +277,14 @@ class ChantEditForm(forms.ModelForm):
         "Mass Alleluias. Punctuation is omitted.",
     )
 
+    folio = forms.CharField(
+        required=True, widget=TextInputWidget, help_text="Binding order",
+    )
+
+    c_sequence = forms.CharField(
+        required=True, widget=TextInputWidget, help_text="Each folio starts with '1'.",
+    )
+
     feast = forms.ModelChoiceField(
         queryset=Feast.objects.all().order_by("name"), required=False
     )
@@ -286,14 +299,6 @@ class ChantEditForm(forms.ModelForm):
         queryset=Genre.objects.all().order_by("name"), required=False
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    folio = forms.CharField(
-        required=True, widget=TextInputWidget, help_text="Binding order",
-    )
-
-    c_sequence = forms.CharField(
-        required=True, widget=TextInputWidget, help_text="Each folio starts with '1'.",
-    )
 
 class ChantProofreadForm(forms.ModelForm):
     class Meta:

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -252,6 +252,7 @@ class ChantEditForm(forms.ModelForm):
             "volpiano": VolpianoAreaWidget(),
             "marginalia": TextInputWidget(),
             # folio: defined below (required)
+            # c_sequence: defined below (required)
             # feast: defined below (foreignkey)
             # office: defined below (foreignkey)
             # genre: defined below (foreignkey)

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -271,6 +271,7 @@ class ChantEditForm(forms.ModelForm):
         'the first word of each chant, and the first word after "Alleluia" for '
         "Mass Alleluias. Punctuation is omitted.",
     )
+
     feast = forms.ModelChoiceField(
         queryset=Feast.objects.all().order_by("name"), required=False
     )
@@ -328,14 +329,14 @@ class ChantProofreadForm(forms.ModelForm):
             "differentia_new"
         ]
         widgets = {
-            "manuscript_full_text_std_spelling": TextAreaWidget(),
+            # manuscript_full_text_std_spelling: defined below
             "manuscript_full_text": TextAreaWidget(),
             "volpiano": VolpianoAreaWidget(),
             "marginalia": TextInputWidget(),
-            "folio": TextInputWidget(),
-            "c_sequence": TextInputWidget(),
-            "office": TextInputWidget(),
-            "genre": TextInputWidget(),
+            # folio: defined below
+            # c_sequence: defined below
+            # "office": TextInputWidget(),
+            # "genre": TextInputWidget(),
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
             "melody_id": TextInputWidget(),
@@ -355,10 +356,52 @@ class ChantProofreadForm(forms.ModelForm):
             "addendum": TextInputWidget(),
             "differentia_new": TextInputWidget()
         }
-    feast = forms.ModelChoiceField(
-        queryset=Feast.objects.all().order_by("name"), required=False
+
+    manuscript_full_text_std_spelling = forms.CharField(
+        required=True,
+        widget=TextAreaWidget,
+        help_text="Manuscript full text with standardized spelling. Enter the words "
+        "according to the manuscript but normalize their spellings following "
+        "Classical Latin forms. Use upper-case letters for proper nouns, "
+        'the first word of each chant, and the first word after "Alleluia" for '
+        "Mass Alleluias. Punctuation is omitted.",
     )
-    feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+
+    folio = forms.CharField(
+        required=True,
+        widget=TextInputWidget,
+        help_text="Binding order",
+    )
+
+    c_sequence = forms.CharField(
+        required=True,
+        widget=TextInputWidget,
+        help_text="Each folio starts with '1'.", 
+    )
+
+    feast = forms.ModelChoiceField(
+        queryset=Feast.objects.all().order_by("name"),
+        required=False,
+    )
+    feast.widget.attrs.update(
+        {"class": "form-control custom-select custom-select-sm"}
+    )
+
+    office = forms.ModelChoiceField(
+        queryset=Office.objects.all().order_by("name"),
+        required=False,
+    )
+    office.widget.attrs.update(
+        {"class": "form-control custom-select custom-select-sm"}
+    )
+
+    genre = forms.ModelChoiceField(
+        queryset=Genre.objects.all().order_by("name"),
+        required=False
+    )
+    genre.widget.attrs.update(
+        {"class": "form-control custom-select custom-select-sm"}
+    )
 
     proofread_by = forms.ModelMultipleChoiceField(
         queryset=get_user_model().objects.filter(
@@ -366,7 +409,9 @@ class ChantProofreadForm(forms.ModelForm):
             Q(groups__name="editor")
         ).order_by("last_name"), required=False
     )
-    proofread_by.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+    proofread_by.widget.attrs.update(
+        {"class": "form-control custom-select custom-select-sm"}
+    )
 
 class SourceEditForm(forms.ModelForm):
     class Meta:

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -247,12 +247,9 @@ class ChantEditForm(forms.ModelForm):
             "indexing_notes"
         ]
         widgets = {
-            "manuscript_full_text_std_spelling": TextAreaWidget(),
             "manuscript_full_text": TextAreaWidget(),
             "volpiano": VolpianoAreaWidget(),
             "marginalia": TextInputWidget(),
-            "folio": TextInputWidget(),
-            "c_sequence": TextInputWidget(),
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
             "melody_id": TextInputWidget(),
@@ -264,6 +261,16 @@ class ChantEditForm(forms.ModelForm):
             "image_link": TextInputWidget(),
             "indexing_notes": TextAreaWidget()
         }
+
+    manuscript_full_text_std_spelling = forms.CharField(
+        required=True,
+        widget=TextAreaWidget,
+        help_text="Manuscript full text with standardized spelling. Enter the words "
+        "according to the manuscript but normalize their spellings following "
+        "Classical Latin forms. Use upper-case letters for proper nouns, "
+        'the first word of each chant, and the first word after "Alleluia" for '
+        "Mass Alleluias. Punctuation is omitted.",
+    )
     feast = forms.ModelChoiceField(
         queryset=Feast.objects.all().order_by("name"), required=False
     )
@@ -278,6 +285,14 @@ class ChantEditForm(forms.ModelForm):
         queryset=Genre.objects.all().order_by("name"), required=False
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+
+    folio = forms.CharField(
+        required=True, widget=TextInputWidget, help_text="Binding order",
+    )
+
+    c_sequence = forms.CharField(
+        required=True, widget=TextInputWidget, help_text="Each folio starts with '1'.",
+    )
 
 class ChantProofreadForm(forms.ModelForm):
     class Meta:

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -61,20 +61,26 @@ class ChantCreateForm(forms.ModelForm):
             "indexing_notes",
             "addendum",
         ]
+        # the widgets dictionary is ignored for a model field with a non-empty
+        # choices attribute. In this case, you must override the form field to
+        # use a different widget. this goes for all foreignkey and required fields
+        # here, which are written explicitly below to override form field
         widgets = {
             "marginalia": TextInputWidget(),
-            # the widgets dictionary is ignored for a model field with a non-empty choices attribute.
-            # In this case, you must override the form field to use a different widget.
-            # this goes for all foreignkey fields here, which are written explicitly below to override form field
+            # folio: defined below (required)
+            # c_sequence: defined below (required)
+            # office: defined below (foreignkey)
+            # genre: defined below (foreignkey)
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
-            #'feast': SelectWidget(),
+            #'feast': defined below (foreignkey)
             "mode": TextInputWidget(),
             "differentia": TextInputWidget(),
             "differentia_new": TextInputWidget(),
             "finalis": TextInputWidget(),
             "extra": TextInputWidget(),
             "chant_range": VolpianoInputWidget(),
+            # manuscript_full_text_std_spelling: defined below (required)
             "manuscript_full_text": TextAreaWidget(),
             "volpiano": VolpianoAreaWidget(),
             "image_link": TextInputWidget(),
@@ -83,19 +89,6 @@ class ChantCreateForm(forms.ModelForm):
             "indexing_notes": TextAreaWidget(),
             "addendum": TextInputWidget(),
         }
-        # error_messages = {
-        #     # specify custom error messages for each field here
-        # }
-
-    manuscript_full_text_std_spelling = forms.CharField(
-        required=True,
-        widget=TextAreaWidget,
-        help_text="Manuscript full text with standardized spelling. Enter the words "
-        "according to the manuscript but normalize their spellings following "
-        "Classical Latin forms. Use upper-case letters for proper nouns, "
-        'the first word of each chant, and the first word after "Alleluia" for '
-        "Mass Alleluias. Punctuation is omitted.",
-    )
 
     folio = forms.CharField(
         required=True, widget=TextInputWidget, help_text="Binding order",
@@ -119,6 +112,16 @@ class ChantCreateForm(forms.ModelForm):
         queryset=Feast.objects.all().order_by("name"), required=False
     )
     feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+
+    manuscript_full_text_std_spelling = forms.CharField(
+        required=True,
+        widget=TextAreaWidget,
+        help_text="Manuscript full text with standardized spelling. Enter the words "
+        "according to the manuscript but normalize their spellings following "
+        "Classical Latin forms. Use upper-case letters for proper nouns, "
+        'the first word of each chant, and the first word after "Alleluia" for '
+        "Mass Alleluias. Punctuation is omitted.",
+    )
 
     # automatically computed fields
     # source and incipit are mandatory fields in model,

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -77,7 +77,6 @@ class ChantCreateForm(forms.ModelForm):
             "finalis": TextInputWidget(),
             "extra": TextInputWidget(),
             "chant_range": VolpianoInputWidget(),
-            "manuscript_full_text_std_spelling": TextAreaWidget(),
             "manuscript_full_text": TextAreaWidget(),
             "volpiano": VolpianoAreaWidget(),
             "image_link": TextInputWidget(),

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -49,13 +49,13 @@
                     </div>
 
                     <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.folio.label_tag }}</small>
+                        <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                         {{ form.folio }}
                         <p class=text-muted><small>{{ form.folio.help_text}}</small></p>
                     </div>
 
                     <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.c_sequence.id_for_label }}"><small>Sequence:</small></label>
+                        <label for="{{ form.c_sequence.id_for_label }}"><small>Sequence:</small><span class="text-danger" title="This field is required">*</span></label>
                         {{ form.c_sequence }}
                         <p class=text-muted><small>{{ form.c_sequence.help_text}}</small></p>
                     </div>
@@ -185,7 +185,7 @@
                 <div class="form-row align-items-end">
                     <div class="form-group m-1 col-lg">
                         <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}"><small>Manuscript Reading
-                                Full Text (standardized spelling): <span style="color:red;">*</span></small></label>
+                                Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small></label>
                         {{ form.manuscript_full_text_std_spelling }}
                         <!--textarea class="form-control" rows="3" id="form.manuscript_full_text_std_spelling.id_for_label"></textarea-->
                         <p>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -39,13 +39,6 @@
                     <div class="form-group m-1 col-lg-2">
                         <small>{{ form.marginalia.label_tag }}</small>
                         {{ form.marginalia }}
-                        <!-- {% if form.marginalia.errors %}
-                            <ol>
-                            {% for error in form.marginalia.errors %}
-                                <li><strong>{{ error|escape }}</strong></li>
-                            {% endfor %}
-                            </ol>
-                        {% endif %} -->
                     </div>
 
                     <div class="form-group m-1 col-lg-2">
@@ -64,32 +57,11 @@
 
                 <div class="form-row">
 
-                    <!--div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.office.id_for_label }}"><small>Office-Mass:</small></label>
-                        <select class="form-control custom-select custom-select-sm" id="{{ form.office.id_for_label }}" name="{{ form.office.html_name }}">
-                            <option value="">- Any -</option>
-                            {% for office in offices %}
-                            <option value="{{office.id}}">{{office.name}}</option>
-                            {% endfor %}
-                        </select>              
-                        <a class="text-muted" href="#"><small>?</small></a>
-                    </div-->
-
                     <div class="form-group m-1 col-lg-2">
                         <label for="{{ form.office.id_for_label }}"><small>Office/Mass:</small></label>
                         {{ form.office }}
                         <a href="/field-descriptions/#Office"><small>?</small></a>
                     </div>
-
-                    <!--div class="form-group m-1 col-lg-2">
-                        <small>{{ form.genre.label_tag }}</small>
-                        <select class="form-control custom-select custom-select-sm" id="{{ form.genre.id_for_label }}" name="{{ form.genre.html_name }}">
-                            <option value="">- Any -</option>
-                            {% for genre in genres %}
-                            <option value="{{genre.id}}">{{genre.name}}</option>
-                            {% endfor %}
-                        </select>
-                    </div-->
 
                     <div class="form-group m-1 col-lg-2">
                         <small>{{ form.genre.label_tag }}</small>
@@ -187,7 +159,6 @@
                         <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}"><small>Manuscript Reading
                                 Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small></label>
                         {{ form.manuscript_full_text_std_spelling }}
-                        <!--textarea class="form-control" rows="3" id="form.manuscript_full_text_std_spelling.id_for_label"></textarea-->
                         <p>
                             <small class="text-muted">{{ form.manuscript_full_text_std_spelling.help_text }}
                                 For more information, consult <a href="/field-descriptions/#Fulltext" target="_blank">Fields and Content Descriptions</a>.
@@ -211,7 +182,6 @@
 
                 <div class="form-row align-items-end">
                     <div class="form-group m-1 col-lg">
-                        <!--p style="font-family: Volpiano; font-size: xx-large;">abcdefg</p-->
                         <small>{{ form.volpiano.label_tag }}</small>
                         {{ form.volpiano }}
                     </div>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -41,7 +41,7 @@
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                <small>Manuscript Reading Full Text (standardized spelling):</small>
+                                <small>Manuscript Reading Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
                             </label>
                             {{ form.manuscript_full_text_std_spelling }}
                             <script>
@@ -85,11 +85,13 @@
                             {{ form.marginalia }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.folio.label_tag }}</small>
+                            <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                             {{ form.folio }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.c_sequence.label_tag }}</small>
+                            <label for="{{ form.c_sequence.id_for_label }}">
+                                <small>Sequence:<span class="text-danger" title="This field is required">*</span></small>
+                            </label>
                             {{ form.c_sequence }}
                         </div>
                         <div class="form-group m-1 col-lg-4">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -36,11 +36,13 @@
                             {{ form.marginalia }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.folio.label_tag }}</small>
+                            <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                             {{ form.folio }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.c_sequence.label_tag }}</small>
+                            <label for="{{ form.c_sequence.id_for_label }}">
+                                <small>Sequence:<span class="text-danger" title="This field is required">*</span></small>
+                            </label>
                             {{ form.c_sequence }}
                         </div>
                         <div class="form-group m-1 col-lg-4">
@@ -113,7 +115,7 @@
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                <small>Manuscript Reading Full Text (standardized spelling):</small>
+                                <small>Manuscript Reading Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
                             </label>
                             {{ form.manuscript_full_text_std_spelling }}
                         </div>

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -33,7 +33,7 @@
 
                     <div class="form-group m-1 col-lg-9">
                         <label for="{{ form.title.id_for_label }}">
-                            Full Manuscript Identification (City, Archive, Shelf-mark)<span class="text-danger" title="This field is required">*</span>:
+                            Full Manuscript Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span>
                         </label>
                         {{ form.title }}
                     </div>
@@ -49,7 +49,7 @@
                     </div>
                     <div class="form-group m-1 col-lg-7">
                         <label for="{{ form.siglum.id_for_label }}">
-                            Siglum<span class="text-danger" title="This field is required">*</span>:
+                            Siglum:<span class="text-danger" title="This field is required">*</span>
                         </label>
                         {{ form.siglum }}
                         <small>RISM-style siglum + Shelf-mark (e.g. GB-Ob 202).</small>

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1192,7 +1192,7 @@ class SourceEditChantsViewTest(TestCase):
 
     def test_update_chant(self):
         source = make_fake_source()
-        chant = Chant.objects.create(source=source, manuscript_full_text_std_spelling="initial")
+        chant = make_fake_chant(source=source, manuscript_full_text_std_spelling="initial")
 
         response = self.client.get(
             reverse('source-edit-chants', args=[source.id]), 
@@ -1200,9 +1200,16 @@ class SourceEditChantsViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "chant_edit.html")
 
+        folio = chant.folio
+        c_sequence = chant.c_sequence
         response = self.client.post(
             reverse('source-edit-chants', args=[source.id]), 
-            {'manuscript_full_text_std_spelling': 'test', 'pk': chant.id})
+            {
+                'manuscript_full_text_std_spelling': 'test',
+                'pk': chant.id,
+                "folio": folio,
+                "c_sequence": c_sequence,
+            })
         self.assertEqual(response.status_code, 302)
         # Check that after the edit, the user is redirected to the source-edit-chants page
         self.assertRedirects(response, reverse('source-edit-chants', args=[source.id]))  

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1320,10 +1320,19 @@ class ChantProofreadViewTest(TestCase):
     
     def test_proofread_chant(self):
         chant = make_fake_chant(manuscript_full_text_std_spelling="lorem ipsum", folio="001r")
+        folio = chant.folio
+        c_sequence = chant.c_sequence
+        ms_std = chant.manuscript_full_text_std_spelling
         self.assertIs(chant.manuscript_full_text_std_proofread, False)
         source = chant.source
         response = self.client.post(f"/proofread-chant/{source.id}?pk={chant.id}&folio=001r", 
-            {'manuscript_full_text_std_proofread': 'True'})
+            {
+                'manuscript_full_text_std_proofread': 'True',
+                "folio": folio,
+                "c_sequence": c_sequence,
+                "manuscript_full_text_std_spelling": ms_std,
+            },
+        )
         self.assertEqual(response.status_code, 302) # 302 Found
         chant.refresh_from_db()
         self.assertIs(chant.manuscript_full_text_std_proofread, True)


### PR DESCRIPTION
This PR:
- On the chant-create, -edit and -proofread pages, sets the `manuscript_full_text_std_spelling`, `folio` and `c_sequence` fields to be required
   - on the corresponding templates, mark these fields with red asterisks to indicate they are required
- tweaks the asterisk formatting on the source-edit template to bring it into alignment with the formatting on the templates mentioned above
- improves comments/layout in `forms.py` (i.e. in several places where there are two lists of that have mostly-corresponding fields and widgets, make sure all items are in the same order and add comments showing where substitutions have been made)
- updates relevant tests
- in doing all this, fixes #453 and fixes #456