### PR TITLE
In templates, replace instances of .get_absolute_url with url tags

### DIFF
--- a/django/cantusdb_project/align_text_mel.py
+++ b/django/cantusdb_project/align_text_mel.py
@@ -155,7 +155,6 @@ def syllabize_melody(volpiano):
         # remove the trailing "--" (added in previous line) from the last syllable
         syls[-1] = syls[-1][:-2]
         syls_melody.append(syls)
-    # print(syls_melody)
     return syls_melody
 
 

--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
+<title>{{ article.title }} | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
     <h3>
-        {{article.title}}
+        {{ article.title }}
     </h3>
     <div class="row">
         <div class="col">

--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -11,7 +11,7 @@
         <div class="col">
             <div class="container">
                 <div class="container text-wrap">
-                    <small>Submitted by <a href="{{ article.author.get_absolute_url }}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
+                    <small>Submitted by <a href="{% url 'user-detail' article.author.id %}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
                     <div style="padding-top: 1em;">
                         {{ article.body.html|safe }}
                     </div>

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+<title>What's New | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-10 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -10,7 +10,7 @@
         <div class="col">
             <small>{{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
             <h4>
-                <a href="{{ article.get_absolute_url }}">{{ article.title }}</a>
+                <a href="{% url 'article-detail' article.id %}">{{ article.title }}</a>
             </h4>
             <div class="container">
                 {{ article.body|safe|truncatechars_html:3000 }}

--- a/django/cantusdb_project/main_app/templates/century_detail.html
+++ b/django/cantusdb_project/main_app/templates/century_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in century.sources.all|dictsort:"title" %}
             <li>
-                <a href="{{ source.get_absolute_url }}">
+                <a href="{% url 'source-detail' source.id %}">
                     {{ source.title }}
                 </a>
             </li>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -11,7 +11,7 @@
             <div class="alert alert-success alert-dismissible">
                 {% for message in messages %}
                 <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                <a href="{{ previous_chant.get_absolute_url }}" style="color:#155724" target="_blank">{{ message }}</a>
+                <a href="{% url 'chant-detail' previous_chant.id %}" style="color:#155724" target="_blank">{{ message }}</a>
                 {% endfor %}
             </div>
             {% endif %}
@@ -232,12 +232,12 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h5><a id="source" href="{{ source.get_absolute_url }}">{{ source.title }}</a></h5>
+                    <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.title }}</a></h5>
                 </div>
                 <div class="card-body" style="font-size: 15px">
                     <b>Suggestions based on the previous chant:</b><br>
                     {% if previous_chant %}
-                        {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{{ previous_chant.get_absolute_url }}" target="_blank">{{ previous_chant.incipit }}</a><br>
+                        {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{% url 'chant-detail' previous_chant.id %}" target="_blank">{{ previous_chant.incipit }}</a><br>
                         Cantus ID: <a href="http://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a><br>
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -64,7 +64,7 @@
                         <div class="col-2">
                             <dt>Feast</dt>
                             <dd>
-                                <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name }}</a>
+                                <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -325,10 +325,26 @@
                                             <table class="table table-sm small table-bordered">     
                                                 {% for chant in chants %}
                                                     <tr>
-                                                        <td>{{ chant.c_sequence }}</td>
-                                                        <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                        <td><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                                        <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
+                                                        <td>
+                                                            {{ chant.c_sequence }}
+                                                        </td>
+                                                        <td>
+                                                            <span title="{{ chant.office.description }}">
+                                                                {{ chant.office.name|default_if_none:"" }}
+                                                            </span>
+                                                            <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
+                                                            {{ chant.position|default_if_none:"" }}
+                                                        </td>
+                                                        <td>
+                                                            <a href="{% url 'chant-detail' chant.id %}">
+                                                                {{ chant.incipit|default_if_none:"" }}
+                                                            </a>
+                                                        </td>
+                                                        <td>
+                                                            <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                                {{ chant.cantus_id|default_if_none:"" }}
+                                                            </a>
+                                                        </td>
                                                     </tr>
                                                 {% endfor %}
                                             </table>
@@ -337,34 +353,71 @@
                                     <a id="previousToggle" href="#" onclick="togglePrevious(); return false;">Display previous chants ▾</a>
                                 {% endif %}
                                 <br>
-
-                                {% for feast, chants in feasts_current_folio %}
-                                    Folio: <b>{{ chant.folio }}</b> - Feast: <b>{{ feast.name }}</b>
-                                    <table class="table table-sm small table-bordered">     
-                                        {% for chant in chants %}
-                                            <tr>
-                                                <td>{{ chant.c_sequence }}</td>
-                                                <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                <td><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                                <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
-                                            </tr>
-                                        {% endfor %}
-                                    </table>
-                                {% endfor %}
+                                {% with chant.c_sequence as current_seq %}
+                                    {% for feast, chants in feasts_current_folio %}
+                                        Folio: <b>{{ chant.folio }}</b> - Feast: <b title="{{ feast.description }}">{{ feast.name }}</b>
+                                        <table class="table table-sm small table-bordered">     
+                                            {% for chant in chants %}
+                                                <tr>
+                                                    <td>
+                                                        {{ chant.c_sequence }}
+                                                    </td>
+                                                    <td>
+                                                        <span title="{{ chant.office.description }}">
+                                                            {{ chant.office.name|default_if_none:"" }}
+                                                        </span>
+                                                        <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
+                                                        {{ chant.position|default_if_none:"" }}
+                                                    </td>
+                                                    <td>
+                                                        <a href="{% url 'chant-detail' chant.id %}">
+                                                            {% if chant.c_sequence == current_seq %}
+                                                                <b>{{ chant.incipit|default_if_none:"" }}</b>
+                                                            {% else %}
+                                                                {{ chant.incipit|default_if_none:"" }}
+                                                            {% endif %}
+                                                        </a>
+                                                    </td>
+                                                    <td>
+                                                        <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                            {{ chant.cantus_id|default_if_none:"" }}
+                                                        </a>
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        </table>
+                                    {% endfor %}
+                                {% endwith %}
 
                                 {% if next_folio %}
                                     <a id="nextToggle" href="#" onclick="toggleNext(); return false;">Display next chants ▾</a>
                                     <br>
                                     <div id="nextDiv" style="display:none">
                                         {% for feast, chants in feasts_next_folio %}
-                                            Folio: <b>{{ next_folio }}</b> - Feast: <b>{{ feast.name }}</b>
+                                            Folio: <b>{{ next_folio }}</b> - Feast: <b title="{{ feast.description }}">{{ feast.name }}</b>
                                             <table class="table table-sm small table-bordered">     
                                                 {% for chant in chants %}
                                                     <tr>
-                                                        <td>{{ chant.c_sequence }}</td>
-                                                        <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                        <td><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                                        <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
+                                                        <td>
+                                                            {{ chant.c_sequence }}
+                                                        </td>
+                                                        <td>
+                                                            <span title="{{ chant.office.description }}">
+                                                                {{ chant.office.name|default_if_none:"" }}
+                                                            </span>
+                                                            <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
+                                                            {{ chant.position|default_if_none:"" }}
+                                                        </td>
+                                                        <td>
+                                                            <a href="{% url 'chant-detail' chant.id %}">
+                                                                {{ chant.incipit|default_if_none:"" }}
+                                                            </a>
+                                                        </td>
+                                                        <td>
+                                                             <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                                {{ chant.cantus_id|default_if_none:"" }}
+                                                            </a>
+                                                        </td>
                                                     </tr>
                                                 {% endfor %}
                                             </table>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -285,7 +285,7 @@
                         <b>Source navigation</b>
                         <br>
                         {% if source %}
-                            <a href="{% url 'source-detail' source.id %}"> <b>{{ source.siglum }}</b> </a>
+                            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"> <b>{{ source.siglum }}</b> </a>
                         {% else %}
                             This chant is not associated with any source. 
                         {% endif %}                            
@@ -381,7 +381,7 @@
                         <div class="card-header">
                             <small><a href="/sources?segment={{ source.segment.id }}">{{ source.segment.name }}</a></small>
                             <br>
-                            {{ source.siglum }}
+                            <span title="{{ source.title }}">{{ source.siglum }}</span>
                         </div>
                         <div class=" card-body">
                             <small>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -30,7 +30,7 @@
                         <div class="col">
                             <dt>Source</dt>
                             <dd>
-                                <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.title }}</a>
+                                <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.title }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -64,7 +64,7 @@
                         <div class="col-2">
                             <dt>Feast</dt>
                             <dd>
-                                <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name }}</a>
+                                <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -73,7 +73,7 @@
                         <div class="col-2">
                             <dt>Office/Mass</dt>
                             <dd>
-                                <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
+                                <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -82,7 +82,7 @@
                         <div class="col-2">
                             <dt>Genre</dt>
                             <dd>
-                                <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
+                                <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
@@ -285,7 +285,7 @@
                         <b>Source navigation</b>
                         <br>
                         {% if source %}
-                            <a href="{{ source.get_absolute_url }}"> <b>{{ source.siglum }}</b> </a>
+                            <a href="{% url 'source-detail' source.id %}"> <b>{{ source.siglum }}</b> </a>
                         {% else %}
                             This chant is not associated with any source. 
                         {% endif %}                            
@@ -327,7 +327,7 @@
                                                     <tr>
                                                         <td>{{ chant.c_sequence }}</td>
                                                         <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                        <td><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                                        <td><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                                         <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                                     </tr>
                                                 {% endfor %}
@@ -345,7 +345,7 @@
                                             <tr>
                                                 <td>{{ chant.c_sequence }}</td>
                                                 <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                <td><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                                <td><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                                 <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                             </tr>
                                         {% endfor %}
@@ -363,7 +363,7 @@
                                                     <tr>
                                                         <td>{{ chant.c_sequence }}</td>
                                                         <td>{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                                        <td><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                                        <td><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                                         <td><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                                     </tr>
                                                 {% endfor %}
@@ -386,7 +386,7 @@
                         <div class=" card-body">
                             <small>
                                 {% if source.provenance.name %}
-                                    Provenance: <b><a href="{{ source.provenance.get_absolute_url }}">{{source.provenance.name}}</a></b>
+                                    Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
                                     <br>
                                 {% endif %}
 
@@ -394,7 +394,7 @@
                                     Date: 
                                     {% for century in source.century.all %}
                                         <b>
-                                            <a href="{{ century.get_absolute_url }}">{{ century.name }}</a>
+                                            <a href="{% url 'century-detail' century.id %}">{{ century.name }}</a>
                                         </b>
                                     {% endfor %}
                                     |
@@ -409,7 +409,7 @@
 
                                 {% if source.notation.all %}
                                     <b>
-                                        <a href="{{ source.notation.all.first.get_absolute_url }}">{{ source.notation.all.first.name }}</a>
+                                        <a href="{% url 'notation-detail' source.notation.all.first.id %}">{{ source.notation.all.first.name }}</a>
                                     </b>
                                     <br>
                                 {% endif %}
@@ -419,7 +419,7 @@
                                     <ul>
                                         {% for editor in source.inventoried_by.all %}
                                             <li>
-                                                <a href={{ editor.get_absolute_url }}><b>{{ editor.full_name }}</b></a>
+                                                <a href="{% url 'user-detail' editor.id %}"><b>{{ editor.full_name }}</b></a>
                                                 <br>
                                                 {{ editor.institution|default_if_none:"" }}
                                             </li>
@@ -433,7 +433,7 @@
                                     <ul>
                                         {% for editor in source.proofreaders.all %}
                                             <li>
-                                                <a href={{ editor.get_absolute_url }}><b>{{ editor.full_name }}</b></a>
+                                                <a href="{% url 'user-detail' editor.id %}"><b>{{ editor.full_name }}</b></a>
                                                 <br>
                                             </li>
                                         {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -227,7 +227,7 @@
                     <small><b>&plus; Add new source</b></small>
                 </a>
                 <br>
-                <a href="{{ source.get_absolute_url }}" style="display: inline-block; margin-top:5px;">
+                <a href="{% url 'source-detail' source.id %}" style="display: inline-block; margin-top:5px;">
                     {{ source.siglum }}
                 </a>
             {% endif %}
@@ -240,7 +240,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>
@@ -282,7 +282,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">
@@ -300,7 +300,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -276,17 +276,40 @@
                     {% comment %} render if the user has selected a specific folio {% endcomment %}
                     {% if feasts_current_folio %}
                         {% for feast, chants in feasts_current_folio %}
-                            <small>Folio: <b>{{ chant.folio }}</b> - Feast: <b>{{ feast.name }}</b></small>
+                            <small>Folio: <b>{{ chant.folio }}</b> - Feast: <b title="{{ chant.feast.description }}">{{ feast.name }}</b></small>
                             <table class="table table-sm small table-bordered">     
                                 {% for chant in chants %}
                                     <tr>
-                                        <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
-                                        <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.c_sequence }}
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <span title="{{ chant.office.description }}">
+                                                {{ chant.office.name|default_if_none:"" }}
+                                            </span>
+                                            <b title="{{ chant.genre.description }}">
+                                                {{ chant.genre.name|default_if_none:"" }}
+                                            </b>
+                                            {{ chant.position|default_if_none:"" }}
+                                        </td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
+                                            <a href="{% url 'chant-detail' chant.id %}" target="_blank">
+                                                {{ chant.incipit|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                {{ chant.cantus_id|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.mode|default:"" }}
+                                        </td>
                                         <td class="h-25" style="width: 10%">
-                                            <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&folio={{ chant.folio }}">EDIT</button></td>
+                                            <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&folio={{ chant.folio }}">
+                                                EDIT
+                                            </a>
+                                        </td>
                                     </tr>
                                 {% endfor %}
                             </table>
@@ -294,17 +317,39 @@
                     {% comment %} render if the user has selected a specific feast {% endcomment %}
                     {% elif folios_current_feast %}
                         {% for folio, chants in folios_current_feast %}
-                            <small>Folio: <b>{{ folio }}</b> - Feast: <b>{{ chant.feast }}</b></small>
+                            <small>Folio: <b>{{ folio }}</b> - Feast: <b title="{{ chant.feast.description }}">{{ chant.feast }}</b></small>
                             <table class="table table-sm small table-bordered">     
                                 {% for chant in chants %}
                                     <tr>
-                                        <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
-                                        <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.c_sequence }}
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <span title="{{ chant.office.description }}">
+                                                {{ chant.office.name|default_if_none:"" }}
+                                            </span>
+                                            <b title="{{ chant.genre.description }}">
+                                                {{ chant.genre.name|default_if_none:"" }}
+                                            </b>
+                                            {{ chant.position|default_if_none:"" }}
+                                        </td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
+                                            <a href="{% url 'chant-detail' chant.id %}" target="_blank">
+                                                {{ chant.incipit|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                {{ chant.cantus_id|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.mode|default:"" }}
+                                        </td>
                                         <td class="h-25" style="width: 10%">
-                                            <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&feast={{ chant.feast.id }}">EDIT</button>
+                                            <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&feast={{ chant.feast.id }}">
+                                                EDIT
+                                            </a>
                                         </td>
                                     </tr>
                                 {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -227,7 +227,7 @@
                     <small><b>&plus; Add new source</b></small>
                 </a>
                 <br>
-                <a href="{% url 'source-detail' source.id %}" style="display: inline-block; margin-top:5px;">
+                <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="display: inline-block; margin-top:5px;">
                     {{ source.siglum }}
                 </a>
             {% endif %}
@@ -240,7 +240,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4><a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -84,13 +84,19 @@
                             </p>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
+                            {% if chant.feast %}
+                                <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
+                            {% endif %}
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                            {% if chant.office %}
+                                <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                            {% endif %}
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                            {% if chant.genre %}
+                                <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                            {% endif %}
                         </td>
                         <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
                         <td class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -76,7 +76,7 @@
                         <td class="text-wrap" style="text-align:center"><b>{{ chant.folio|default:"" }}</b></td>
                         <td class="text-wrap" style="text-align:center">{{ chant.c_sequence|default_if_none:"" }}</td> {# default_if_none: sometimes, c_sequence is 0, and should still be displayed #}
                         <td class="text-wrap">
-                            <a href="{{ chant.get_absolute_url }}"><b>{{ chant.incipit|default:"" }}</b></a>
+                            <a href="{% url 'chant-detail' chant.id %}"><b>{{ chant.incipit|default:"" }}</b></a>
                             <p>{{ chant.manuscript_full_text_std_spelling|default:"" }}<br>
                             {% if chant.volpiano %}
                                 <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
@@ -84,13 +84,13 @@
                             </p>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
+                            <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
                         </td>
                         <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
                         <td class="text-wrap" style="text-align:center">
@@ -117,7 +117,7 @@
             <div class="card mb-3 w-100">
 
                 <div class="card-header">
-                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h4>
                 </div>
 
                 <div class="card-body">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -72,7 +72,7 @@
                 <tbody>
                     {% for chant in chants %}
                     <tr>
-                        <td class="text-wrap" style="text-align:center">{{ chant.siglum|default:"" }}</td>
+                        <td class="text-wrap" style="text-align:center" title="{{ chant.source.title }}">{{ chant.source.siglum|default:"" }}</td>
                         <td class="text-wrap" style="text-align:center"><b>{{ chant.folio|default:"" }}</b></td>
                         <td class="text-wrap" style="text-align:center">{{ chant.c_sequence|default_if_none:"" }}</td> {# default_if_none: sometimes, c_sequence is 0, and should still be displayed #}
                         <td class="text-wrap">
@@ -117,7 +117,7 @@
             <div class="card mb-3 w-100">
 
                 <div class="card-header">
-                    <h4><a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
                 </div>
 
                 <div class="card-body">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -85,7 +85,7 @@
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             {% if chant.feast %}
-                                <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
+                                <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name|default:"" }}</a>
                             {% endif %}
                         </td>
                         <td class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -260,7 +260,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4><a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>
@@ -298,7 +298,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">
@@ -316,7 +316,7 @@
                                     <tr>
                                         <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
                                         <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default_if_none:"" }}</a></td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
                                         <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
                                         <td class="h-25" style="width: 10%">

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -296,13 +296,34 @@
                             <table class="table table-sm small table-bordered">     
                                 {% for chant in chants %}
                                     <tr>
-                                        <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
-                                        <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.c_sequence }}
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <span title="{{ chant.office.description }}">{{ chant.office.name|default_if_none:"" }}</span>
+                                            <b title="{{ chant.genre.description }}">
+                                                {{ chant.genre.name|default_if_none:"" }}
+                                            </b>
+                                            {{ chant.position|default_if_none:"" }}
+                                        </td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
+                                            <a href="{% url 'chant-detail' chant.id %}">
+                                                {{ chant.incipit|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                {{ chant.cantus_id|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.mode|default:"" }}
+                                        </td>
                                         <td class="h-25" style="width: 10%">
-                                            <a href="{% url 'chant-proofread' source.id %}?pk={{ chant.pk }}&folio={{ chant.folio }}">EDIT</button></td>
+                                            <a href="{% url 'chant-proofread' source.id %}?pk={{ chant.pk }}&folio={{ chant.folio }}">
+                                                EDIT
+                                            </a>
+                                        </td>
                                     </tr>
                                 {% endfor %}
                             </table>
@@ -314,13 +335,33 @@
                             <table class="table table-sm small table-bordered">     
                                 {% for chant in chants %}
                                     <tr>
-                                        <td class="h-25" style="width: 5%">{{ chant.c_sequence }}</td>
-                                        <td class="h-25" style="width: 20%">{{ chant.office.name|default_if_none:"" }} <b>{{ chant.genre.name|default_if_none:"" }}</b> {{ chant.position|default_if_none:"" }} </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0"><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 20%"><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default_if_none:"" }}</a></td>
-                                        <td class="h-25" style="width: 5%">{{ chant.mode|default:"" }}</td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.c_sequence }}
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <span title="{{ chant.office.description }}">{{ chant.office.name|default_if_none:"" }}</span>
+                                            <b title="{{ chant.genre.description }}">
+                                                {{ chant.genre.name|default_if_none:"" }}
+                                            </b>
+                                            {{ chant.position|default_if_none:"" }}
+                                        </td>
+                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
+                                            <a href="{% url 'chant-detail' chant.id %}">
+                                                {{ chant.incipit|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 20%">
+                                            <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                {{ chant.cantus_id|default_if_none:"" }}
+                                            </a>
+                                        </td>
+                                        <td class="h-25" style="width: 5%">
+                                            {{ chant.mode|default:"" }}
+                                        </td>
                                         <td class="h-25" style="width: 10%">
-                                            <a href="{% url 'chant-proofread' source.id %}?pk={{ chant.pk }}&feast={{ chant.feast.id }}">EDIT</button>
+                                            <a href="{% url 'chant-proofread' source.id %}?pk={{ chant.pk }}&feast={{ chant.feast.id }}">
+                                                EDIT
+                                            </a>
                                         </td>
                                     </tr>
                                 {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -260,7 +260,7 @@
 
             <div class="card mb-3 w-100">
                 <div class="card-header">
-                    <h4><a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h4>
+                    <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
                     <small>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -209,7 +209,7 @@
                     {% for chant in chants %}
                         <tr>
                             <td class="text-wrap" style="text-align:left">
-                                <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.siglum }}</a>
+                                <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.folio|default:""|truncatechars_html:140 }}

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -10,7 +10,7 @@
     <h3>Search Chants</h3>
     {% if source %}
         <p>
-            <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
+            <b>Searching in source: <a href="{% url 'source-detail' source.id %}" target="_blank">{{ source.title }}</a></b>
         </p>
     {% elif keyword %}
         <p>
@@ -209,7 +209,7 @@
                     {% for chant in chants %}
                         <tr>
                             <td class="text-wrap" style="text-align:left">
-                                <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
+                                <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.siglum }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.folio|default:""|truncatechars_html:140 }}
@@ -217,12 +217,12 @@
 
                             <td class="text-wrap" style="text-align:left">
                                 {% comment %} this is used for distinguishing chants from sequences,
-                                if the object is chant, use chant.get_absolute_url,
-                                otherwise, use sequence.get_absolute_url
+                                if the object is chant, use chant-detail view,
+                                otherwise, use sequence-detail view.
                                 the combined queryset turned all objects into chants
                                 so this is the only way to make the distinction {% endcomment %}
                                 {% if chant.search_vector %}
-                                    <b><a href="{{ chant.get_absolute_url }}">{{ chant.incipit|default:"" }}</a></b>
+                                    <b><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
                                 {% else %}
                                     <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
                                 {% endif %}
@@ -231,13 +231,13 @@
                                 </p>           
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a>
+                                <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.office.get_absolute_url }}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                                <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.genre.get_absolute_url }}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                                <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.position|default:"" }}

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -209,7 +209,9 @@
                     {% for chant in chants %}
                         <tr>
                             <td class="text-wrap" style="text-align:left">
-                                <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
+                                {% if chant.source %}
+                                    <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
+                                {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.folio|default:""|truncatechars_html:140 }}

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -234,7 +234,7 @@
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {% if chant.feast %}
-                                    <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
+                                    <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name|default:"" }}</a>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -231,13 +231,19 @@
                                 </p>           
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
+                                {% if chant.feast %}
+                                    <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a>
+                                {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                                {% if chant.office %}
+                                    <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                                {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                                {% if chant.genre %}
+                                    <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                                {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.position|default:"" }}

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -49,7 +49,7 @@
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>
-                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
+                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{% url 'chant-detail' chant.id %}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
                     <td class="text-wrap">{% if chant.image_link %}<a href="{{ chant.image_link }}" target="_blank">Image</a>{% endif %}</td>
                 </tr>
             {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -31,7 +31,9 @@
             {% for chant in chants %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
+                        {% if chant.source %}
+                            <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
+                        {% endif %}
                     </td>
                     <td class="text-wrap">{{ chant.folio }}</td>
                     {% comment %} this is used for distinguishing chants from sequences,

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -31,23 +31,23 @@
             {% for chant in chants %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{{ chant.source.get_absolute_url }}">{{ chant.source.siglum }}</a>
+                        <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.siglum }}</a>
                     </td>
                     <td class="text-wrap">{{ chant.folio }}</td>
                     {% comment %} this is used for distinguishing chants from sequences,
-                    if the object is chant, use chant.get_absolute_url,
-                    otherwise, use sequence.get_absolute_url
+                    if the object is chant, use chant-detail view,
+                    otherwise, use sequence-detail view.
                     the combined queryset turned all objects into chants
                     so this is the only way to make the distinction {% endcomment %}
                     {% if chant.search_vector %}
-                        <td class="text-wrap"><a href="{{ chant.get_absolute_url }}">{{ chant.incipit }}</a></td>
+                        <td class="text-wrap"><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% else %}
                         <td class="text-wrap"><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% endif %}
                     <td class="text-wrap" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }} </td>
                     <td class="text-wrap" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }} </td>
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
-                    <td class="text-wrap"><a href="{{ chant.feast.get_absolute_url }}">{{ chant.feast.name|default:"" }}</a></td>
+                    <td class="text-wrap"><a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>
                     <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{{ chant.get_absolute_url }}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
                     <td class="text-wrap">{% if chant.image_link %}<a href="{{ chant.image_link }}" target="_blank">Image</a>{% endif %}</td>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -31,7 +31,7 @@
             {% for chant in chants %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.siglum }}</a>
+                        <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
                     </td>
                     <td class="text-wrap">{{ chant.folio }}</td>
                     {% comment %} this is used for distinguishing chants from sequences,

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -44,8 +44,8 @@
                     {% else %}
                         <td class="text-wrap"><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% endif %}
-                    <td class="text-wrap" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }} </td>
-                    <td class="text-wrap" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }} </td>
+                    <td class="text-wrap"><a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a></td>
+                    <td class="text-wrap"><a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -44,8 +44,17 @@
                     {% else %}
                         <td class="text-wrap"><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit }}</a></td>
                     {% endif %}
-                    <td class="text-wrap"><a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a></td>
-                    <td class="text-wrap"><a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a></td>
+                    <td class="text-wrap">
+                        {% if chant.office %}
+                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                        {% endif %}
+                    </td>
+                    <td class="text-wrap">
+                        {% if chant.genre %}
+                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                        {% endif %}
+                    </td>
+                        
                     <td class="text-wrap">{{ chant.position|default:"" }}</td>
                     <td class="text-wrap"><a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a></td>
                     <td class="text-wrap">{{ chant.mode|default:"" }}</td>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -46,20 +46,35 @@
                     {% endif %}
                     <td class="text-wrap">
                         {% if chant.office %}
-                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                         {% endif %}
                     </td>
                     <td class="text-wrap">
                         {% if chant.genre %}
-                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
                         {% endif %}
                     </td>
-                        
-                    <td class="text-wrap">{{ chant.position|default:"" }}</td>
-                    <td class="text-wrap"><a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name|default:"" }}</a></td>
-                    <td class="text-wrap">{{ chant.mode|default:"" }}</td>
-                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">{% if chant.volpiano %}<a href="{% url 'chant-detail' chant.id %}" style="text-decoration: none" title="Chant has volpiano melody">1</a>{% endif %}</td>
-                    <td class="text-wrap">{% if chant.image_link %}<a href="{{ chant.image_link }}" target="_blank">Image</a>{% endif %}</td>
+                    <td class="text-wrap">
+                        {{ chant.position|default:"" }}
+                    </td>
+                    <td class="text-wrap">
+                        {% if chant.feast %}
+                            <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name }}</a>
+                        {% endif %}
+                    </td>
+                    <td class="text-wrap">
+                        {{ chant.mode|default:"" }}
+                    </td>
+                    <td class="text-wrap" style="font-family: volpiano; font-size:30px">
+                        {% if chant.volpiano %}
+                            <a href="{% url 'chant-detail' chant.id %}" style="text-decoration: none" title="Chant has volpiano melody">1</a>
+                        {% endif %}
+                    </td>
+                    <td class="text-wrap">
+                        {% if chant.image_link %}
+                            <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -48,12 +48,16 @@
                     {% endif %}
                     <td class="text-wrap">
                         {% if chant.office %}
-                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
+                            <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">
+                                {{ chant.office.name }}
+                            </a>
                         {% endif %}
                     </td>
                     <td class="text-wrap">
                         {% if chant.genre %}
-                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
+                            <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">
+                                {{ chant.genre.name }}
+                            </a>
                         {% endif %}
                     </td>
                     <td class="text-wrap">
@@ -61,7 +65,9 @@
                     </td>
                     <td class="text-wrap">
                         {% if chant.feast %}
-                            <a href="{% url 'feast-detail' chant.feast.id %}">{{ chant.feast.name }}</a>
+                            <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">
+                                {{ chant.feast.name }}
+                            </a>
                         {% endif %}
                     </td>
                     <td class="text-wrap">

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -57,7 +57,7 @@
                         {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
                         <td><a href="{% url 'chant-by-cantus-id' cantus_id|urlencode:"" %}">{{ cantus_id|default:"" }}</a></td>
                         <td>{{ incipit }}</td>
-                        <td><a href="{{ genre.get_absolute_url }}" title="{{ genre.description }}">{{ genre.name }}</a></td>
+                        <td><a href="{% url 'genre-detail' genre.id %}" title="{{ genre.description }}">{{ genre.name }}</a></td>
                         <td>{{ count }}</td>
                     </tr>
                     {% endfor %}

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -57,7 +57,11 @@
                         {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
                         <td><a href="{% url 'chant-by-cantus-id' cantus_id|urlencode:"" %}">{{ cantus_id|default:"" }}</a></td>
                         <td>{{ incipit }}</td>
-                        <td><a href="{% url 'genre-detail' genre.id %}" title="{{ genre.description }}">{{ genre.name }}</a></td>
+                        <td>
+                            {% if genre %}
+                                <a href="{% url 'genre-detail' genre.id %}" title="{{ genre.description }}">{{ genre.name }}</a>
+                            {% endif %}
+                        </td>
                         <td>{{ count }}</td>
                     </tr>
                     {% endfor %}

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -78,7 +78,7 @@
                 <tbody>
                     {% for source, count in sources_zip %}
                         <tr>
-                            <td><a href="{% url 'chant-list' %}?source={{ source.id }}">{{ source.siglum }}</a></td>
+                            <td><a href="{% url 'chant-list' %}?source={{ source.id }}" title="{{ source.title }}">{{ source.siglum }}</a></td>
                             <td><a href="{% url 'chant-list' %}?source={{ source.id }}&feast={{ feast.id }}">{{ count }}</a></td>
                         </tr>
                     {% endfor %}

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -69,7 +69,7 @@
             {% for feast in feasts %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{{ feast.get_absolute_url }}"><b>{{ feast.name }}</b></a>
+                        <a href="{% url 'feast-detail' feast.id %}"><b>{{ feast.name }}</b></a>
                     </td>
                     <td class="text-wrap">{{ feast.description|default:"" }}</td>
                     <td class="text-wrap">

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -69,7 +69,9 @@
             {% for feast in feasts %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{% url 'feast-detail' feast.id %}" title="{{ feast.description }}"><b>{{ feast.name }}</b></a>
+                        <a href="{% url 'feast-detail' feast.id %}" title="{{ feast.description }}">
+                            <b>{{ feast.name }}</b>
+                        </a>
                     </td>
                     <td class="text-wrap">{{ feast.description|default:"" }}</td>
                     <td class="text-wrap">

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -69,7 +69,7 @@
             {% for feast in feasts %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{% url 'feast-detail' feast.id %}"><b>{{ feast.name }}</b></a>
+                        <a href="{% url 'feast-detail' feast.id %}" title="{{ feast.description }}"><b>{{ feast.name }}</b></a>
                     </td>
                     <td class="text-wrap">{{ feast.description|default:"" }}</td>
                     <td class="text-wrap">

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -60,9 +60,21 @@
                             {{ chant.s_sequence|default_if_none:"" }}
                         {% endif %}
                     </td>
-                    <td>{{ chant.feast.name|default_if_none:"" }}</td>
-                    <td><span title="{{ chant.office.description }}">{{ chant.office.name|default_if_none:"" }}</span></td>
-                    <td><span title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</span></td>
+                    <td>
+                        <span title="{{ chant.feast.description }}">
+                            {{ chant.feast.name|default_if_none:"" }}
+                        </span>
+                    </td>
+                    <td>
+                        <span title="{{ chant.office.description }}">
+                            {{ chant.office.name|default_if_none:"" }}
+                        </span>
+                    </td>
+                    <td>
+                        <span title="{{ chant.genre.description }}">
+                            {{ chant.genre.name|default_if_none:"" }}
+                        </span>
+                    </td>
                     <td>{{ chant.position|default_if_none:"" }}</td>
                     <td><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                     <td>{{ chant.cantus_id|default_if_none:"" }}</td>

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -22,7 +22,7 @@
 <body>
     <title>Inventory | Cantus Manuscript Database</title>
     <h3>CANTUS Manuscript Inventory: 
-        <a href="{{ source.get_absolute_url }}" target="_href">{{ source.title }}</a>
+        <a href="{% url 'source-detail' source.id %}" target="_href">{{ source.title }}</a>
     </h3>
     This source inventory contains {{ chants.count }} chants.
     <table class="table table-sm small table-bordered table-striped table-hover">
@@ -64,7 +64,7 @@
                     <td><span title="{{ chant.office.description }}">{{ chant.office.name|default_if_none:"" }}</span></td>
                     <td><span title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</span></td>
                     <td>{{ chant.position|default_if_none:"" }}</td>
-                    <td><a href="{{ chant.get_absolute_url }}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
+                    <td><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
                     <td>{{ chant.cantus_id|default_if_none:"" }}</td>
                     <td>{{ chant.mode|default_if_none:"" }}</td>
                     <td>{{ chant.differentia|default_if_none:"" }}</td>

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -50,7 +50,7 @@
                         `default`: use the given default if the value evaluates to False
                         `default_if_none`: use the given default only if the value is None
                     {% endcomment %}
-                    <td>{{ chant.source.siglum|default_if_none:"" }}</td>
+                    <td title="{{ chant.source.title }}">{{ chant.source.siglum|default_if_none:"" }}</td>
                     <td>{{ chant.marginalia|default_if_none:"" }}</td>
                     <td>{{ chant.folio|default_if_none:"" }}</td>
                     <td>

--- a/django/cantusdb_project/main_app/templates/genre_list.html
+++ b/django/cantusdb_project/main_app/templates/genre_list.html
@@ -43,7 +43,7 @@
             {% for genre in genres %}
                 <tr>
                     <td style="text-align:center">
-                        <a href="{{ genre.get_absolute_url }}"><b>{{ genre.name }}</b></a>
+                        <a href="{% url 'genre-detail' genre.id %}"><b>{{ genre.name }}</b></a>
                     </td>
                     <td style="text-align:center">
                         {{ genre.description|default:"" }}

--- a/django/cantusdb_project/main_app/templates/indexer_list.html
+++ b/django/cantusdb_project/main_app/templates/indexer_list.html
@@ -31,13 +31,13 @@
             {% for indexer in indexers %}
                 <tr>
                     <td class="text-center text-wrap">
-                        <a href="{{ indexer.get_absolute_url }}">{{ indexer.full_name }}</a>
+                        <a href="{% url 'user-detail' indexer.id %}">{{ indexer.full_name }}</a>
                     </td>
                     <td class="text-center text-wrap">{{ indexer.institution|default:"" }}</td>
                     <td class="text-center text-wrap">{{ indexer.city|default:"" }}</td>
                     <td class="text-center text-wrap">{{ indexer.country|default:"" }}</td>
                     <td class="text-center text-wrap">
-                        <a href="{{ indexer.get_absolute_url }}#sources">{{ indexer.source_count }} source{{ indexer.source_count|pluralize }}</a>
+                        <a href="{% url 'user-detail' indexer.id %}#sources">{{ indexer.source_count }} source{{ indexer.source_count|pluralize }}</a>
                     </td>
                 </tr>
             {% endfor %}

--- a/django/cantusdb_project/main_app/templates/melody_search.html
+++ b/django/cantusdb_project/main_app/templates/melody_search.html
@@ -82,7 +82,7 @@
             </form>
 
             {% if source %}
-                <b>Searching in source: <a href="{{ source.get_absolute_url }}" target="_blank">{{ source.title }}</a></b>
+                <b>Searching in source: <a href="{% url 'source-detail' source.id %}" target="_blank">{{ source.title }}</a></b>
             {% endif %}
 
             <div id="resultsDiv"></div>

--- a/django/cantusdb_project/main_app/templates/notation_detail.html
+++ b/django/cantusdb_project/main_app/templates/notation_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in notation.sources.all|dictsort:"title" %}
             <li>
-                <a href="{{ source.get_absolute_url }}">
+                <a href="{% url 'source-detail' source.id %}">
                     {{ source.title }}
                 </a>
             </li>

--- a/django/cantusdb_project/main_app/templates/office_list.html
+++ b/django/cantusdb_project/main_app/templates/office_list.html
@@ -18,7 +18,7 @@
             {% for office in offices %}
                 <tr>
                     <td class="text-wrap">
-                        <a href="{{ office.get_absolute_url }}"><b>{{ office.name }}</b></a>
+                        <a href="{% url 'office-detail' office.id %}"><b>{{ office.name }}</b></a>
                     </td>
                     <td class="text-wrap">{{ office.description }}</td>
                 </tr>

--- a/django/cantusdb_project/main_app/templates/provenance_detail.html
+++ b/django/cantusdb_project/main_app/templates/provenance_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in provenance.sources.all|dictsort:"title" %}
             <li>
-                <a href="{{ source.get_absolute_url }}">
+                <a href="{% url 'source-detail' source.id %}">
                     {{ source.title }}
                 </a>
             </li>

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -30,7 +30,7 @@
             Source
         </dt>
         <dd>
-            <a href="{{ sequence.source.get_absolute_url }}">
+            <a href="{% url 'source-detail' sequence.source.id %}">
                 {{ sequence.source.title }}
             </a>
         </dd>
@@ -80,7 +80,7 @@
                     Genre
                 </dt>
                 <dd>
-                    <a href="{{ sequence.genre.get_absolute_url }}" title="{{ sequence.genre.description }}">{{ sequence.genre.name }}</a>
+                    <a href="{% url 'genre-detail' sequence.genre.id %}" title="{{ sequence.genre.description }}">{{ sequence.genre.name }}</a>
                 </dd>
             </div>
             {% endif %}
@@ -185,12 +185,12 @@
             {% for sequence in concordances %}
                 <tr>
                     <td class="text-wrap" style="text-align:center">
-                        <a href="{{ sequence.source.get_absolute_url }}"><b>{{ sequence.siglum }}</b></a>
+                        <a href="{% url 'source-detail' sequence.source.id %}"><b>{{ sequence.siglum }}</b></a>
                         <br>
                         <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
                     </td>
                     <td class="text-wrap" style="text-align:center">
-                        <a href={{ sequence.get_absolute_url}} >{{ sequence.incipit|default:"" }}</a>
+                        <a href="{% url 'sequence-detail' sequence.id %}">{{ sequence.incipit|default:"" }}</a>
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         {{ sequence.rubrics|default:"" }}

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -26,14 +26,16 @@
         <dd>
             {{ sequence.siglum }}
         </dd>
-        <dt>
-            Source
-        </dt>
-        <dd>
-            <a href="{% url 'source-detail' sequence.source.id %}">
-                {{ sequence.source.title }}
-            </a>
-        </dd>
+        {% if sequence.source %}
+            <dt>
+                Source
+            </dt>
+            <dd>
+                <a href="{% url 'source-detail' sequence.source.id %}">
+                    {{ sequence.source.title }}
+                </a>
+            </dd>
+        {% endif %}
         <div class="row">
             <div class="col">
                 {% if sequence.folio %}
@@ -185,9 +187,11 @@
             {% for sequence in concordances %}
                 <tr>
                     <td class="text-wrap" style="text-align:center">
-                        <a href="{% url 'source-detail' sequence.source.id %}"><b>{{ sequence.siglum }}</b></a>
-                        <br>
-                        <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
+                        {% if sequence.source %}
+                            <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}"><b>{{ sequence.siglum }}</b></a>
+                            <br>
+                            <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
+                        {% endif %}
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         <a href="{% url 'sequence-detail' sequence.id %}">{{ sequence.incipit|default:"" }}</a>

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -45,13 +45,13 @@
             {% for sequence in sequences %}
                 <tr style="text-align:center">
                     <td class="text-wrap">
-                        <a href={{ sequence.source.get_absolute_url }}>
+                        <a href="{% url 'source-detail' sequence.source.id %}">
                             <b>{{ sequence.source.siglum|default:"" }}</b><br>
                         </a>
                         <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}
                     </td>
                     <td class="text-wrap">
-                        <a href="{{ sequence.get_absolute_url }}">
+                        <a href="{% url 'sequence-detail' sequence.id %}">
                             {{ sequence.incipit|default:"" }}
                         </a>
                     </td>

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -46,8 +46,8 @@
                 <tr style="text-align:center">
                     <td class="text-wrap">
                         {% if sequence.source %}
-                            <a href="{% url 'source-detail' sequence.source.id %}">
-                                <b>{{ sequence.source.siglum|default:"" }}</b><br>
+                            <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}">
+                                <b>{{ sequence.source.siglum }}</b><br>
                             </a>
                         {% endif %}
                         <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -45,9 +45,11 @@
             {% for sequence in sequences %}
                 <tr style="text-align:center">
                     <td class="text-wrap">
-                        <a href="{% url 'source-detail' sequence.source.id %}">
-                            <b>{{ sequence.source.siglum|default:"" }}</b><br>
-                        </a>
+                        {% if sequence.source %}
+                            <a href="{% url 'source-detail' sequence.source.id %}">
+                                <b>{{ sequence.source.siglum|default:"" }}</b><br>
+                            </a>
+                        {% endif %}
                         <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}
                     </td>
                     <td class="text-wrap">

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -49,7 +49,7 @@
                     <dt>Other Editors</dt>
                     <dd>
                         {% for editor in source.other_editors.all %}
-                            <a href={{ editor.get_absolute_url }}>{{ editor.full_name }}</a><br>
+                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
                         {% endfor %}
                     </dd>
                 {% endif %}
@@ -58,7 +58,7 @@
                     <dt>Full Text Entered by</dt>
                     <dd>
                         {% for editor in source.full_text_entered_by.all %}
-                            <a href={{ editor.get_absolute_url }}>{{ editor.full_name }}</a><br>
+                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
                         {% endfor %}
                     </dd>
                 {% endif %}
@@ -67,7 +67,7 @@
                     <dt>Melodies Entered by</dt>
                     <dd>
                         {% for editor in source.melodies_entered_by.all %}
-                            <a href={{ editor.get_absolute_url }}>{{ editor.full_name }}</a><br>
+                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
                         {% endfor %}
                     </dd>
                 {% endif %}
@@ -110,12 +110,12 @@
                         {% for sequence in sequences %}
                             <tr>
                                 <td class="text-wrap" style="text-align:center">
-                                    <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a>
+                                    <a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a>
                                     <br>
                                     <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
                                 </td>
                                 <td class="text-wrap" style="text-align:center">
-                                    <a href={{ sequence.get_absolute_url }} >{{ sequence.incipit|default:"" }}</a>
+                                    <a href="{% url 'sequence-detail' sequence.id %}" >{{ sequence.incipit|default:"" }}</a>
                                 </td>
                                 <td class="text-wrap" style="text-align:center">
                                     {{ sequence.rubrics|default:"" }}
@@ -185,13 +185,13 @@
                 <div class=" card-body">
                     <small>
                         {% if source.provenance.name %}
-                            Provenance: <b><a href="{{ source.provenance.get_absolute_url }}">{{source.provenance.name}}</a></b>
+                            Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
                             <br>
                         {% endif %}
                         {% if source.date %}
                             Date: 
                             {% for century in source.century.all %}
-                                <b><a href="{{ century.get_absolute_url }}">
+                                <b><a href="{% url 'century-detail' century.id %}">
                                     {{ century.name }}
                                 </a></b>
                             {% endfor %}
@@ -204,7 +204,7 @@
                             <br>
                         {% endif %}
                         {% if source.notation.all %}
-                            Notation: <b><a href="{{ source.notation.all.first.get_absolute_url }}">
+                            Notation: <b><a href="{% url 'notation-detail' source.notation.all.first.id %}">
                                 {{ source.notation.all.first.name }}
                             </a></b>
                             <br>
@@ -214,7 +214,7 @@
                             <ul>
                                 {% for editor in source.inventoried_by.all %}
                                     <li>
-                                        <a href={{ editor.get_absolute_url }}><b>{{ editor.full_name }}</b></a><br>
+                                        <a href={% url 'user-detail' editor.id %}><b>{{ editor.full_name }}</b></a><br>
                                         {{ editor.institution|default_if_none:"" }}
                                     </li>
                                 {% endfor %}
@@ -226,7 +226,7 @@
                             <ul>
                                 {% for editor in source.proofreaders.all %}
                                     <li>
-                                        <a href={{ editor.get_absolute_url }}><b>{{ editor.full_name }}</b></a><br>
+                                        <a href={% url 'user-detail' editor.id %}><b>{{ editor.full_name }}</b></a><br>
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -110,7 +110,7 @@
                         {% for sequence in sequences %}
                             <tr>
                                 <td class="text-wrap" style="text-align:center">
-                                    <a href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a>
+                                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a>
                                     <br>
                                     <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
                                 </td>

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -81,7 +81,7 @@
             {% for source in sources %}
                 <tr>
                     <td class="text-wrap" style="text-align:center">
-                        <a href="{% url 'source-detail' source.id %}"><b>{{ source.siglum }}</b></a>
+                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"><b>{{ source.siglum }}</b></a>
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         {{ source.summary|default:""|truncatechars_html:140 }}

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -81,14 +81,18 @@
             {% for source in sources %}
                 <tr>
                     <td class="text-wrap" style="text-align:center">
-                        <a href="{{ source.get_absolute_url }}"><b>{{ source.siglum }}</b></a>
+                        <a href="{% url 'source-detail' source.id %}"><b>{{ source.siglum }}</b></a>
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         {{ source.summary|default:""|truncatechars_html:140 }}
                     </td>
                     <td class="text-wrap" style="text-align:center">
-                        <b><a href="{{ source.century.first.get_absolute_url }}">{{ source.century.first.name }}</a></b><br>
-                        <a href="{{ source.provenance.get_absolute_url }}">{{ source.provenance.name|default:"" }}</a>
+                        {% if source.century.all %}
+                            <b><a href="{% url 'century-detail' source.century.first.id %}">{{ source.century.first.name }}</a></b><br>
+                        {% endif %}
+                        {% if source.provenance %}
+                            <a href="{% url 'provenance-detail' source.provenance.id %}">{{ source.provenance.name }}</a>
+                        {% endif %}
                     </td>
                     <td class="text-wrap" style="text-align:center">
                         {% if source.image_link %}

--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -74,7 +74,7 @@
             <ul>
                 {% for source in edited_sources %}
                     <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a> ({{ source.title }})
                     </li>
                 {% endfor %}
             </ul>

--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -34,7 +34,7 @@
             <ul>
                 {% for source in inventoried_sources %}
                     <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a> ({{ source.title }})
                     </li>
                 {% endfor %}
             </ul>
@@ -44,7 +44,7 @@
             <ul>
                 {% for source in full_text_sources %}
                     <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a> ({{ source.title }})
                     </li>
                 {% endfor %}
             </ul>
@@ -54,7 +54,7 @@
             <ul>
                 {% for source in melody_sources %}
                     <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a> ({{ source.title }})
                     </li>
                 {% endfor %}
             </ul>
@@ -64,7 +64,7 @@
             <ul>
                 {% for source in proofread_sources %}
                     <li>
-                        <a href="{{ source.get_absolute_url }}">{{ source.siglum }}</a> ({{ source.title }})
+                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a> ({{ source.title }})
                     </li>
                 {% endfor %}
             </ul>

--- a/django/cantusdb_project/main_app/templates/user_list.html
+++ b/django/cantusdb_project/main_app/templates/user_list.html
@@ -30,7 +30,7 @@
             {% for user in users %}
                 <tr>
                     <td class="text-center text-wrap">
-                        <a href="{{ user.get_absolute_url }}">{{ user.full_name|default:"" }}</a>
+                        <a href="{% url 'user-detail' user.id %}">{{ user.full_name|default:"" }}</a>
                     </td>
                     <td>{{ user.institution|default:"" }}</td>
                     <td>{{ user.city|default:"" }}</td>

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -266,7 +266,7 @@ def make_fake_source(published=None, title=None, segment=None, segment_name=None
     # tuples and we only need the first element of each tuple
 
     if title is None:
-        title = make_fake_text(LONG_CHAR_FIELD_MAX)
+        title = faker.sentence()
     if siglum is None:
         siglum = make_fake_text(SHORT_CHAR_FIELD_MAX)
     if description is None:

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -752,6 +752,7 @@ class ChantSearchViewTest(TestCase):
     def test_source_link_column(self):
         siglum = "Sigl-01"
         source = make_fake_source(published=True, siglum=siglum)
+        source_title = source.title
         url = source.get_absolute_url()
         fulltext = "manuscript full text"
         search_term = "full"
@@ -764,8 +765,9 @@ class ChantSearchViewTest(TestCase):
         )
         html = str(response.content)
         self.assertIn(siglum, html)
+        self.assertIn(source_title, html)
         self.assertIn(url, html)
-        self.assertIn(f'<a href="{url}">{siglum}</a>', html)
+        self.assertIn(f'<a href="{url}" title="{source_title}">{siglum}</a>', html)
         
     def test_folio_column(self):
         source = make_fake_source(published=True)
@@ -786,6 +788,7 @@ class ChantSearchViewTest(TestCase):
         source = make_fake_source(published=True)
         feast = make_fake_feast()
         feast_name = feast.name
+        feast_description = feast.description
         url = feast.get_absolute_url()
         fulltext = "manuscript full text"
         search_term = "full"
@@ -799,8 +802,9 @@ class ChantSearchViewTest(TestCase):
         )
         html = str(response.content)
         self.assertIn(feast_name, html)
+        self.assertIn(feast_description, html)
         self.assertIn(url, html)
-        self.assertIn(f'<a href="{url}">{feast_name}</a>', html)
+        self.assertIn(f'<a href="{url}" title="{feast_description}">{feast_name}</a>', html)
         
     def test_office_column(self):
         source = make_fake_source(published=True)

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -13,6 +13,7 @@ Django==4.1.7
 django-autocomplete-light==3.5.1
 django-extra-views==0.13.0
 django-quill-editor==0.1.40
+django_debug_toolbar==3.8.1
 Faker==4.1.0
 gunicorn==20.0.4
 idna==2.10


### PR DESCRIPTION
Mainly as a step toward implementing more effective querying in the Chant Search View and other views, this PR replaces almost all instances of `.get_absolute_url` in all templates with `{% url %}` tags.

I also had to go through and add some `{% if chant.feast %}` (or .office, .source, .genre, etc.) when rendering links, to prevent the template from generating an error when it tried to get the `id` of a nonexistent feast/office/etc. Before changing how links are encoded, these would have generated empty links (equivalent to `<a href="">`).

As I was working in the views, it was not difficult to implement some other small changes we've been thinking of for a while. These include adding title attributes giving more information about feasts, genres and offices when they are moused over (i.e. fixes #543), bolding the current chant on the Chant detail page (i.e. fixes #478), and clarifying templates by improving indentation in some places.

(also - oops, it looks as though the change to `requirements.txt` from #560 got rolled up into this PR. I can remove this if you think it's best)