### PR TITLE
Improve Chant Edit page, re: volpiano preview and edit syllabification

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -80,26 +80,34 @@
                     </div>
 
                     {% if chant.volpiano %}
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <small>Preview of melody with text:</small>
-                            {% if chant.manuscript_syllabized_full_text %}
-                                <p><small>Syllabification is based on saved syllabized text.</small></p>
-                            {% endif %}
-                            <dd>
-                                {% for zip in syllabized_text_with_melody %}
-                                    {% for syl_mel, syl_text in zip %}
-                                        <span style="float: left">
-                                            <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
-                                            <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
-                                            <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
-                                        </span>
+                        <div class="form-row">
+                            <div class="form-group m-1 col-lg-12">
+                                <small>Preview of melody with text:</small>
+                                {% if chant.manuscript_syllabized_full_text %}
+                                    <p><small>Syllabification is based on saved syllabized text.</small></p>
+                                {% endif %}
+                                <dd>
+                                    {% for zip in syllabized_text_with_melody %}
+                                        {% for syl_mel, syl_text in zip %}
+                                            <span style="float: left">
+                                                <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
+                                                <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
+                                                <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
+                                            </span>
+                                        {% endfor %}
                                     {% endfor %}
-                                {% endfor %}
-                            </dd>
+                                </dd>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-4">
+                            <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
+                                <small>Edit syllabification (new window)</small>
+                            </a>
                         </div>
                     </div>
-                {% endif %}
 
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-2">
@@ -185,36 +193,6 @@
                         <div class="form-group m-1 col-lg-12">
                             <small>{{ form.indexing_notes.label_tag }}</small>
                             {{ form.indexing_notes }}
-                        </div>
-                    </div>
-
-                    {% if chant.volpiano %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <small>Preview of melody and text:</small>
-                                <br>
-                                {% if chant.manuscript_syllabized_full_text %}
-                                    <small>Syllabification is based on saved syllabized text.</small>
-                                    <br>
-                                {% endif %}
-                                {% for zip in syllabized_text_with_melody %}
-                                    {% for syl_mel, syl_text in zip %}
-                                        <span style="float: left">
-                                            <div style="font-family: volpiano; font-size: 28px">{{ syl_mel }}</div>
-                                            <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
-                                            <div class="mt-2" style="font-size: 10px"><pre>{{ syl_text }}</pre></div>
-                                        </span>
-                                    {% endfor %}
-                                {% endfor %}
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-4">
-                            <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
-                                <small>Edit syllabification (new window)</small>
-                            </a>
                         </div>
                     </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -213,7 +213,7 @@
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-4">
                             <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
-                                <small>Edit syllabification (new window):</small>
+                                <small>Edit syllabification (new window)</small>
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
fixes #505

This PR also moves the "Edit Syllabification" link to immediately beneath the volpiano preview, where it will be more useful, removes a "Preview of melody and text:" that was a duplicate in the wrong place, and standardizes some indentation in the template.