### PR TITLE
add `.absolute_url` field to all models

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/save_all_objects.py
+++ b/django/cantusdb_project/main_app/management/commands/save_all_objects.py
@@ -13,6 +13,10 @@ from main_app.models import (
     Source,
 )
 
+# Run with `python manage.py save_all_objects`.
+# This command runs through all objects in the database
+# and saves them, thus triggering any on_save hooks in signals.py.
+
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/django/cantusdb_project/main_app/management/commands/save_all_objects.py
+++ b/django/cantusdb_project/main_app/management/commands/save_all_objects.py
@@ -1,0 +1,43 @@
+from django.core.management.base import BaseCommand
+from main_app.models import (
+    Century,
+    Chant,
+    Feast,
+    Genre,
+    Notation,
+    Office,
+    Provenance,
+    RismSiglum,
+    Segment,
+    Sequence,
+    Source,
+)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        pass
+
+    def handle(self, *args, **options):
+        for cls in (
+            Century,
+            Chant,
+            Feast,
+            Genre,
+            Notation,
+            Office,
+            Provenance,
+            RismSiglum,
+            Segment,
+            Sequence,
+            Source,
+        ):
+            CHUNK_SIZE = 100
+            objects_count = cls.objects.count()
+            start_index = 0
+            while start_index <= objects_count:
+                print(f"processing {cls} chunk with start index of", start_index)
+                chunk = cls.objects.all()[start_index:start_index+CHUNK_SIZE]
+                for object in chunk:
+                    object.save()
+                start_index += CHUNK_SIZE

--- a/django/cantusdb_project/main_app/models/base_model.py
+++ b/django/cantusdb_project/main_app/models/base_model.py
@@ -3,6 +3,7 @@ from typing import List
 from django.db import models
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.urls.exceptions import NoReverseMatch
 
 
 class BaseModel(models.Model):
@@ -60,7 +61,11 @@ class BaseModel(models.Model):
     def get_absolute_url(self) -> str:
         """Get the absolute URL for an instance of a model."""
         detail_name = self.__class__.__name__.lower() + "-detail"
-        return reverse(detail_name, kwargs={"pk": self.pk})
+        try:
+            return reverse(detail_name, kwargs={"pk": self.pk})
+        except NoReverseMatch: # model has no associated detail view
+            return None
+
 
     @classmethod
     def get_verbose_name_plural(cls) -> str:

--- a/django/cantusdb_project/main_app/models/base_model.py
+++ b/django/cantusdb_project/main_app/models/base_model.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
+
 class BaseModel(models.Model):
     """Base model that containing fields and functionality used in all models.
 
@@ -23,18 +24,23 @@ class BaseModel(models.Model):
         auto_now=True, help_text="The date this entry was updated"
     )
     created_by = models.ForeignKey(
-        get_user_model(), 
+        get_user_model(),
         related_name="%(class)s_created_by_user",
-        on_delete=models.CASCADE, 
-        blank=True, 
-        null=True
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
     )
     last_updated_by = models.ForeignKey(
-        get_user_model(), 
+        get_user_model(),
         related_name="%(class)s_last_updated_by_user",
-        on_delete=models.CASCADE, 
-        blank=True, 
-        null=True
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+    )
+    absolute_url = models.CharField(
+        blank=True,
+        null=True,
+        max_length=255,
     )
 
     class Meta:

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -16,9 +16,10 @@ from main_app.models import Feast
 
 @receiver(post_save)
 def on_object_save(instance, **kwargs):
-    # Migrations are objects, so without this check, Django tries to
-    # call .get_absolute_url on Migrations while running `manage.py migrate`
-    if "get_absolute_url" in dir(instance):
+    # so without these checks, Django will try to
+    # call .get_absolute_url on Migrations while running `manage.py migrate`,
+    # and try to set the absolute_url of User objects.
+    if "get_absolute_url" in dir(instance) and "absolute_url" in dir(instance):
         update_absolute_url(instance)
 
 @receiver(post_save, sender=Chant)

--- a/django/cantusdb_project/main_app/templates/century_detail.html
+++ b/django/cantusdb_project/main_app/templates/century_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in century.sources.all|dictsort:"title" %}
             <li>
-                <a href="{{ source.get_absolute_url }}">
+                <a href="{{ source.absolute_url }}">
                     {{ source.title }}
                 </a>
             </li>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -11,7 +11,7 @@
             <div class="alert alert-success alert-dismissible">
                 {% for message in messages %}
                 <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                <a href="{{ previous_chant.get_absolute_url }}" style="color:#155724" target="_blank">{{ message }}</a>
+                <a href="{{ previous_chant.absolute_url }}" style="color:#155724" target="_blank">{{ message }}</a>
                 {% endfor %}
             </div>
             {% endif %}
@@ -232,12 +232,12 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h5><a id="source" href="{{ source.get_absolute_url }}">{{ source.title }}</a></h5>
+                    <h5><a id="source" href="{{ source.absolute_url }}">{{ source.title }}</a></h5>
                 </div>
                 <div class="card-body" style="font-size: 15px">
                     <b>Suggestions based on the previous chant:</b><br>
                     {% if previous_chant %}
-                        {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{{ previous_chant.get_absolute_url }}" target="_blank">{{ previous_chant.incipit }}</a><br>
+                        {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{{ previous_chant.absolute_url }}" target="_blank">{{ previous_chant.incipit }}</a><br>
                         Cantus ID: <a href="http://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a><br>
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -30,7 +30,7 @@
                         <div class="col">
                             <dt>Source</dt>
                             <dd>
-                                <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.title }}</a>
+                                <a href="{{ chant.source.absolute_url }}">{{ chant.source.title }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -64,7 +64,7 @@
                         <div class="col-2">
                             <dt>Feast</dt>
                             <dd>
-                                <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name }}</a>
+                                <a href="{{ chant.feast.absolute_url }}">{{ chant.feast.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -73,7 +73,7 @@
                         <div class="col-2">
                             <dt>Office/Mass</dt>
                             <dd>
-                                <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
+                                <a href="{{ chant.office.absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -82,7 +82,7 @@
                         <div class="col-2">
                             <dt>Genre</dt>
                             <dd>
-                                <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
+                                <a href="{{ chant.genre.absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -285,7 +285,7 @@
                         <b>Source navigation</b>
                         <br>
                         {% if source %}
-                            <a href="{{ source.get_absolute_url }}"> <b>{{ source.siglum }}</b> </a>
+                            <a href="{{ source.absolute_url }}"> <b>{{ source.siglum }}</b> </a>
                         {% else %}
                             This chant is not associated with any source. 
                         {% endif %}                            
@@ -329,7 +329,7 @@
                                                     <tr>
                                                         <td>{{ chant.c_sequence }}</td>
                                                         <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                        <td><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                                        <td><a href="{{ chant.absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                                         <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                                     </tr>
                                                 {% endfor %}
@@ -347,7 +347,7 @@
                                             <tr>
                                                 <td>{{ chant.c_sequence }}</td>
                                                 <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                <td><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                                <td><a href="{{ chant.absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                                 <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                             </tr>
                                         {% endfor %}
@@ -365,7 +365,7 @@
                                                     <tr>
                                                         <td>{{ chant.c_sequence }}</td>
                                                         <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                        <td><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                                        <td><a href="{{ chant.absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                                         <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                                     </tr>
                                                 {% endfor %}
@@ -388,7 +388,7 @@
                         <div class=" card-body">
                             <small>
                                 {% if source.provenance.name %}
-                                    Provenance: <b><a href="{{ source.provenance.get_absolute_url }}">{{source.provenance.name}}</a></b>
+                                    Provenance: <b><a href="{{ source.provenance.absolute_url }}">{{source.provenance.name}}</a></b>
                                     <br>
                                 {% endif %}
 
@@ -396,7 +396,7 @@
                                     Date: 
                                     {% for century in source.century.all %}
                                         <b>
-                                            <a href="{{ century.get_absolute_url }}">{{ century.name }}</a>
+                                            <a href="{{ century.absolute_url }}">{{ century.name }}</a>
                                         </b>
                                     {% endfor %}
                                     |
@@ -411,7 +411,7 @@
 
                                 {% if source.notation.all %}
                                     <b>
-                                        <a href="{{ source.notation.all.first.get_absolute_url }}">{{ source.notation.all.first.name }}</a>
+                                        <a href="{{ source.notation.all.first.absolute_url }}">{{ source.notation.all.first.name }}</a>
                                     </b>
                                     <br>
                                 {% endif %}
@@ -421,7 +421,7 @@
                                     <ul>
                                         {% for editor in source.inventoried_by.all %}
                                             <li>
-                                                <a href={{ editor.get_absolute_url }}><b>{{ editor.full_name }}</b></a>
+                                                <a href={{ editor.absolute_url }}><b>{{ editor.full_name }}</b></a>
                                                 <br>
                                                 {{ editor.institution|default_if_none:"" }}
                                             </li>
@@ -435,7 +435,7 @@
                                     <ul>
                                         {% for editor in source.proofreaders.all %}
                                             <li>
-                                                <a href={{ editor.get_absolute_url }}><b>{{ editor.full_name }}</b></a>
+                                                <a href={{ editor.absolute_url }}><b>{{ editor.full_name }}</b></a>
                                                 <br>
                                             </li>
                                         {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -249,7 +249,7 @@
                     <small><b>&plus; Add new source</b></small>
                 </a>
                 <br>
-                <a href="{{ source.get_absolute_url }}" style="display: inline-block; margin-top:5px;">
+                <a href="{{ source.absolute_url }}" style="display: inline-block; margin-top:5px;">
                     {{ source.siglum }}
                 </a>
             {% endif %}
@@ -262,7 +262,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{{ source.absolute_url }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>
@@ -304,7 +304,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">
@@ -322,7 +322,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -76,7 +76,7 @@
                         <td class="text-wrap" style="text-align:center"><b>{{ chant.folio|default:"" }}</b></td>
                         <td class="text-wrap" style="text-align:center">{{ chant.c_sequence|default_if_none:"" }}</td> {# default_if_none: sometimes, c_sequence is 0, and should still be displayed #}
                         <td class="text-wrap">
-                            <a href="{{ chant.get_absolute_url }}"><b>{{ chant.incipit|default:"" }}</b></a>
+                            <a href="{{ chant.absolute_url }}"><b>{{ chant.incipit|default:"" }}</b></a>
                             <p>{{ chant.manuscript_full_text_std_spelling|default:"" }}<br>
                             {% if chant.volpiano %}
                                 <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
@@ -84,13 +84,13 @@
                             </p>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
+                            <a href="{{ chant.feast.absolute_url }}">{{ chant.feast.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                            <a href="{{ chant.office.absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                            <a href="{{ chant.genre.absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
                         <td class="text-wrap" style="text-align:center">
@@ -117,7 +117,7 @@
             <div class="card mb-3 w-100">
 
                 <div class="card-header">
-                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{{ source.absolute_url }}">{{ source.siglum }}</a></h4>
                 </div>
 
                 <div class="card-body">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -260,7 +260,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{{ source.absolute_url }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>
@@ -298,7 +298,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">
@@ -316,7 +316,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -10,7 +10,7 @@
     <h3>Search Chants</h3>
     {% if source %}
         <p>
-            <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
+            <b>Searching in source: <a href="{{ source.absolute_url }}" target="_blank">{{ source.title }}</a></b>
         </p>
     {% elif keyword %}
         <p>
@@ -209,7 +209,7 @@
                     {% for chant in chants %}
                         <tr>
                             <td class="text-wrap" style="text-align:left">
-                                <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
+                                <a href="{{ chant.source.absolute_url }}">{{ chant.source.siglum }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.folio|default:""|truncatechars_html:140 }}
@@ -217,12 +217,12 @@
 
                             <td class="text-wrap" style="text-align:left">
                                 {% comment %} this is used for distinguishing chants from sequences,
-                                if the object is chant, use chant.get_absolute_url,
-                                otherwise, use sequence.get_absolute_url
+                                if the object is chant, use chant.absolute_url,
+                                otherwise, use sequence.absolute_url
                                 the combined queryset turned all objects into chants
                                 so this is the only way to make the distinction {% endcomment %}
                                 {% if chant.search_vector %}
-                                    <b><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default:"" }}</a></b>
+                                    <b><a href="{{ chant.absolute_url }}">{{ chant.incipit|default:"" }}</a></b>
                                 {% else %}
                                     <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
                                 {% endif %}
@@ -231,13 +231,13 @@
                                 </p>           
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
+                                <a href="{{ chant.feast.absolute_url }}">{{ chant.feast.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                                <a href="{{ chant.office.absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                                <a href="{{ chant.genre.absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.position|default:"" }}

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -31,25 +31,25 @@
             {% for chant in chants %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
+                        <a href="{{ chant.source.absolute_url }}">{{ chant.source.siglum }}</a>
                     </td>
                     <td class="text-wrap">{{ chant.folio }}</td>
                     {% comment %} this is used for distinguishing chants from sequences,
-                    if the object is chant, use chant.get_absolute_url,
-                    otherwise, use sequence.get_absolute_url
+                    if the object is chant, use chant.absolute_url,
+                    otherwise, use sequence.absolute_url
                     the combined queryset turned all objects into chants
                     so this is the only way to make the distinction {% endcomment %}
                     {% if chant.search_vector %}
-                        <td class="text-wrap"><a href="{{ chant.get_absolute_url }}">{{ chant.incipit }}</a></td>
+                        <td class="text-wrap"><a href="{{ chant.absolute_url }}">{{ chant.incipit }}</a></td>
                     {% else %}
                         <td class="text-wrap"><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% endif %}
                     <td class="text-wrap" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }} </td>
                     <td class="text-wrap" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }} </td>
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
-                    <td class="text-wrap"><a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>
+                    <td class="text-wrap"><a href="{{ chant.feast.absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>
-                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
+                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{{ chant.absolute_url }}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
                     <td class="text-wrap">{% if chant.image_link %}<a href="{{ chant.image_link }}" target="_blank">Image</a>{% endif %}</td>
                 </tr>
             {% endfor %}

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -24,27 +24,27 @@
                 <tr>
                     {% if object.title %}
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
+                            <a href="{{ object.absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
                         </td>
                     {% elif object.manuscript_full_text_std_spelling %}
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.manuscript_full_text_std_spelling|truncatechars:30 }}</b></a>
+                            <a href="{{ object.absolute_url }}"><b>{{ object.manuscript_full_text_std_spelling|truncatechars:30 }}</b></a>
                         </td>
                     {% elif object.name %}
                         <td class="text-wrap" style="text-align:center">
                             {% if object|classname == "Notation" or object|classname == "Provenance" or object|classname == "Segment" %}
                                 <b>{{ object.name|truncatechars:30 }}
                             {% else %}
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                <a href="{{ object.absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
                             {% endif %}
                         </td>
                     {% elif object.full_name %}
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
+                            <a href="{{ object.absolute_url }}"><b>{{ object.full_name }}</b></a>
                         </td>
                     {% else %}
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
+                            <a href="{{ object.absolute_url }}"><b>{{ object|classname }} Object</b></a>
                         </td>
                     {% endif %}
                     <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -57,7 +57,7 @@
                         {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
                         <td><a href="{% url 'chant-by-cantus-id' cantus_id|urlencode:"" %}">{{ cantus_id|default:"" }}</a></td>
                         <td>{{ incipit }}</td>
-                        <td><a href="{{ genre.get_absolute_url }}" title="{{ genre.description }}">{{ genre.name }}</a></td>
+                        <td><a href="{{ genre.absolute_url }}" title="{{ genre.description }}">{{ genre.name }}</a></td>
                         <td>{{ count }}</td>
                     </tr>
                     {% endfor %}


### PR DESCRIPTION
This PR adds a new field, `.absolute_url`, to all (non-User) models. In doing so, it clears the way for implementing the change in #529 - this way, all the data needed to render the template will be present in the database, and we will no longer need to load Python objects into memory in order to call their `.get_absolute_url` methods.

The PR adds a new hook to `signals.py`, which ensures that whenever an object is saved, its `absolute_url` field is up-to-date (we don't expect objects' `id`s to change often (perhaps while syncing data with OldCantus?), but this ensures that nothing breaks if it occurs). In order to populate these fields initially, a new management command, `save_all_objects`, has been added to load and save all objects in the database, thus triggering the new `on_object_save` hook. _This command will need to be run when these changes are added to our staging and production servers._

If I got all my `git checkout`s correct, these changes pass all tests introduced in #539.