### PR TITLE
Add melody-with-text preview to Chant Edit, Proofread pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -79,6 +79,28 @@
                         </div>
                     </div>
 
+                    {% if chant.volpiano %}
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-12">
+                            <small>Preview of melody with text:</small>
+                            {% if chant.manuscript_syllabized_full_text %}
+                                <p><small>Syllabification is based on saved syllabized text.</small></p>
+                            {% endif %}
+                            <dd>
+                                {% for zip in syllabized_text_with_melody %}
+                                    {% for syl_mel, syl_text in zip %}
+                                        <span style="float: left">
+                                            <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
+                                            <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
+                                            <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
+                                        </span>
+                                    {% endfor %}
+                                {% endfor %}
+                            </dd>
+                        </div>
+                    </div>
+                {% endif %}
+
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-2">
                             <small>{{ form.marginalia.label_tag }}</small>

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -172,6 +172,28 @@
                         </div>
                     </div>
 
+                    {% if chant.volpiano %}
+                        <div class="form-row">
+                            <div class="form-group m-1 col-lg-12">
+                                <small>Preview of melody with text:</small>
+                                {% if chant.manuscript_syllabized_full_text %}
+                                    <p><small>Syllabification is based on saved syllabized text.</small></p>
+                                {% endif %}
+                                <dd>
+                                    {% for zip in syllabized_text_with_melody %}
+                                        {% for syl_mel, syl_text in zip %}
+                                            <span style="float: left">
+                                                <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
+                                                <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
+                                                <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
+                                            </span>
+                                        {% endfor %}
+                                    {% endfor %}
+                                </dd>
+                            </div>
+                        </div>
+                    {% endif %}
+
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <small>{{ form.image_link.label_tag }}</small>


### PR DESCRIPTION
Fixes #507

Whereas on OldCantus, the preview is at the bottom of the page near the "Save" button, this PR adds the preview beneath the Volpiano field, where it will be most useful.

The preview is only displayed once the chant is saved, i.e. this PR makes no effort to update the preview in real time (see #508)

This is how it looks on the Chant Edit page:
![Screen Shot 2023-01-18 at 11 32 19 AM](https://user-images.githubusercontent.com/58090591/213241094-950e59ec-b20c-499f-a66e-2603e052ea72.png)
And here it is on the Chant Proofread page:
![Screen Shot 2023-01-18 at 11 32 03 AM](https://user-images.githubusercontent.com/58090591/213241089-18fab16e-1d04-4b2f-8a4f-36edcabd612d.png)
