### PR TITLE
Century Detail page: exclude links to source detail pages that user can't visit

### DIFF
--- a/django/cantusdb_project/main_app/templates/century_detail.html
+++ b/django/cantusdb_project/main_app/templates/century_detail.html
@@ -7,7 +7,7 @@
     </object>
     <h3>{{ century.name }}</h3>
     <ul>
-        {% for source in century.sources.all|dictsort:"title" %}
+        {% for source in sources|dictsort:"title" %}
             <li>
                 <a href="{% url 'source-detail' source.id %}">
                     {{ source.title }}

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -266,25 +266,25 @@ def make_fake_sequence(source=None, title=None, incipit=None, cantus_id=None) ->
 
 
 def make_fake_source(
-        published:Optional[bool] = None,
-        title:Optional[str] = None,
-        segment_name:Optional[str] = None,
-        segment:Optional[Segment] = None,
-        siglum:Optional[str] = None,
-        rism_siglum:Optional[RismSiglum] = None,
-        description:Optional[str] = None,
-        summary:Optional[str] = None,
-        provenance:Optional[Provenance] = None,
-        century:Optional[Century] = None,
-        full_source:Optional[bool] = None,
-        indexing_notes:Optional[str] = None,
+        published: bool = True,
+        title: Optional[str] = None,
+        segment_name: Optional[str] = None,
+        segment: Optional[Segment] = None,
+        siglum: Optional[str] = None,
+        rism_siglum: Optional[RismSiglum] = None,
+        description: Optional[str] = None,
+        summary: Optional[str] = None,
+        provenance: Optional[Provenance] = None,
+        century: Optional[Century] = None,
+        full_source: bool = True,
+        indexing_notes: Optional[str] = None,
     ) -> Source:
     """Generates a fake Source object."""
     # The cursus_choices and source_status_choices lists in Source are lists of
     # tuples and we only need the first element of each tuple
 
-    if published is None:
-        published = True
+    # if published...
+    #     published already defaults to True
     if title is None:
         title = faker.sentence()
     if segment_name is None:
@@ -309,8 +309,8 @@ def make_fake_source(
         provenance = make_fake_provenance()
     if century is None:
         century = make_fake_century()
-    if full_source is None:
-        full_source = True
+    # if full_source...
+    #     full_source already defaults to True
     if indexing_notes is None:
         indexing_notes = make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS,
@@ -329,6 +329,7 @@ def make_fake_source(
         description=description,
         summary=summary,
         provenance=provenance,
+        # century: ManyToManyField, must be set below
         full_source=full_source,
         indexing_notes=indexing_notes,
         provenance_notes=make_fake_text(

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -15,6 +15,8 @@ from main_app.models import Sequence
 from main_app.models import Source
 from django.contrib.auth import get_user_model
 
+from typing import Optional
+
 # Max values for two types of Char fields
 LONG_CHAR_FIELD_MAX = 255
 SHORT_CHAR_FIELD_MAX = 63
@@ -263,28 +265,56 @@ def make_fake_sequence(source=None, title=None, incipit=None, cantus_id=None) ->
     return sequence
 
 
-def make_fake_source(published=None, title=None, segment=None, segment_name=None, siglum=None, description=None, summary=None, provenance=None, full_source=None, rism_siglum=None, indexing_notes=None) -> Source:
+def make_fake_source(
+        published:Optional[bool]=None,
+        title:Optional[str]=None,
+        segment_name:Optional[str]=None,
+        segment:Optional[Segment]=None,
+        siglum:Optional[str]=None,
+        rism_siglum:Optional[RismSiglum]=None,
+        description:Optional[str]=None,
+        summary:Optional[str]=None,
+        provenance:Optional[Provenance]=None,
+        century:Optional[Century]=None,
+        full_source:Optional[bool]=None,
+        indexing_notes:Optional[str]=None,
+    ) -> Source:
     """Generates a fake Source object."""
     # The cursus_choices and source_status_choices lists in Source are lists of
     # tuples and we only need the first element of each tuple
 
-    if title is None:
-        title = faker.sentence()
-    if siglum is None:
-        siglum = make_fake_text(SHORT_CHAR_FIELD_MAX)
-    if description is None:
-        description = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        )
     if published is None:
         published = True
+    if title is None:
+        title = faker.sentence()
+    if segment_name is None:
+        segment_name = faker.sentence(nb_words=2)
     if segment is None:
         segment = make_fake_segment(name=segment_name)
+    if siglum is None:
+        siglum = make_fake_text(SHORT_CHAR_FIELD_MAX)
     if rism_siglum is None:
         rism_siglum = make_fake_rism_siglum()
+    if description is None:
+        description = make_fake_text(
+            max_size=MAX_NUMBER_TEXT_CHARS,
+            min_size=MIN_NUMBER_TEXT_CHARS,
+        )
     if summary is None:
         summary = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
+            max_size=MAX_NUMBER_TEXT_CHARS,
+            min_size=MIN_NUMBER_TEXT_CHARS,
+        )
+    if provenance is None:
+        provenance = make_fake_provenance()
+    if century is None:
+        century = make_fake_century()
+    if full_source is None:
+        full_source = True
+    if indexing_notes is None:
+        indexing_notes = make_fake_text(
+            max_size=MAX_NUMBER_TEXT_CHARS,
+            min_size=MIN_NUMBER_TEXT_CHARS,
         )
 
     cursus_choices = [x[0] for x in Source.cursus_choices]
@@ -293,34 +323,34 @@ def make_fake_source(published=None, title=None, segment=None, segment_name=None
     source = Source.objects.create(
         published=published,
         title=title,
+        segment=segment,
         siglum=siglum,
         rism_siglum=rism_siglum,
+        description=description,
+        summary=summary,
         provenance=provenance,
+        full_source=full_source,
+        indexing_notes=indexing_notes,
         provenance_notes=make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         ),
-        full_source=full_source,
         date=make_fake_text(SHORT_CHAR_FIELD_MAX),
         cursus=random.choice(cursus_choices),
-        segment=segment,
         source_status=random.choice(source_status_choices),
         complete_inventory=faker.boolean(),
-        summary=summary,
         liturgical_occasions=make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         ),
-        description=description,
         selected_bibliography=make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         ),
         image_link=faker.image_url(),
-        indexing_notes=indexing_notes,
         indexing_date=make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         ),
         json_info=None,
     )
-    source.century.set([make_fake_century()])
+    source.century.set([century])
     source.notation.set([make_fake_notation()])
     source.inventoried_by.set([make_fake_user()])
     source.full_text_entered_by.set([make_fake_user()])

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -266,18 +266,18 @@ def make_fake_sequence(source=None, title=None, incipit=None, cantus_id=None) ->
 
 
 def make_fake_source(
-        published:Optional[bool]=None,
-        title:Optional[str]=None,
-        segment_name:Optional[str]=None,
-        segment:Optional[Segment]=None,
-        siglum:Optional[str]=None,
-        rism_siglum:Optional[RismSiglum]=None,
-        description:Optional[str]=None,
-        summary:Optional[str]=None,
-        provenance:Optional[Provenance]=None,
-        century:Optional[Century]=None,
-        full_source:Optional[bool]=None,
-        indexing_notes:Optional[str]=None,
+        published:Optional[bool] = None,
+        title:Optional[str] = None,
+        segment_name:Optional[str] = None,
+        segment:Optional[Segment] = None,
+        siglum:Optional[str] = None,
+        rism_siglum:Optional[RismSiglum] = None,
+        description:Optional[str] = None,
+        summary:Optional[str] = None,
+        provenance:Optional[Provenance] = None,
+        century:Optional[Century] = None,
+        full_source:Optional[bool] = None,
+        indexing_notes:Optional[str] = None,
     ) -> Source:
     """Generates a fake Source object."""
     # The cursus_choices and source_status_choices lists in Source are lists of

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -350,6 +350,35 @@ class CenturyDetailViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "base.html")
         self.assertTemplateUsed(response, "century_detail.html")
+    
+    def test_listed_sources(self):
+        century = make_fake_century()
+        century_sources = [
+            make_fake_source(century=century, published=True)
+            for _ in range(5)
+        ]
+        response = self.client.get(reverse("century-detail", args=[century.id]))
+        returned_sources = response.context["sources"]
+        for source in century_sources:
+            self.assertIn(source, returned_sources)
+
+    def test_unpublished_sources_not_listed(self):
+        century = make_fake_century()
+        published_sources = [
+            make_fake_source(century=century, published=True)
+            for _ in range(5)
+        ]
+        unpublished_sources = [
+            make_fake_source(century=century, published=False)
+            for _ in range(5)
+        ]
+        response = self.client.get(reverse("century-detail", args=[century.id]))
+        returned_sources = response.context["sources"]
+        for source in published_sources:
+            self.assertIn(source, returned_sources)
+        for source in unpublished_sources:
+            self.assertNotIn(source, returned_sources)
+
 
 
 class ChantListViewTest(TestCase):

--- a/django/cantusdb_project/main_app/views/century.py
+++ b/django/cantusdb_project/main_app/views/century.py
@@ -12,10 +12,9 @@ class CenturyDetailView(DetailView):
         century = self.get_object()
         user = self.request.user
         display_unpublished = user.is_authenticated
-        print(display_unpublished)
         sources = Source.objects.filter(century=century)
         if not display_unpublished:
-            print("filtering chants!    ")
             sources = sources.filter(published=True)
+        sources=sources.only("title", "id")
         context["sources"] = sources
         return context

--- a/django/cantusdb_project/main_app/views/century.py
+++ b/django/cantusdb_project/main_app/views/century.py
@@ -1,13 +1,13 @@
 from django.views.generic import DetailView
 from main_app.models import Century, Source
-from typing import Any, Dict
+from typing import Any
 
 class CenturyDetailView(DetailView):
     model = Century
     context_object_name = "century"
     template_name = "century_detail.html"
 
-    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         century = self.get_object()
         user = self.request.user

--- a/django/cantusdb_project/main_app/views/century.py
+++ b/django/cantusdb_project/main_app/views/century.py
@@ -1,7 +1,21 @@
 from django.views.generic import DetailView
-from main_app.models import Century
+from main_app.models import Century, Source
+from typing import Any, Dict
 
 class CenturyDetailView(DetailView):
     model = Century
     context_object_name = "century"
     template_name = "century_detail.html"
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        century = self.get_object()
+        user = self.request.user
+        display_unpublished = user.is_authenticated
+        print(display_unpublished)
+        sources = Source.objects.filter(century=century)
+        if not display_unpublished:
+            print("filtering chants!    ")
+            sources = sources.filter(published=True)
+        context["sources"] = sources
+        return context


### PR DESCRIPTION
This PR fixes #581.

In all, it:
- Changes `CenturyDetailView` to exclude private sources when the user is not logged in, and tweaks `century_detail.html` to accommodate these changes.
- Adds several tests to `CenturyDetailViewTest` to ensure that all the right sources, and none of the wrong sources, are being displayed on the Century Detail page
- tweaks `make_fake_source`, adding a `century` parameter, to accommodate the new tests just mentioned
  - in doing so, I took the opportunity to reorder some of the parameters/logic so that they're consistent, and add type annotations.