### PR TITLE
Improve Chant Search View

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -209,8 +209,8 @@
                     {% for chant in chants %}
                         <tr>
                             <td class="text-wrap" style="text-align:left">
-                                {% if chant.source %}
-                                    <a href="{% url 'source-detail' chant.source.id %}" title="{{ chant.source.title }}">{{ chant.source.siglum }}</a>
+                                {% if chant.source__id %}
+                                    <a href="{% url 'source-detail' chant.source__id %}" title="{{ chant.source__title }}">{{ chant.source__siglum }}</a>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
@@ -233,25 +233,25 @@
                                 </p>           
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                {% if chant.feast %}
-                                    <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name|default:"" }}</a>
+                                {% if chant.feast__id %}
+                                    <a href="{% url 'feast-detail' chant.feast__id %}" title="{{ chant.feast__description }}">{{ chant.feast__name|default:"" }}</a>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                {% if chant.office %}
-                                    <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                                {% if chant.office__id %}
+                                    <a href="{% url 'office-detail' chant.office__id %}" title="{{ chant.office__description }}">{{ chant.office__name|default:"" }}</a>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                {% if chant.genre %}
-                                    <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                                {% if chant.genre__id %}
+                                    <a href="{% url 'genre-detail' chant.genre__id %}" title="{{ chant.genre__description }}">{{ chant.genre__name|default:"" }}</a>
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.position|default:"" }}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ chant.get_ci_url }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
+                                <a href="http://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
                             </td>
                             <td class="text-wrap" style="text-align:center">
                                 {{ chant.mode|default:"" }}

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -747,7 +747,6 @@ class ChantSearchViewTest(TestCase):
             source=source,
             manuscript_full_text="hoc tantum possum dicere",
         )
-        # use a random subset of words as search term
         search_term = "tantum possum"
         response = self.client.get(
             reverse("chant-search"), {"keyword": search_term, "op": "contains"}

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -654,14 +654,15 @@ class ChantSearchViewTest(TestCase):
         response = self.client.get(
             reverse("chant-search"), {"keyword": "lorem", "op": "contains"}
         )
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
         source.published = False
         source.save()
         response = self.client.get(
             reverse("chant-search"), {"keyword": "lorem", "op": "contains"}
         )
-        self.assertNotIn(chant, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 0)
 
     def test_search_by_office(self):
         source = make_fake_source(published=True)
@@ -669,28 +670,32 @@ class ChantSearchViewTest(TestCase):
         chant = Chant.objects.create(source=source, office=office)
         search_term = get_random_search_term(office.name)
         response = self.client.get(reverse("chant-search"), {"office": search_term})
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_filter_by_genre(self):
         source = make_fake_source(published=True)
         genre = make_fake_genre()
         chant = Chant.objects.create(source=source, genre=genre)
         response = self.client.get(reverse("chant-search"), {"genre": genre.id})
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_search_by_cantus_id(self):
         source = make_fake_source(published=True)
         chant = Chant.objects.create(source=source, cantus_id=faker.numerify("######"))
         search_term = get_random_search_term(chant.cantus_id)
         response = self.client.get(reverse("chant-search"), {"cantus_id": search_term})
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_search_by_mode(self):
         source = make_fake_source(published=True)
         chant = Chant.objects.create(source=source, mode=faker.numerify("#"))
         search_term = get_random_search_term(chant.mode)
         response = self.client.get(reverse("chant-search"), {"mode": search_term})
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_search_by_feast(self):
         source = make_fake_source(published=True)
@@ -698,7 +703,8 @@ class ChantSearchViewTest(TestCase):
         chant = Chant.objects.create(source=source, feast=feast)
         search_term = get_random_search_term(feast.name)
         response = self.client.get(reverse("chant-search"), {"feast": search_term})
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_search_by_position(self):
         source = make_fake_source(published=True)
@@ -706,7 +712,8 @@ class ChantSearchViewTest(TestCase):
         chant = Chant.objects.create(source=source, position=position)
         search_term = "1"
         response = self.client.get(reverse("chant-search"), {"position": search_term})
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_filter_by_melody(self):
         source = make_fake_source(published=True)
@@ -716,38 +723,37 @@ class ChantSearchViewTest(TestCase):
         chant_without_melody = Chant.objects.create(source=source)
         response = self.client.get(reverse("chant-search"), {"melodies": "true"})
         # only chants with melodies should be in the result
-        self.assertIn(chant_with_melody, response.context["chants"])
-        self.assertNotIn(chant_without_melody, response.context["chants"])
+        self.assertEqual(len(response.context["chants"]), 1)
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(context_chant_id, chant_with_melody.id)
 
     def test_keyword_search_starts_with(self):
         source = make_fake_source(published=True)
         chant = Chant.objects.create(
-            source=source, incipit=make_fake_text(max_size=200)
+            source=source,
+            manuscript_full_text_std_spelling=make_fake_text(max_size=200),
         )
-        # use the beginning part of the incipit as search term
-        search_term = chant.incipit[0 : random.randint(1, len(chant.incipit))]
+        # use the beginning part of the full text as the search term
+        search_term = chant.manuscript_full_text_std_spelling[0 : random.randint(1, len(chant.manuscript_full_text_std_spelling))]
         response = self.client.get(
             reverse("chant-search"), {"keyword": search_term, "op": "starts_with"}
         )
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_keyword_search_contains(self):
         source = make_fake_source(published=True)
         chant = Chant.objects.create(
-            source=source, manuscript_full_text=make_fake_text(max_size=400)
+            source=source,
+            manuscript_full_text="hoc tantum possum dicere",
         )
-        # split full text into words
-        full_text_words = chant.manuscript_full_text.split(" ")
         # use a random subset of words as search term
-        search_term = " ".join(
-            random.choices(
-                full_text_words, k=random.randint(1, max(len(full_text_words) - 1, 1))
-            )
-        )
+        search_term = "tantum possum"
         response = self.client.get(
             reverse("chant-search"), {"keyword": search_term, "op": "contains"}
         )
-        self.assertIn(chant, response.context["chants"])
+        context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant.id, context_chant_id)
 
     def test_source_link_column(self):
         siglum = "Sigl-01"

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -818,8 +818,12 @@ class ChantSearchView(ListView):
                 keyword = self.request.GET.get("keyword")
                 # the operation parameter can be "contains" or "starts_with"
                 if self.request.GET.get("op") == "contains":
-                    chant_set = keyword_search(chant_set, keyword)
-                    sequence_set = keyword_search(sequence_set, keyword)
+                    chant_set = chant_set.filter(
+                        manuscript_full_text_std_spelling__icontains=keyword
+                    )
+                    sequence_set = sequence_set.filter(
+                        manuscript_full_text_std_spelling__icontains=keyword
+                    )
                 else:
                     chant_set = chant_set.filter(incipit__istartswith=keyword)
                     sequence_set = sequence_set.filter(incipit__istartswith=keyword)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -722,8 +722,6 @@ class ChantSearchView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
-                                     # for rendering chant_search.html template
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         display_unpublished = self.request.user.is_authenticated
@@ -975,8 +973,6 @@ class ChantSearchMSView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
-                                     # for rendering chant_search.html template
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         # If the "apply" button hasn't been clicked, return empty queryset

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -829,7 +829,7 @@ class ChantSearchView(ListView):
                     sequence_set = sequence_set.filter(incipit__istartswith=keyword)
 
             # once unioned, the queryset cannot be filtered/annotated anymore, so we put union to the last
-            queryset = chant_set.union(sequence_set)
+            queryset = chant_set.union(sequence_set, all=True)
             queryset = queryset.order_by(order, "id")
 
         return queryset

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -797,33 +797,34 @@ class ChantSearchView(ListView):
                 # as a substring
                 feasts = Feast.objects.filter(name__icontains=feast)
                 q_obj_filter &= Q(feast__in=feasts)
-            order: str = 'siglum'
             order_get_param: Optional[str] = self.request.GET.get('order')
             sort_get_param: Optional[str] = self.request.GET.get('sort')
-            if order_get_param is not None:
-                if order_get_param == 'siglum':
-                    pass # this is the default
-                elif order_get_param == 'incipit':
-                    order = 'incipit'
-                elif order_get_param == 'office':
-                    order = 'office'
-                elif order_get_param == 'genre':
-                    order = 'genre'
-                elif order_get_param == 'cantus_id':
-                    order = 'cantus_id'
-                elif order_get_param == 'mode':
-                    order = 'mode'
-                elif order_get_param == 'has_fulltext':
-                    order = 'manuscript_full_text'
-                elif order_get_param == 'has_melody':
-                    order = 'volpiano'
-                elif order_get_param == 'has_image':
-                    order = 'image_link'
+            
+            order_param_options = (
+                'incipit',
+                'office',
+                'genre',
+                'cantus_id',
+                'mode',
+                'has_fulltext',
+                'has_melody',
+                'has_image',
+            )
+            if order_get_param in order_param_options:
+                if order_get_param == "has_fulltext":
+                    order = "manuscript_full_text"
+                elif order_get_param == "has_melody":
+                    order = "volpiano"
+                elif order_get_param == "has_image":
+                    order = "image_link"
+                else:
+                    order = order_get_param
+            else:
+                order = 'siglum'
 
-            if sort_get_param and sort_get_param == "asc":
-                pass # this is the default
-            elif sort_get_param and sort_get_param == 'desc':
-                order = "-" + order
+            # sort values: "asc" and "desc". Default is "asc"
+            if sort_get_param and sort_get_param == 'desc':
+                order = f"-{order}"
 
             if not display_unpublished:
                 chant_set: QuerySet = Chant.objects.filter(source__published=True)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -846,7 +846,7 @@ class ChantSearchView(ListView):
                     keyword_filter = ms_spelling_filter | std_spelling_filter
                     chant_set = chant_set.filter(keyword_filter)
                     sequence_set = sequence_set.filter(keyword_filter)
-                elif operation == "starts_with":
+                else:
                     ms_spelling_filter = Q(
                         manuscript_full_text__istartswith=keyword
                     )
@@ -1076,7 +1076,7 @@ class ChantSearchMSView(ListView):
                 )
                 keyword_filter = ms_spelling_filter | std_spelling_filter
                 queryset.filter(keyword_filter)
-            elif operation == "starts_with":
+            else:
                 ms_spelling_filter = Q(
                     manuscript_full_text__istartswith=keyword
                 )

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -722,6 +722,11 @@ class ChantSearchView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
+        # if user has just arrived on the Chant Search page, there will be no
+        # GET parameters.
+        if not self.request.GET:
+            return Chant.objects.none()
+        
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         display_unpublished = self.request.user.is_authenticated
@@ -763,10 +768,6 @@ class ChantSearchView(ListView):
             # The field names should be keys in the "GET" QueryDict if the search button has been clicked,
             # even if the user put nothing into the search form and hit "apply" immediately.
             # In that case, we return the all chants + seqs filtered by the search form.
-            # On the contrary, if the user just arrived at the search page, there should be no params in GET
-            # In that case, we return an empty queryset.
-            if not self.request.GET:
-                return Chant.objects.none()
             # For every GET parameter other than incipit, add to the Q object
             if self.request.GET.get("office"):
                 office = self.request.GET.get("office")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -849,6 +849,9 @@ class ChantSearchView(ListView):
                     std_spelling_filter = Q(
                         manuscript_full_text_std_spelling__icontains=keyword
                     )
+                    incipit_filter = Q(
+                        incipit__icontains=keyword
+                    )
                 else:
                     ms_spelling_filter = Q(
                         manuscript_full_text__istartswith=keyword
@@ -856,7 +859,10 @@ class ChantSearchView(ListView):
                     std_spelling_filter = Q(
                         manuscript_full_text_std_spelling__istartswith=keyword
                     )
-                keyword_filter = ms_spelling_filter | std_spelling_filter
+                    incipit_filter = Q(
+                        incipit__istartswith=keyword
+                    )
+                keyword_filter = ms_spelling_filter | std_spelling_filter | incipit_filter
                 chant_set = chant_set.filter(keyword_filter)
                 sequence_set = sequence_set.filter(keyword_filter)
 
@@ -1051,8 +1057,9 @@ class ChantSearchMSView(ListView):
                 std_spelling_filter = Q(
                     manuscript_full_text_std_spelling__icontains=keyword
                 )
-                keyword_filter = ms_spelling_filter | std_spelling_filter
-                queryset.filter(keyword_filter)
+                incipit_filter = Q(
+                    incipit__icontains=keyword
+                )
             else:
                 ms_spelling_filter = Q(
                     manuscript_full_text__istartswith=keyword
@@ -1060,8 +1067,11 @@ class ChantSearchMSView(ListView):
                 std_spelling_filter = Q(
                     manuscript_full_text_std_spelling__istartswith=keyword
                 )
-                keyword_filter = ms_spelling_filter | std_spelling_filter
-                queryset.filter(keyword_filter)
+                incipit_filter = Q(
+                    incipit__istartswith=keyword
+                )
+            keyword_filter = ms_spelling_filter | std_spelling_filter | incipit_filter
+            queryset.filter(keyword_filter)
         # ordering with the folio string gives wrong order
         # old cantus is also not strictly ordered by folio (there are outliers)
         # so we order by id for now, which is the order that the chants are entered into the DB

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -722,8 +722,8 @@ class ChantSearchView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        global CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
-                                            # for rendering chant_search.html template
+        CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
+                                     # for rendering chant_search.html template
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         display_unpublished = self.request.user.is_authenticated
@@ -969,8 +969,8 @@ class ChantSearchMSView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        global CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
-                                            # for rendering chant_search.html template
+        CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
+                                     # for rendering chant_search.html template
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         # If the "apply" button hasn't been clicked, return empty queryset

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -27,30 +27,6 @@ from collections import Counter
 from django.contrib.auth.mixins import UserPassesTestMixin
 
 
-
-def keyword_search(queryset: QuerySet, keywords: str) -> QuerySet:
-    """
-    Performs a keyword search over a QuerySet
-
-    Uses PostgreSQL's full text search features
-
-    Args:
-        queryset (QuerySet): A QuerySet to be searched
-        keywords (str): A string of keywords to search the QuerySet
-
-    Returns:
-        QuerySet: A QuerySet filtered by keywords
-    """
-    query = SearchQuery(keywords)
-    rank_annotation = SearchRank(F("search_vector"), query)
-    filtered_queryset = (
-        queryset.annotate(rank=rank_annotation)
-        .filter(search_vector=query)
-        .order_by("-rank")
-    )
-    return filtered_queryset
-
-
 class ChantDetailView(DetailView):
     """
     Displays a single Chant object. Accessed with ``chants/<int:pk>``

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -793,40 +793,40 @@ class ChantSearchView(ListView):
                 # as a substring
                 feasts = Feast.objects.filter(name__icontains=feast)
                 q_obj_filter &= Q(feast__in=feasts)
-            if self.request.GET.get('order'):
-                if self.request.GET.get('order') == 'siglum':
-                    order = 'siglum'
-                elif self.request.GET.get('order') == 'incipit':
+            order: str = 'siglum'
+            order_get_param: Optional[str] = self.request.GET.get('order')
+            sort_get_param: Optional[str] = self.request.GET.get('sort')
+            if order_get_param is not None:
+                if order_get_param == 'siglum':
+                    pass # this is the default
+                elif order_get_param == 'incipit':
                     order = 'incipit'
-                elif self.request.GET.get('order') == 'office':
+                elif order_get_param == 'office':
                     order = 'office'
-                elif self.request.GET.get('order') == 'genre':
+                elif order_get_param == 'genre':
                     order = 'genre'
-                elif self.request.GET.get('order') == 'cantus_id':
+                elif order_get_param == 'cantus_id':
                     order = 'cantus_id'
-                elif self.request.GET.get('order') == 'mode':
+                elif order_get_param == 'mode':
                     order = 'mode'
-                elif self.request.GET.get('order') == 'has_fulltext':
+                elif order_get_param == 'has_fulltext':
                     order = 'manuscript_full_text'
-                elif self.request.GET.get('order') == 'has_melody':
+                elif order_get_param == 'has_melody':
                     order = 'volpiano'
-                elif self.request.GET.get('order') == 'has_image':
+                elif order_get_param == 'has_image':
                     order = 'image_link'
-                else:
-                    order = 'siglum'
-            else:
-                order = 'siglum'
-            if self.request.GET.get('sort'):
-                if self.request.GET.get('sort') == "asc":
-                    order = order
-                elif self.request.GET.get('sort') == 'desc':
-                    order = "-" + order
+
+            if sort_get_param and sort_get_param == "asc":
+                pass # this is the default
+            elif sort_get_param and sort_get_param == 'desc':
+                order = "-" + order
+
             if not display_unpublished:
-                chant_set = Chant.objects.filter(source__published=True)
-                sequence_set = Sequence.objects.filter(source__published=True)
+                chant_set: QuerySet = Chant.objects.filter(source__published=True)
+                sequence_set: QuerySet = Sequence.objects.filter(source__published=True)
             else:
-                chant_set = Chant.objects
-                sequence_set = Sequence.objects
+                chant_set: QuerySet = Chant.objects.all()
+                sequence_set: QuerySet = Sequence.objects.all()
             # Filter the QuerySet with Q object
             chant_set = chant_set.filter(q_obj_filter)
             sequence_set = sequence_set.filter(q_obj_filter)
@@ -836,8 +836,8 @@ class ChantSearchView(ListView):
             # Finally, do keyword searching over the querySet
             if self.request.GET.get("keyword"):
                 keyword = self.request.GET.get("keyword")
-                operation = self.request.GET.get("op")
-                if operation == "contains":
+                operation: Optional[str] = self.request.GET.get("op")
+                if operation and operation == "contains":
                     ms_spelling_filter = Q(
                         manuscript_full_text__icontains=keyword
                     )

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -25,6 +25,7 @@ from django.http import Http404
 from next_chants import next_chants
 from collections import Counter
 from django.contrib.auth.mixins import UserPassesTestMixin
+from typing import Optional
 
 
 class ChantDetailView(DetailView):
@@ -843,9 +844,6 @@ class ChantSearchView(ListView):
                     std_spelling_filter = Q(
                         manuscript_full_text_std_spelling__icontains=keyword
                     )
-                    keyword_filter = ms_spelling_filter | std_spelling_filter
-                    chant_set = chant_set.filter(keyword_filter)
-                    sequence_set = sequence_set.filter(keyword_filter)
                 else:
                     ms_spelling_filter = Q(
                         manuscript_full_text__istartswith=keyword
@@ -853,9 +851,9 @@ class ChantSearchView(ListView):
                     std_spelling_filter = Q(
                         manuscript_full_text_std_spelling__istartswith=keyword
                     )
-                    keyword_filter = ms_spelling_filter | std_spelling_filter
-                    chant_set = chant_set.filter(keyword_filter)
-                    sequence_set = sequence_set.filter(keyword_filter)
+                keyword_filter = ms_spelling_filter | std_spelling_filter
+                chant_set = chant_set.filter(keyword_filter)
+                sequence_set = sequence_set.filter(keyword_filter)
 
             # once unioned, the queryset cannot be filtered/annotated anymore, so we put union to the last
             queryset = chant_set.union(sequence_set, all=True)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -28,6 +28,35 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from typing import Optional
 
 
+CHANT_SEARCH_TEMPLATE_VALUES = (
+    # for views that use chant_search.html, this allows them to
+    # fetch only those values needed for rendering the template
+    "id",
+    "folio",
+    "search_vector",
+    "incipit",
+    "manuscript_full_text_std_spelling",
+    "position",
+    "cantus_id",
+    "mode",
+    "manuscript_full_text",
+    "volpiano",
+    "image_link",
+
+    "source__id",
+    "source__title",
+    "source__siglum",
+    "feast__id",
+    "feast__description",
+    "feast__name",
+    "office__id",
+    "office__description",
+    "office__name",
+    "genre__id",
+    "genre__description",
+    "genre__name",
+)
+
 class ChantDetailView(DetailView):
     """
     Displays a single Chant object. Accessed with ``chants/<int:pk>``
@@ -693,32 +722,8 @@ class ChantSearchView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        values_for_rendering_template = (
-            "id",
-            "folio",
-            "search_vector",
-            "incipit",
-            "manuscript_full_text_std_spelling",
-            "position",
-            "cantus_id",
-            "mode",
-            "manuscript_full_text",
-            "volpiano",
-            "image_link",
-
-            "source__id",
-            "source__title",
-            "source__siglum",
-            "feast__id",
-            "feast__description",
-            "feast__name",
-            "office__id",
-            "office__description",
-            "office__name",
-            "genre__id",
-            "genre__description",
-            "genre__name",
-        )
+        global CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
+                                            # for rendering chant_search.html template
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         display_unpublished = self.request.user.is_authenticated
@@ -732,12 +737,12 @@ class ChantSearchView(ListView):
                 chant_set = chant_set.filter(
                     manuscript_full_text_std_spelling__istartswith=incipit
                 ).values(
-                    *values_for_rendering_template
+                    *CHANT_SEARCH_TEMPLATE_VALUES
                 )
                 sequence_set = sequence_set.filter(
                     manuscript_full_text_std_spelling__istartswith=incipit
                 ).values(
-                    *values_for_rendering_template
+                    *CHANT_SEARCH_TEMPLATE_VALUES
                 )
                 queryset = chant_set.union(sequence_set, all=True)
             else:
@@ -747,12 +752,12 @@ class ChantSearchView(ListView):
                 chant_set = chant_set.filter(
                     q_obj_filter
                 ).values(
-                    *values_for_rendering_template
+                    *CHANT_SEARCH_TEMPLATE_VALUES
                 )
                 sequence_set = sequence_set.filter(
                     q_obj_filter
                 ).values(
-                    *values_for_rendering_template
+                    *CHANT_SEARCH_TEMPLATE_VALUES
                 )
                 queryset = chant_set.union(sequence_set, all=True)
 
@@ -831,8 +836,8 @@ class ChantSearchView(ListView):
             chant_set = chant_set.filter(q_obj_filter)
             sequence_set = sequence_set.filter(q_obj_filter)
             # Fetch only the values necessary for rendering the template
-            chant_set = chant_set.values(*values_for_rendering_template)
-            sequence_set = sequence_set.values(*values_for_rendering_template)
+            chant_set = chant_set.values(*CHANT_SEARCH_TEMPLATE_VALUES)
+            sequence_set = sequence_set.values(*CHANT_SEARCH_TEMPLATE_VALUES)
             # Finally, do keyword searching over the querySet
             if self.request.GET.get("keyword"):
                 keyword = self.request.GET.get("keyword")
@@ -964,34 +969,8 @@ class ChantSearchMSView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        values_for_rendering_template = (
-            # fetch only those database columns necessary for rendering
-            # the template
-            "id",
-            "folio",
-            "search_vector",
-            "incipit",
-            "manuscript_full_text_std_spelling",
-            "position",
-            "cantus_id",
-            "mode",
-            "manuscript_full_text",
-            "volpiano",
-            "image_link",
-
-            "source__id",
-            "source__title",
-            "source__siglum",
-            "feast__id",
-            "feast__description",
-            "feast__name",
-            "office__id",
-            "office__description",
-            "office__name",
-            "genre__id",
-            "genre__description",
-            "genre__name",
-        )
+        global CHANT_SEARCH_TEMPLATE_VALUES # in order to fetch only those values necessary
+                                            # for rendering chant_search.html template
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()
         # If the "apply" button hasn't been clicked, return empty queryset
@@ -1059,7 +1038,7 @@ class ChantSearchMSView(ListView):
         # Filter the QuerySet with Q object
         queryset = queryset.filter(q_obj_filter)
         # Fetch only the values necessary for rendering the template
-        queryset = queryset.values(*values_for_rendering_template)
+        queryset = queryset.values(*CHANT_SEARCH_TEMPLATE_VALUES)
         # Finally, do keyword searching over the QuerySet
         if self.request.GET.get("keyword"):
             keyword = self.request.GET.get("keyword")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -692,9 +692,7 @@ class ChantSearchView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        template_values = (
-            # fetch only those database columns necessary for rendering
-            # the template
+        values_for_rendering_template = (
             "id",
             "folio",
             "search_vector",
@@ -733,12 +731,12 @@ class ChantSearchView(ListView):
                 chant_set = chant_set.filter(
                     manuscript_full_text_std_spelling__istartswith=incipit
                 ).values(
-                    *template_values
+                    *values_for_rendering_template
                 )
                 sequence_set = sequence_set.filter(
                     manuscript_full_text_std_spelling__istartswith=incipit
                 ).values(
-                    *template_values
+                    *values_for_rendering_template
                 )
                 queryset = chant_set.union(sequence_set, all=True)
             else:
@@ -748,12 +746,12 @@ class ChantSearchView(ListView):
                 chant_set = chant_set.filter(
                     q_obj_filter
                 ).values(
-                    *template_values
+                    *values_for_rendering_template
                 )
                 sequence_set = sequence_set.filter(
                     q_obj_filter
                 ).values(
-                    *template_values
+                    *values_for_rendering_template
                 )
                 queryset = chant_set.union(sequence_set, all=True)
 
@@ -832,8 +830,8 @@ class ChantSearchView(ListView):
             chant_set = chant_set.filter(q_obj_filter)
             sequence_set = sequence_set.filter(q_obj_filter)
             # Fetch only the values necessary for rendering the template
-            chant_set = chant_set.values(*template_values)
-            sequence_set = sequence_set.values(*template_values)
+            chant_set = chant_set.values(*values_for_rendering_template)
+            sequence_set = sequence_set.values(*values_for_rendering_template)
             # Finally, do keyword searching over the querySet
             if self.request.GET.get("keyword"):
                 keyword = self.request.GET.get("keyword")
@@ -968,7 +966,7 @@ class ChantSearchMSView(ListView):
         return context
 
     def get_queryset(self) -> QuerySet:
-        template_values = (
+        values_for_rendering_template = (
             # fetch only those database columns necessary for rendering
             # the template
             "id",
@@ -1063,7 +1061,7 @@ class ChantSearchMSView(ListView):
         # Filter the QuerySet with Q object
         queryset = queryset.filter(q_obj_filter)
         # Fetch only the values necessary for rendering the template
-        queryset = queryset.values(*template_values)
+        queryset = queryset.values(*values_for_rendering_template)
         # Finally, do keyword searching over the QuerySet
         if self.request.GET.get("keyword"):
             keyword = self.request.GET.get("keyword")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -816,15 +816,15 @@ class ChantSearchView(ListView):
             # Finally, do keyword searching over the querySet
             if self.request.GET.get("keyword"):
                 keyword = self.request.GET.get("keyword")
-                # the operation parameter can be "contains" or "starts_with"
-                if self.request.GET.get("op") == "contains":
+                operation = self.request.GET.get("op")
+                if operation == "contains":
                     chant_set = chant_set.filter(
                         manuscript_full_text_std_spelling__icontains=keyword
                     )
                     sequence_set = sequence_set.filter(
                         manuscript_full_text_std_spelling__icontains=keyword
                     )
-                else:
+                elif operation == "starts_with":
                     chant_set = chant_set.filter(incipit__istartswith=keyword)
                     sequence_set = sequence_set.filter(incipit__istartswith=keyword)
 


### PR DESCRIPTION
This PR implements several changes to the Chant Search View in order to improve execution time:
- when a queryset containing Chants and a queryset containing Sequences are combined using `.union()`, we now pass an `all=True` argument to prevent Postgres from checking the resulting queryset to ensure all items are `DISTINCT` from each other
- we now apply `.values()` to fetch only the values needed for rendering the template
- these changes were applied to both ChantSearchView and ChantSearchMSView, since they both use the same template

Some other related changes occurred:
- updated tests for Chant Search View
- updated tests for Chant Search MS View
  - Also wrote a bunch of new tests in ChantSearchMSViewTest, mostly copied from ChantSearchViewTest, ensuring that the values/links/etc. in the cells of the table render correctly. Since we previously weren't testing this, the Chant Search MS page was initially broken by the changes in the template, and the all tests were passing even when they shouldn't have been. So it's a good thing these tests are now here!
- we no longer use `keyword_search`, previously used in both views mentioned above, so I was able to delete the function.
- some slight refactoring of how we handle query parameters, mostly to make the code more self-documenting

I tried to replace the `{% if chant.search_vector %}` field with an annotation, but I kept running into an error, `ORDER BY term does not match any column in the result set.` This will be a nice thing to refactor eventually, but it's not urgent, so I'll try to figure this out another time. Since we no longer use `keyword_search`, once this is done, we can remove the `search_vector` from our Chant/Sequence model.