### PR TITLE
fix requirements.txt by bumping asgiref version

### DIFF
--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-asgiref==3.5.0
+asgiref==3.5.2
 astroid==2.4.2
 attrs==19.3.0
 backports.zoneinfo==0.2.1


### PR DESCRIPTION
In testing #557, I restarted the cantusdb container but didn't delete my images. Now I know to do this in the future! Turns out Django 4.1.7 depends on asgiref >=3.5.2.