### PR TITLE
Add title attributes in useful places, fix Chant-by-Cantus-ID page formatting

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -209,16 +209,16 @@
                 <table id="concordanceTable" class="table table-bordered table-sm small" style="table-layout: fixed; width: 100%;">
                     <thead>
                         <tr>
-                            <th scope="col" class="text-wrap" style="width:15%">Siglum</th>
-                            <th scope="col" class="text-wrap" style="width:6%">Folio</th>
-                            <th scope="col" class="text-wrap" style="width:23%">Incipit</th>
-                            <th scope="col" class="text-wrap" style="width:4%"></th>
-                            <th scope="col" class="text-wrap" style="width:4%"></th>
-                            <th scope="col" class="text-wrap" style="width:4%"></th>
-                            <th scope="col" class="text-wrap" style="width:20%">Feast</th>
-                            <th scope="col" class="text-wrap" style="width:7%">Mode</th>
-                            <th scope="col" class="text-wrap" style="width:8%">Image</th>
-                            <th scope="col" class="text-wrap" style="width:9%">DB</th>
+                            <th scope="col" class="text-wrap" style="width:15%" title="Siglum">Siglum</th>
+                            <th scope="col" class="text-wrap" style="width:6%" title="Folio">Folio</th>
+                            <th scope="col" class="text-wrap" style="width:23%" title="Incipit">Incipit</th>
+                            <th scope="col" class="text-wrap" style="width:4%" title="Office"></th>
+                            <th scope="col" class="text-wrap" style="width:4%" title="Genre"></th>
+                            <th scope="col" class="text-wrap" style="width:4%" title="Position"></th>
+                            <th scope="col" class="text-wrap" style="width:20%" title="Feast">Feast</th>
+                            <th scope="col" class="text-wrap" style="width:7%" title="Mode">Mode</th>
+                            <th scope="col" class="text-wrap" style="width:8%" title="Image Link">Image</th>
+                            <th scope="col" class="text-wrap" style="width:9%" title="Database">DB</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -73,7 +73,7 @@
                         <div class="col-2">
                             <dt>Office/Mass</dt>
                             <dd>
-                                <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name }}</a>
+                                <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -82,7 +82,7 @@
                         <div class="col-2">
                             <dt>Genre</dt>
                             <dd>
-                                <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name }}</a>
+                                <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
                             </dd>
                         </div>
                     {% endif %}

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -87,10 +87,10 @@
                             <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name|default:"" }}</a>
+                            <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name|default:"" }}</a>
+                            <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
                         <td class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -56,17 +56,17 @@
             <table class="table table-responsive table-sm table-bordered small">
                 <thead>
                     <tr>
-                        <th scope="col" class="text-wrap">Siglum</th>
-                        <th scope="col" class="text-wrap">Folio</th>
-                        <th scope="col" class="text-wrap"></th>
-                        <th scope="col" class="text-wrap">Incipit / Full text</th>
-                        <th scope="col" class="text-wrap">Feast</th>
-                        <th scope="col" class="text-wrap"></th>
-                        <th scope="col" class="text-wrap"></th>
-                        <th scope="col" class="text-wrap"></th>
-                        <th scope="col" class="text-wrap">CantusID</th>
-                        <th scope="col" class="text-wrap">Mode</th>
-                        <th scope="col" class="text-wrap"></th>
+                        <th scope="col" class="text-wrap" title="Siglum">Siglum</th>
+                        <th scope="col" class="text-wrap" title="Folio">Folio</th>
+                        <th scope="col" class="text-wrap" title="Sequence"></th>
+                        <th scope="col" class="text-wrap" title="Incipit / Full text">Incipit / Full text</th>
+                        <th scope="col" class="text-wrap" title="Feast">Feast</th>
+                        <th scope="col" class="text-wrap" title="Office"></th>
+                        <th scope="col" class="text-wrap" title="Genre"></th>
+                        <th scope="col" class="text-wrap" title="Position"></th>
+                        <th scope="col" class="text-wrap" title="Cantus ID">CantusID</th>
+                        <th scope="col" class="text-wrap" title="Mode">Mode</th>
+                        <th scope="col" class="text-wrap" title="Image link"></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -234,10 +234,10 @@
                                 <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.office.get_absolute_url }}">{{ chant.office.name|default:"" }}</a>
+                                <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.genre.get_absolute_url }}">{{ chant.genre.name|default:"" }}</a>
+                                <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.position|default:"" }}

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -95,7 +95,7 @@
             <table class="table table-sm small table-bordered">
                 <thead>
                     <tr>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">
                             {% if order == "siglum" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
@@ -106,10 +106,10 @@
                                 <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Folio">
                             Folio
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Incipit/Full Text">
                             {% if order == "incipit" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
@@ -120,10 +120,10 @@
                                 <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Feast">
                             Feast
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Office">
                             {% if order == "office" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
@@ -134,7 +134,7 @@
                                 <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Genre">
                             {% if order == "genre" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
@@ -145,10 +145,10 @@
                                 <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Position">
                             Position
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">
                             {% if order == "cantus_id" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
@@ -159,7 +159,7 @@
                                 <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Mode">
                             {% if order == "mode" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
@@ -170,7 +170,7 @@
                                 <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Manuscript Full Text">
                             {% if order == "has_fulltext" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
@@ -181,7 +181,7 @@
                                 <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Volpiano Melody">
                             {% if order == "has_melody" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
@@ -192,7 +192,7 @@
                                 <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
                             {% endif %}
                         </th>
-                        <th scope="col" class="text-wrap" style="text-align:center">
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Image Link">
                             {% if order == "has_image" %}
                                 {% if sort == "desc" %}
                                     <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -44,7 +44,7 @@
                     {% else %}
                         <td class="text-wrap"><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% endif %}
-                    <td class="text-wrap">{{ chant.office|default:"" }} </td>
+                    <td class="text-wrap">{{ chant.office.name|default:"" }} </td>
                     <td class="text-wrap">{{ chant.genre.name|default:"" }} </td>
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -44,8 +44,8 @@
                     {% else %}
                         <td class="text-wrap"><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% endif %}
-                    <td class="text-wrap">{{ chant.office.name|default:"" }} </td>
-                    <td class="text-wrap">{{ chant.genre.name|default:"" }} </td>
+                    <td class="text-wrap" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }} </td>
+                    <td class="text-wrap" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }} </td>
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -15,16 +15,16 @@
     <table class="table table-bordered table-sm small">
         <thead>
             <tr>
-                <th scope="col" class="text-wrap">Source</th>
-                <th scope="col" class="text-wrap">Folio</th>
-                <th scope="col" class="text-wrap">Title</th>
-                <th scope="col" class="text-wrap">Office </th>
-                <th scope="col" class="text-wrap">Genre </th>
-                <th scope="col" class="text-wrap">Position</th>
-                <th scope="col" class="text-wrap">Feast</th>
-                <th scope="col" class="text-wrap">Mode</th>
-                <th scope="col" class="text-wrap" style="font-family: volpiano; font-size:30px; font-weight:normal;">1</th>
-                <th scope="col" class="text-wrap">Facsimile</th>
+                <th scope="col" class="text-wrap" title="Source">Source</th>
+                <th scope="col" class="text-wrap" title="Folio">Folio</th>
+                <th scope="col" class="text-wrap" title="Title">Title</th>
+                <th scope="col" class="text-wrap" title="Office">Office </th>
+                <th scope="col" class="text-wrap" title="Genre">Genre </th>
+                <th scope="col" class="text-wrap" title="Position">Position</th>
+                <th scope="col" class="text-wrap" title="Feast">Feast</th>
+                <th scope="col" class="text-wrap" title="Mode">Mode</th>
+                <th scope="col" class="text-wrap" style="font-family: volpiano; font-size:30px; font-weight:normal;" title="Volpiano Melody">1</th>
+                <th scope="col" class="text-wrap" title="Image Link">Facsimile</th>
             </tr>
         </thead>
         <tbody>

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -57,7 +57,7 @@
                         {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
                         <td><a href="{% url 'chant-by-cantus-id' cantus_id|urlencode:"" %}">{{ cantus_id|default:"" }}</a></td>
                         <td>{{ incipit }}</td>
-                        <td><a href="{{ genre.get_absolute_url }}">{{ genre.name }}</a></td>
+                        <td><a href="{{ genre.get_absolute_url }}" title="{{ genre.description }}">{{ genre.name }}</a></td>
                         <td>{{ count }}</td>
                     </tr>
                     {% endfor %}

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -28,18 +28,18 @@
     <table class="table table-sm small table-bordered table-striped table-hover">
         <thead>
             <tr>
-                <th width="80">Siglum</th>
-                <th width="30">Marg</th>
-                <th width="30">Folio</th>
-                <th width="30">Seq</th>
-                <th width="80">Feast</th>
-                <th width="30">Office</th>
-                <th width="30">Genre</th>
-                <th width="30">Pos</th>
-                <th width="200">Incipit</th>
-                <th width="80">Cantus ID</th>
-                <th width="30">Mode</th>
-                <th width="30">Diff</th>
+                <th width="80" title="Siglum">Siglum</th>
+                <th width="30" title="Marginalia">Marg</th>
+                <th width="30" title="Folio">Folio</th>
+                <th width="30" title="Sequence">Seq</th>
+                <th width="80" title="Feast">Feast</th>
+                <th width="30" title="Office">Office</th>
+                <th width="30" title="Genre">Genre</th>
+                <th width="30" title="Position">Pos</th>
+                <th width="200" title="Incipit">Incipit</th>
+                <th width="80" title="Cantus ID">Cantus ID</th>
+                <th width="30" title="Mode">Mode</th>
+                <th width="30" title="Differentia">Diff</th>
             </tr>
         </thead>
 

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -55,8 +55,8 @@
                     <td>{{ chant.folio|default_if_none:"" }}</td>
                     <td>{{ chant.c_sequence|default_if_none:"" }}</td>
                     <td>{{ chant.feast.name|default_if_none:"" }}</td>
-                    <td>{{ chant.office.name|default_if_none:"" }}</td>
-                    <td>{{ chant.genre.name|default_if_none:"" }}</td>
+                    <td><span title="{{ chant.office.description }}">{{ chant.office.name|default_if_none:"" }}</span></td>
+                    <td><span title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</span></td>
                     <td>{{ chant.position|default_if_none:"" }}</td>
                     <td><a href="{{ chant.get_absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                     <td>{{ chant.cantus_id|default_if_none:"" }}</td>

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -80,7 +80,7 @@
                     Genre
                 </dt>
                 <dd>
-                    <a href="{{ sequence.genre.get_absolute_url }}">{{ sequence.genre.name }}</a>
+                    <a href="{{ sequence.genre.get_absolute_url }}" title="{{ sequence.genre.description }}">{{ sequence.genre.name }}</a>
                 </dd>
             </div>
             {% endif %}


### PR DESCRIPTION
This PR does two main things:

- Where we display the `.name`s of Genres and Offices (i.e. the abbreviations for these objects), it adds `title=""` attributes to these elements, so that the `.description` of the Genre/Office (i.e. the full name of the object) is displayed upon mouseover.
  - I haven't made an effort to do this in places where concordances are being displayed; the information we get from CantusIndex is not set up for these to be added without lots of extra code being written
  - Neither have I made an effort to add these to sidebars - I've only done it in the main panel for each view
- In tables where we leave an empty column header or use an abbreviation, include `title` attributes to all column headers spelling out what the columns mean (e.g. in several places, we just leave empty column headers instead of writing out "Genre" or "Office", in order to save space. We also use "Mel" instead of "Volpiano Melody" and "Image" instead of "Image Link")

Along the way, I discovered that on the Chant-by-Cantus-ID page, we were displaying the string representation of chants' offices rather than their abbreviation. This caused this property to be quite out-of-proportion compared to how OldCantus renders this information. This PR fixes this.

OldCantus:
![Screen Shot 2022-12-16 at 2 52 56 PM](https://user-images.githubusercontent.com/58090591/208178223-e268b6e9-3c70-4ee4-b7b9-08b2864b3b18.png)

NewCantus, previously:
![Screen Shot 2022-12-16 at 2 51 29 PM](https://user-images.githubusercontent.com/58090591/208178016-d54b1505-40fe-401a-a538-4e0e306e63a1.png)

NewCantus, now:
![Screen Shot 2022-12-16 at 2 52 09 PM](https://user-images.githubusercontent.com/58090591/208178120-6738402d-3eb9-4dc8-844e-48ed78049868.png)
