### PR TITLE
Full Index view etc.: Replace instances of "index" with "inventory"

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -268,7 +268,7 @@
 
                 <h4>List of melodies</h4>
                 <span id="melodyLoadingPrompt" style="display: none; color: #922"><b>Loading melodies...</b></span>
-                <a id="melodyButton" href="#" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">» Display the melodies connected with this chant</a>
+                <a id="melodyButton" href="#" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">Display the melodies connected with this chant</a>
                 <div id="melodyDiv"></div>        
             {% endif %}
 
@@ -314,9 +314,7 @@
                                 {% endif %}
 
                                 {% if chant.image_link %}
-                                    <br>
-                                    <a href={{ chant.image_link }} target="_blank">» Display facsimile <b>({{ chant.folio }})</b></a>
-                                    <br>
+                                    <a href={{ chant.image_link }} class="guillemet" target="_blank">Display facsimile <b>({{ chant.folio }})</b></a>
                                 {% endif %}
 
                                 {% if previous_folio %}

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -145,21 +145,15 @@
                             {% endfor %}
                         </select>
                         <br>
-                        <a href="{% url "chant-list" %}?source={{ source.id }}" target="_blank">» View all chants</a>
-                        &nbsp;
-                        <a href="{% url "chant-index" %}?source={{ source.id }}" target="_blank">» View full inventory</a>
-                        &nbsp;
-                        <a href="{% url "csv-export" source.id%}" target="_blank">» CSV export</a>
-                        <br>
-                        <a href="{% url "chant-search-ms" source.id %}" target="_blank" >» Search chants in this manuscript</a>
-                        &nbsp;
+                        <a href="{% url "chant-list" %}?source={{ source.id }}" class="guillemet" target="_blank">View all chants</a>
+                        <a href="{% url "chant-index" %}?source={{ source.id }}" class="guillemet" target="_blank">View full inventory</a>
+                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
+                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
                         {% if source.image_link %}
-                        <a href="{{ source.image_link }}" target="_blank">» Image gallery</a>
+                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>
                         {% endif %}
-                        <br>
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  target="_blank">» Search melodies in this manuscript</a>
-                        <br>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" target="_blank">» Analyse this manuscript (Cantus Analysis Tool)</a>
+                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
+                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
                     </small>
                 </div>    
 

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -147,7 +147,7 @@
                         <br>
                         <a href="{% url "chant-list" %}?source={{ source.id }}" target="_blank">» View all chants</a>
                         &nbsp;
-                        <a href="{% url "chant-index" %}?source={{ source.id }}" target="_blank">» View full index</a>
+                        <a href="{% url "chant-index" %}?source={{ source.id }}" target="_blank">» View full inventory</a>
                         &nbsp;
                         <a href="{% url "csv-export" source.id%}" target="_blank">» CSV export</a>
                         <br>

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -20,11 +20,11 @@
 </head>
 
 <body>
-    <title>Index | Cantus Manuscript Database</title>
-    <h3>CANTUS Manuscript Index: 
+    <title>Inventory | Cantus Manuscript Database</title>
+    <h3>CANTUS Manuscript Inventory: 
         <a href="{{ source.get_absolute_url }}" target="_href">{{ source.title }}</a>
     </h3>
-    This source index contains {{ chants.count }} chants.
+    This source inventory contains {{ chants.count }} chants.
     <table class="table table-sm small table-bordered table-striped table-hover">
         <thead>
             <tr>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -161,21 +161,15 @@
                         </select>
 
                         <br>
-                        <a href="{% url "chant-list" %}?source={{ source.id }}" target="_blank">» View all chants</a>
-                        &nbsp;
-                        <a href="{% url "chant-index" %}?source={{ source.id }}" target="_blank">» View full inventory</a>
-                        &nbsp;
-                        <a href="{% url "csv-export" source.id%}" target="_blank">» CSV export</a>
-                        <br>
-                        <a href="{% url "chant-search-ms" source.id %}" target="_blank" >» Search chants in this manuscript</a>
-                        &nbsp;
+                        <a href="{% url "chant-list" %}?source={{ source.id }}" class="guillemet" target="_blank">View all chants</a>
+                        <a href="{% url "chant-index" %}?source={{ source.id }}" class="guillemet" target="_blank">View full inventory</a>
+                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
+                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
                         {% if source.image_link %}
-                            <a href="{{ source.image_link }}" target="_blank">» Image gallery</a>
+                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>
                         {% endif %}
-                        <br>
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  target="_blank">» Search melodies in this manuscript</a>
-                        <br>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" target="_blank">» Analyse this manuscript (Cantus Analysis Tool)</a>
+                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
+                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
                     </small>
                 </div>    
             </div>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -163,7 +163,7 @@
                         <br>
                         <a href="{% url "chant-list" %}?source={{ source.id }}" target="_blank">» View all chants</a>
                         &nbsp;
-                        <a href="{% url "chant-index" %}?source={{ source.id }}" target="_blank">» View full index</a>
+                        <a href="{% url "chant-index" %}?source={{ source.id }}" target="_blank">» View full inventory</a>
                         &nbsp;
                         <a href="{% url "csv-export" source.id%}" target="_blank">» CSV export</a>
                         <br>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -99,6 +99,15 @@
         .footer h5 {
             margin: 25px 0px 10px
         }
+        
+        /* links, appearing in sidebars, preceded with guillemets ("»"s) */
+        .guillemet {
+            display: block
+        }
+
+        .guillemet::before {
+            content: "» "
+        }
 
         /* this class is used for displaying results under the global search bar */
         .list-group-item-action:hover {


### PR DESCRIPTION
fixes #550 

I also took this opportunity, since I was looking at it, to clean up the sidebars on several of our views. It's always looked cluttered to me; now all the links are on their own lines, the "»"s are applied with a CSS pseudoclass, and I got to remove a bunch of `<br>`s and `&nbsp`s from the templates.

Before (Source Detail page):
![Screen Shot 2023-02-10 at 4 27 47 PM](https://user-images.githubusercontent.com/58090591/218201100-91a3b9c3-41e6-4789-bd2e-9c577fc91da5.png)

Now:
![Screen Shot 2023-02-10 at 4 28 28 PM](https://user-images.githubusercontent.com/58090591/218201459-97d30cfa-f7c4-4cc0-968f-971e8ce99aed.png)