### PR TITLE
Add django_debug_toolbar to requirements.txt

### DIFF
--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -13,6 +13,7 @@ Django==4.1.7
 django-autocomplete-light==3.5.1
 django-extra-views==0.13.0
 django-quill-editor==0.1.40
+django_debug_toolbar==3.8.1
 Faker==4.1.0
 gunicorn==20.0.4
 idna==2.10


### PR DESCRIPTION
Earlier today, I had a painful time trying to set up Django Debug Toolbar. I'm hoping that by adding it to requirements.txt, it can streamline the process of switching it on and off. DDT requires a fair bit of configuration in settings.py and urls.py, so there's little chance of it (say) accidentally ending up turned-on on the production server.