### PR TITLE
Prevent UnboundLocalErrors from occurring

### DIFF
--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -69,6 +69,7 @@ def make_fake_chant(source=None,
     cantus_id=None,
     feast=None,
     manuscript_full_text_std_spelling=None,
+    incipit=None,
     manuscript_full_text_std_proofread=None,
     manuscript_full_text=None,
     volpiano=None,
@@ -97,6 +98,8 @@ def make_fake_chant(source=None,
         manuscript_full_text_std_spelling = make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         )
+    if incipit is None:
+        incipit = manuscript_full_text_std_spelling[0:INCIPIT_LENGTH]
     if manuscript_full_text_std_proofread is None:
         manuscript_full_text_std_proofread = False
     if manuscript_full_text is None:
@@ -127,7 +130,7 @@ def make_fake_chant(source=None,
         chant_range=make_fake_text(LONG_CHAR_FIELD_MAX),
         addendum=make_fake_text(LONG_CHAR_FIELD_MAX),
         manuscript_full_text_std_spelling=manuscript_full_text_std_spelling,
-        incipit=manuscript_full_text_std_spelling[0:INCIPIT_LENGTH],
+        incipit=incipit,
         manuscript_full_text_std_proofread=manuscript_full_text_std_proofread,
         manuscript_full_text=manuscript_full_text,
         manuscript_full_text_proofread=faker.boolean(),

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1545,6 +1545,40 @@ class SourceEditChantsViewTest(TestCase):
         )
         self.assertEqual(chant_2.volpiano, "abacadaeafagahaja")
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
+    
+    def test_chant_with_volpiano_with_no_fulltext(self):
+        # in the past, a Chant Edit page will error rather than loading properly when the chant has volpiano but no fulltext
+        source = make_fake_source()
+        chant = make_fake_chant(
+            source=source,
+            volpiano="1---f--e---f--d---e--c---d--d",
+            incipit="dies irae"
+        )
+        chant.manuscript_full_text = None
+        chant.manuscript_full_text_std_spelling = None
+        chant.save()
+        response = self.client.get(
+            reverse('source-edit-chants', args=[source.id]), 
+            {'pk': chant.id}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_chant_with_volpiano_with_no_incipit(self):
+        # in the past, a Chant Edit page will error rather than loading properly when the chant has volpiano but no fulltext/incipit
+        source = make_fake_source()
+        chant = make_fake_chant(
+            source=source,
+            volpiano="1---d---da--g--f--e---e-eg--fed---d-nmn-mn---d",
+        )
+        chant.manuscript_full_text = None
+        chant.manuscript_full_text_std_spelling = None
+        chant.incipit = None
+        chant.save()
+        response = self.client.get(
+            reverse('source-edit-chants', args=[source.id]), 
+            {'pk': chant.id}
+        )
+        self.assertEqual(response.status_code, 200)
 
 
 class ChantProofreadViewTest(TestCase):
@@ -1610,6 +1644,23 @@ class ChantProofreadViewTest(TestCase):
         self.assertEqual(response.status_code, 302) # 302 Found
         chant.refresh_from_db()
         self.assertIs(chant.manuscript_full_text_std_proofread, True)
+
+    def test_chant_with_volpiano_with_no_incipit(self):
+        # in the past, a Chant Proofread page will error rather than loading properly when the chant has volpiano but no fulltext/incipit
+        source = make_fake_source()
+        chant = make_fake_chant(
+            source=source,
+            volpiano="1---m---l---k---m---h",
+        )
+        chant.manuscript_full_text = None
+        chant.manuscript_full_text_std_spelling = None
+        chant.incipit = None
+        chant.save()
+        response = self.client.get(
+            reverse('source-edit-chants', args=[source.id]), 
+            {'pk': chant.id}
+        )
+        self.assertEqual(response.status_code, 200)
 
 
 class ChantEditSyllabificationViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -590,6 +590,38 @@ class ChantDetailViewTest(TestCase):
         expected_url_fragment = f"edit-chants/{source.id}?pk={chant.id}&folio={chant.folio}"
 
         self.assertIn(expected_url_fragment, str(response.content))
+    
+    def test_chant_with_volpiano_with_no_fulltext(self):
+        # in the past, a Chant Detail page will error rather than loading properly when the chant has volpiano but no fulltext
+        source = make_fake_source()
+        chant = make_fake_chant(
+            source=source,
+            volpiano="1---c--g--e---e---d---c---c---f---e---e--d---d---c",
+            incipit="somebody"
+        )
+        chant.manuscript_full_text = None
+        chant.manuscript_full_text_std_spelling = None
+        chant.save()
+        response = self.client.get(
+            reverse("chant-detail", args=[chant.id])
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_chant_with_volpiano_with_no_incipit(self):
+        # in the past, a Chant Detail page will error rather than loading properly when the chant has volpiano but no fulltext/incipit
+        source = make_fake_source()
+        chant = make_fake_chant(
+            source=source,
+            volpiano="1---g---a---g--a---g---e---c--e---|---f---g--f--g---f--d---9--d",
+        )
+        chant.manuscript_full_text = None
+        chant.manuscript_full_text_std_spelling = None
+        chant.incipit = None
+        chant.save()
+        response = self.client.get(
+            reverse("chant-detail", args=[chant.id])
+        )
+        self.assertEqual(response.status_code, 200)
 
 
 class ChantByCantusIDViewTest(TestCase):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1601,10 +1601,13 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         chant = self.get_object()
 
         # Preview of melody and text:
-        # in the old CantusDB,
+        # in OldCantus,
         # 'manuscript_syllabized_full_text' exists => preview constructed from 'manuscript_syllabized_full_text'
         # no 'manuscript_syllabized_full_text', but 'manuscript_full_text' exists => preview constructed from 'manuscript_full_text'
         # no 'manuscript_syllabized_full_text' and no 'manuscript_full_text' => preview constructed from 'manuscript_full_text_std_spelling'
+        # to this we add:
+        # no full text of any kind => preview constructed from `incipit`
+        # none of the above => show message explaining why melody preview has no text
 
         if chant.volpiano:
             syls_melody = syllabize_melody(chant.volpiano)
@@ -1621,6 +1624,11 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             elif chant.manuscript_full_text_std_spelling:
                 syls_text = syllabize_text(chant.manuscript_full_text_std_spelling, pre_syllabized=False)
                 syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            elif chant.incipit:
+                syls_text = syllabize_text(chant.incipit, pre_syllabized=False)
+                syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            else:
+                syls_text = [["(no saved Full Text or Incipit)"]]
 
             word_zip = align(syls_text, syls_melody)
             context["syllabized_text_with_melody"] = word_zip

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -86,9 +86,11 @@ class ChantDetailView(DetailView):
                     chant.manuscript_full_text, pre_syllabized=False
                 )
                 syls_text, syls_melody = postprocess(syls_text, syls_melody)
-            else:
+            elif chant.incipit:
                 syls_text = syllabize_text(chant.incipit, pre_syllabized=False)
                 syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            else:
+                syls_text = [[""]]
 
             word_zip = align(syls_text, syls_melody)
             context["syllabized_text_with_melody"] = word_zip

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -86,8 +86,14 @@ class ChantDetailView(DetailView):
                     chant.manuscript_full_text, pre_syllabized=False
                 )
                 syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            elif chant.manuscript_full_text_std_spelling:
+                syls_text = syllabize_text(
+                    chant.manuscript_full_text_std_spelling, pre_syllabized=False
+                )
             elif chant.incipit:
-                syls_text = syllabize_text(chant.incipit, pre_syllabized=False)
+                syls_text = syllabize_text(
+                    chant.incipit, pre_syllabized=False
+                )
                 syls_text, syls_melody = postprocess(syls_text, syls_melody)
             else:
                 syls_text = [[""]]

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1634,7 +1634,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
                 syls_text = syllabize_text(chant.incipit, pre_syllabized=False)
                 syls_text, syls_melody = postprocess(syls_text, syls_melody)
             else:
-                syls_text = [["(no saved Full Text or Incipit)"]]
+                syls_text = [[""]]
 
             word_zip = align(syls_text, syls_melody)
             context["syllabized_text_with_melody"] = word_zip


### PR DESCRIPTION
This PR provides a default syllabized text in situations where a chant has its `volpiano` set but has no full text (or incipit). It fixes #574, on Chant Proofread and Edit pages, and also prevents a similar error on Chant Detail pages. It also includes some new tests for these views, which only check that the response to a GET request has a 200 code.

Some implementation details:
- On Chant Detail page, we check for MS spelling full text, then standardized spelling full text, then incipit. Finding none of these, we render the volpiano with no text beneath
- On the Chant Edit/Proofread pages, we check all of the fields listed above. If we find none of them, we display a message explaining that there is no saved full text (hopefully this will be helpful for transcribers? Particularly since sometimes, the standardized spelling field will automatically be populated using text pulled (I think) from CI, so this lets them know that that text is not currently saved in the database). See screenshot below:

![Screen Shot 2023-03-03 at 3 09 46 PM](https://user-images.githubusercontent.com/58090591/222816797-5fe9b7d6-2573-4671-92da-314e0663f85e.png)
