### PR TITLE
chant_detail.html: add missing 'class=guillemet'

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -268,7 +268,7 @@
 
                 <h4>List of melodies</h4>
                 <span id="melodyLoadingPrompt" style="display: none; color: #922"><b>Loading melodies...</b></span>
-                <a id="melodyButton" href="#" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">Display the melodies connected with this chant</a>
+                <a id="melodyButton" href="#" class="guillemet" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">Display the melodies connected with this chant</a>
                 <div id="melodyDiv"></div>        
             {% endif %}
 


### PR DESCRIPTION
noticed while testing staging, there used to be a guillemet before "load melodies connected with this chant" on chant_detail.html.