### PR TITLE
add `time_function` function for optimization testing

### DIFF
--- a/django/cantusdb_project/time_function.py
+++ b/django/cantusdb_project/time_function.py
@@ -1,0 +1,12 @@
+from functools import wraps
+from time import time
+
+def time_function(fn):
+    @wraps(fn)
+    def measure_time(*args, **kwargs):
+        t1 = time()
+        result = fn(*args, **kwargs)
+        t2 = time()
+        print(f"@time_function: {fn.__name__} took {t2 - t1:.3f}s.")
+        return result
+    return measure_time


### PR DESCRIPTION
A useful function for testing for bottlenecks and verifying that optimizations are actually optimizing - putting it here so it'll always be around. If you notice any `@time_function`s left over from testing in future PRs, please tell me off as you would for extraneous `print` statements.