### PR TITLE
Fix failing ChantSearchView tests

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -654,82 +654,170 @@ class ChantSearchViewTest(TestCase):
         response = self.client.get(
             reverse("chant-search"), {"keyword": "lorem", "op": "contains"}
         )
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
         source.published = False
         source.save()
         response = self.client.get(
             reverse("chant-search"), {"keyword": "lorem", "op": "contains"}
         )
-        self.assertNotIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 0)
 
     def test_search_by_office(self):
         source = make_fake_source(published=True)
-        office = make_fake_office()
-        chant = Chant.objects.create(source=source, office=office)
-        search_term = get_random_search_term(office.name)
+        target_office = make_fake_office()
+        other_office = make_fake_office()
+        target_chant = Chant.objects.create(
+            source=source,
+            office=target_office,
+            manuscript_full_text_std_spelling=make_fake_text(max_size=20),
+        )
+        Chant.objects.create(
+            source=source,
+            office=other_office,
+        )
+        search_term = get_random_search_term(target_office.name)
         response = self.client.get(reverse("chant-search"), {"office": search_term})
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            target_chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"]
+        )
 
     def test_filter_by_genre(self):
         source = make_fake_source(published=True)
-        genre = make_fake_genre()
-        chant = Chant.objects.create(source=source, genre=genre)
-        response = self.client.get(reverse("chant-search"), {"genre": genre.id})
-        self.assertIn(chant, response.context["chants"])
+        target_genre = make_fake_genre()
+        other_genre = make_fake_genre()
+        target_chant = Chant.objects.create(
+            source=source,
+            genre=target_genre,
+            manuscript_full_text_std_spelling=make_fake_text(max_size=20),
+        )
+        Chant.objects.create(source=source, genre=other_genre)
+        response = self.client.get(reverse("chant-search"), {"genre": target_genre.id})
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            target_chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"]
+        )
 
     def test_search_by_cantus_id(self):
         source = make_fake_source(published=True)
-        chant = Chant.objects.create(source=source, cantus_id=faker.numerify("######"))
-        search_term = get_random_search_term(chant.cantus_id)
+        target_cantus_id = faker.numerify("######")
+        other_cantus_id = faker.numerify("######")
+        target_chant = Chant.objects.create(
+            source=source,
+            cantus_id=target_cantus_id,
+            manuscript_full_text_std_spelling=make_fake_text(max_size=20),
+        )
+        Chant.objects.create(source=source, cantus_id=other_cantus_id)
+        search_term = get_random_search_term(target_chant.cantus_id)
         response = self.client.get(reverse("chant-search"), {"cantus_id": search_term})
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            target_chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
     def test_search_by_mode(self):
         source = make_fake_source(published=True)
-        chant = Chant.objects.create(source=source, mode=faker.numerify("#"))
-        search_term = get_random_search_term(chant.mode)
+        target_chant = Chant.objects.create(
+            source=source,
+            mode=faker.numerify("#"),
+            manuscript_full_text_std_spelling = make_fake_text(max_size=20),
+        )
+        Chant.objects.create(source=source, mode=faker.numerify("#"))
+        search_term = get_random_search_term(target_chant.mode)
         response = self.client.get(reverse("chant-search"), {"mode": search_term})
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            target_chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
     def test_search_by_feast(self):
         source = make_fake_source(published=True)
-        feast = make_fake_feast()
-        chant = Chant.objects.create(source=source, feast=feast)
-        search_term = get_random_search_term(feast.name)
+        target_feast = make_fake_feast()
+        other_feast = make_fake_feast()
+        target_chant = Chant.objects.create(
+            source=source,
+            feast=target_feast,
+            manuscript_full_text_std_spelling = make_fake_text(max_size=20),
+        )
+        Chant.objects.create(
+            source=source,
+            feast=other_feast,
+        )
+        search_term = get_random_search_term(target_feast.name)
         response = self.client.get(reverse("chant-search"), {"feast": search_term})
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            target_chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
     def test_search_by_position(self):
         source = make_fake_source(published=True)
-        position = 1
-        chant = Chant.objects.create(source=source, position=position)
-        search_term = "1"
-        response = self.client.get(reverse("chant-search"), {"position": search_term})
-        self.assertIn(chant, response.context["chants"])
+        target_position = 1
+        other_position = 2
+        target_chant = Chant.objects.create(
+            source=source,
+            position=target_position,
+            manuscript_full_text_std_spelling = make_fake_text(max_size=20),
+        )
+        Chant.objects.create(
+            source=source,
+            position=other_position,
+        )
+        response = self.client.get(reverse("chant-search"), {"position": str(target_position)})
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            target_chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
     def test_filter_by_melody(self):
         source = make_fake_source(published=True)
         chant_with_melody = Chant.objects.create(
-            source=source, volpiano=make_fake_text(max_size=20)
+            source=source,
+            volpiano=make_fake_text(max_size=20),
+            manuscript_full_text_std_spelling=make_fake_text(max_size=20)
         )
         chant_without_melody = Chant.objects.create(source=source)
         response = self.client.get(reverse("chant-search"), {"melodies": "true"})
         # only chants with melodies should be in the result
-        self.assertIn(chant_with_melody, response.context["chants"])
-        self.assertNotIn(chant_without_melody, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            chant_with_melody.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
     def test_keyword_search_starts_with(self):
         source = make_fake_source(published=True)
         chant = Chant.objects.create(
-            source=source, incipit=make_fake_text(max_size=200)
+            source=source,
+            incipit=make_fake_text(max_size=200),
+            manuscript_full_text_std_spelling=make_fake_text(max_size=20)
+        )
+        Chant.objects.create(
+            source=source,
+            incipit=make_fake_text(max_size=200),
+            manuscript_full_text_std_spelling=make_fake_text(max_size=20)
         )
         # use the beginning part of the incipit as search term
         search_term = chant.incipit[0 : random.randint(1, len(chant.incipit))]
         response = self.client.get(
             reverse("chant-search"), {"keyword": search_term, "op": "starts_with"}
         )
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        self.assertEqual(
+            chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
     def test_keyword_search_contains(self):
         source = make_fake_source(published=True)
@@ -747,7 +835,10 @@ class ChantSearchViewTest(TestCase):
         response = self.client.get(
             reverse("chant-search"), {"keyword": search_term, "op": "contains"}
         )
-        self.assertIn(chant, response.context["chants"])
+        self.assertEqual(
+            chant.manuscript_full_text_std_spelling,
+            response.context["chants"][0]["manuscript_full_text_std_spelling"],
+        )
 
 
 class ChantSearchMSViewTest(TestCase):


### PR DESCRIPTION
Evidently, I forgot to run the test suite before opening #529... Since the Chant Search View only returns a handful of columns necessary for rendering the search page now (rather than entire Chant objects), a number of tests which used `AssertIs` began failing. With this PR, all tests now pass.

I also took the opportunity to improve a few of the tests - instead of simply checking that chants that should be found by a particular query are found, several of the tests now include dummy chants that _shouldn't_ be found by a query, and checks that these chants are _not_ in fact returned in the context for the view.