### PR TITLE
Ensure Chant Search View has complete suite of tests

### DIFF
--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -62,6 +62,7 @@ def make_fake_century() -> Century:
 
 def make_fake_chant(source=None,
     folio=None,
+    office=None,
     genre=None,
     position=None,
     c_sequence=None,
@@ -79,6 +80,8 @@ def make_fake_chant(source=None,
     if folio is None:
         # two digits and one letter
         folio = faker.bothify("##?")
+    if office is None:
+        office = make_fake_office()
     if genre is None:
         genre = make_fake_genre()
     if position is None:
@@ -108,7 +111,7 @@ def make_fake_chant(source=None,
         marginalia=make_fake_text(SHORT_CHAR_FIELD_MAX),
         folio=folio,
         c_sequence=c_sequence,
-        office=make_fake_office(),
+        office=office,
         genre=genre,
         position=position,
         # cantus_id in the form of six digits
@@ -164,9 +167,7 @@ def make_fake_genre(name=None) -> Genre:
         name = faker.lexify("???")
     genre = Genre.objects.create(
         name=name,
-        description=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        description=faker.sentence(),
         mass_office=make_fake_text(SHORT_CHAR_FIELD_MAX),
     )
     return genre
@@ -195,9 +196,7 @@ def make_fake_office() -> Office:
     """Generates a fake Office object."""
     office = Office.objects.create(
         name=faker.lexify(text="??"),
-        description=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        description=faker.sentence(),
     )
     return office
 

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -70,6 +70,7 @@ def make_fake_chant(source=None,
     feast=None,
     manuscript_full_text_std_spelling=None,
     manuscript_full_text_std_proofread=None,
+    manuscript_full_text=None,
     volpiano=None,
     manuscript_syllabized_full_text=None,
     next_chant=None,
@@ -98,6 +99,8 @@ def make_fake_chant(source=None,
         )
     if manuscript_full_text_std_proofread is None:
         manuscript_full_text_std_proofread = False
+    if manuscript_full_text is None:
+        manuscript_full_text = manuscript_full_text_std_spelling
     if volpiano is None:
         volpiano = make_fake_text(20)
     if manuscript_syllabized_full_text is None:
@@ -126,7 +129,7 @@ def make_fake_chant(source=None,
         manuscript_full_text_std_spelling=manuscript_full_text_std_spelling,
         incipit=manuscript_full_text_std_spelling[0:INCIPIT_LENGTH],
         manuscript_full_text_std_proofread=manuscript_full_text_std_proofread,
-        manuscript_full_text=manuscript_full_text_std_spelling,
+        manuscript_full_text=manuscript_full_text,
         manuscript_full_text_proofread=faker.boolean(),
         volpiano=volpiano,
         volpiano_proofread=faker.boolean(),
@@ -146,10 +149,8 @@ def make_fake_chant(source=None,
 def make_fake_feast() -> Feast:
     """Generates a fake Feast object."""
     feast = Feast.objects.create(
-        name=make_fake_text(LONG_CHAR_FIELD_MAX),
-        description=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        name=faker.sentence(),
+        description=faker.sentence(),
         # feast_code in the form of eight digits
         feast_code=faker.numerify("########"),
         notes=make_fake_text(

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -749,6 +749,155 @@ class ChantSearchViewTest(TestCase):
         )
         self.assertIn(chant, response.context["chants"])
 
+    def test_source_link_properly_rendered(self):
+        siglum = "Sigl-01"
+        source = make_fake_source(published=True, siglum=siglum)
+        url = source.get_absolute_url()
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext
+        )
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(siglum, html)
+        self.assertIn(url, html)
+        self.assertIn(f'<a href="{url}">{siglum}</a>', html)
+        
+    def test_folio_properly_rendered(self):
+        source = make_fake_source(published=True)
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext
+        )
+        folio = chant.folio
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(folio, html)
+        
+    def test_feast_link_properly_rendered(self):
+        source = make_fake_source(published=True)
+        feast = make_fake_feast()
+        feast_name = feast.name
+        url = feast.get_absolute_url()
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext,
+            feast=feast,
+        )
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(feast_name, html)
+        self.assertIn(url, html)
+        self.assertIn(f'<a href="{url}">{feast_name}</a>', html)
+        
+    def test_office_link_properly_rendered(self):
+        source = make_fake_source(published=True)
+        office = make_fake_office()
+        office_name = office.name
+        office_description = office.description
+        print("office_description:", office_description)
+        url = office.get_absolute_url()
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext,
+            office=office,
+        )
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(office_name, html)
+        self.assertIn(office_description, html)
+        self.assertIn(url, html)
+        self.assertIn(f'<a href="{url}" title="{office_description}">{office_name}</a>', html)
+        
+    def test_genre_link_properly_rendered(self):
+        source = make_fake_source(published=True)
+        genre = make_fake_genre()
+        genre_name = genre.name
+        genre_description = genre.description
+        url = genre.get_absolute_url()
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext,
+            genre=genre,
+        )
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(genre_name, html)
+        self.assertIn(genre_description, html)
+        self.assertIn(url, html)
+        self.assertIn(f'<a href="{url}" title="{genre_description}">{genre_name}</a>', html)
+        
+    def test_position_properly_rendered(self):
+        source = make_fake_source(published=True)
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext,
+        )
+        position = chant.position
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(position, html)
+
+    def test_cantus_index_link_property_rendered(self):
+        source = make_fake_source(published=True)
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext,
+        )
+        cantus_id = chant.cantus_id
+        url = chant.get_ci_url()
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )
+        html = str(response.content)
+        self.assertIn(cantus_id, html)
+        self.assertIn(url, html)
+        self.assertIn(f'<a href="{url}" target="_blank">{cantus_id}</a>', html)
+
+    def test_image_link_property_rendered(self):
+        source = make_fake_source(published=True)
+        fulltext = "manuscript full text"
+        search_term = "full"
+        chant = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling=fulltext,
+        )
+        image_link = 'http://www.example.com/image_link'
+        chant.image_link = image_link
+        chant.save()
+        response = self.client.get(
+            reverse("chant-search"), {"keyword": search_term, "op": "contains"}
+        )        
+        html = str(response.content)
+        self.assertIn(image_link, html)
+        self.assertIn(f'<a href="{image_link}" target="_blank">Image</a>', html)
+        
 
 class ChantSearchMSViewTest(TestCase):
     def test_url_and_templates(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -749,7 +749,7 @@ class ChantSearchViewTest(TestCase):
         )
         self.assertIn(chant, response.context["chants"])
 
-    def test_source_link_properly_rendered(self):
+    def test_source_link_column(self):
         siglum = "Sigl-01"
         source = make_fake_source(published=True, siglum=siglum)
         url = source.get_absolute_url()
@@ -767,7 +767,7 @@ class ChantSearchViewTest(TestCase):
         self.assertIn(url, html)
         self.assertIn(f'<a href="{url}">{siglum}</a>', html)
         
-    def test_folio_properly_rendered(self):
+    def test_folio_column(self):
         source = make_fake_source(published=True)
         fulltext = "manuscript full text"
         search_term = "full"
@@ -782,7 +782,7 @@ class ChantSearchViewTest(TestCase):
         html = str(response.content)
         self.assertIn(folio, html)
         
-    def test_feast_link_properly_rendered(self):
+    def test_feast_column(self):
         source = make_fake_source(published=True)
         feast = make_fake_feast()
         feast_name = feast.name
@@ -802,7 +802,7 @@ class ChantSearchViewTest(TestCase):
         self.assertIn(url, html)
         self.assertIn(f'<a href="{url}">{feast_name}</a>', html)
         
-    def test_office_link_properly_rendered(self):
+    def test_office_column(self):
         source = make_fake_source(published=True)
         office = make_fake_office()
         office_name = office.name
@@ -824,7 +824,7 @@ class ChantSearchViewTest(TestCase):
         self.assertIn(url, html)
         self.assertIn(f'<a href="{url}" title="{office_description}">{office_name}</a>', html)
         
-    def test_genre_link_properly_rendered(self):
+    def test_genre_column(self):
         source = make_fake_source(published=True)
         genre = make_fake_genre()
         genre_name = genre.name
@@ -846,7 +846,7 @@ class ChantSearchViewTest(TestCase):
         self.assertIn(url, html)
         self.assertIn(f'<a href="{url}" title="{genre_description}">{genre_name}</a>', html)
         
-    def test_position_properly_rendered(self):
+    def test_position_column(self):
         source = make_fake_source(published=True)
         fulltext = "manuscript full text"
         search_term = "full"
@@ -861,7 +861,7 @@ class ChantSearchViewTest(TestCase):
         html = str(response.content)
         self.assertIn(position, html)
 
-    def test_cantus_index_link_property_rendered(self):
+    def test_cantus_id_column(self):
         source = make_fake_source(published=True)
         fulltext = "manuscript full text"
         search_term = "full"
@@ -879,7 +879,7 @@ class ChantSearchViewTest(TestCase):
         self.assertIn(url, html)
         self.assertIn(f'<a href="{url}" target="_blank">{cantus_id}</a>', html)
 
-    def test_mode_properly_rendered(self):
+    def test_mode_column(self):
         source = make_fake_source(published=True)
         fulltext = "manuscript full text"
         search_term = "full"
@@ -898,7 +898,7 @@ class ChantSearchViewTest(TestCase):
         html = str(response.content)
         self.assertIn(mode, html)
 
-    def test_manuscript_full_text_indicator_properly_rendered(self):
+    def test_manuscript_full_text_column(self):
         source = make_fake_source(published=True)
         std_fulltext = "standard full text"
         ms_fulltext = "manuscript full text"
@@ -932,7 +932,7 @@ class ChantSearchViewTest(TestCase):
             html,
         )
 
-    def test_volpiano_indicator_properly_rendered(self):
+    def test_volpiano_column(self):
         source = make_fake_source(published=True)
         full_text = "standard full text"
         search_term = "full"
@@ -962,7 +962,7 @@ class ChantSearchViewTest(TestCase):
             html
         )
 
-    def test_image_link_property_rendered(self):
+    def test_image_link_column(self):
         source = make_fake_source(published=True)
         fulltext = "standard full text"
         search_term = "full"


### PR DESCRIPTION
This PR improves our test suite for the Chant Search View, ensuring that the right information shows up where it should in each row of the results table.

These changes also necessitated some changes to our "make_fake_{}" functions. Previously, `\n`s would occasionally appear in fake texts. In places where this was causing problems, I switched from using `make_fake_text` to `faker.sentence`, which eliminates the possibility of new lines being generated.