### PR TITLE
Optimize Chant Search page

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -669,6 +669,7 @@ class ChantSearchView(ListView):
                         "has_image".
         ``sort``: whether to sort results in ascending or descending order.
                   Options are "asc" and "desc".
+        ``search_bar``: Text entered in the Global Search Bar
     """
 
     paginate_by = 100

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -656,7 +656,19 @@ class ChantSearchView(ListView):
                       Volpiano form. Valid values are "true" or "false".
         ``feast``: Filters by Feast of Chant
         ``keyword``: Searches text of Chant for keywords
-        ``op``: Operation to take with keyword search. Options are "contains" and "starts_with"
+        ``op``: Operation to take with keyword search. Options are "contains" and "starts_with".
+        ``order``: which field to order search results by. Options are:
+                        "siglum",
+                        "incipit",
+                        "office",
+                        "genre",
+                        "cantus_id",
+                        "mode",
+                        "has_fulltext",
+                        "has_melody",
+                        "has_image".
+        ``sort``: whether to sort results in ascending or descending order.
+                  Options are "asc" and "desc".
     """
 
     paginate_by = 100

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -836,6 +836,47 @@ class ChantSearchView(ListView):
                     chant_set = chant_set.filter(incipit__istartswith=keyword)
                     sequence_set = sequence_set.filter(incipit__istartswith=keyword)
 
+            chant_set = chant_set.select_related(
+                # this allows the `name`, `description`, etc. of sources/feasts/etc.
+                # to be displayed in the template without having to run additional
+                # database queries
+                "source",
+                "feast",
+                "office",
+                "genre",
+            ).values(
+                # fetch only the properties that are needed to render the template
+                "id",
+                "folio",
+                "manuscript_full_text_std_spelling",
+                "incipit",
+                "position",
+                "mode",
+                "manuscript_full_text",
+                "volpiano",
+                "image_link",
+            )
+            sequence_set = sequence_set.select_related(
+                # this allows the `name`, `description` etc. of sources/feasts/etc.
+                # to be displayed in the template without having to run additional
+                # database queries
+                "source",
+                "feast",
+                "office",
+                "genre",
+            ).values(
+                # fetch only the properties that are needed to render the template
+                "id",
+                "folio",
+                "manuscript_full_text_std_spelling",
+                "incipit",
+                "position",
+                "mode",
+                "manuscript_full_text",
+                "volpiano",
+                "image_link",
+            )
+
             # once unioned, the queryset cannot be filtered/annotated anymore, so we put union to the last
             queryset = chant_set.union(sequence_set)
             queryset = queryset.order_by(order, "id")


### PR DESCRIPTION
This PR optimizes the Chant Search page by minimizing the number of database queries run and fetching only information necessary for rendering the template.

These changes improve search speed by roughly a factor of two. A handful of searches I tested locally:

```
"Search term" without_optimization with_optimization (both in seconds)
---
"" 11 6
"Alleluia" 3 2
"Eripuit" 3 2
"Draconis" 2.5 2
"Et" 8 2.5
```

It also improves documentation by adding missing information to a docstring.