### PR TITLE
Full Index/Inventory page - for sources in bower segment, fix broken urls and fix ordering of sequences

### DIFF
--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -54,9 +54,9 @@
                     <td>{{ chant.marginalia|default_if_none:"" }}</td>
                     <td>{{ chant.folio|default_if_none:"" }}</td>
                     <td>
-                        {% if chant.is_chant %}
+                        {% if chant.record_type == "chant" %}
                             {{ chant.c_sequence }}
-                        {% elif chant.is_sequence %}
+                        {% elif chant.record_type == "sequence" %}
                             {{ chant.s_sequence }}
                         {% endif %}
                     </td>
@@ -77,9 +77,9 @@
                     </td>
                     <td>{{ chant.position|default_if_none:"" }}</td>
                     <td>
-                        {% if chant.is_chant %}
+                        {% if chant.record_type == "chant" %}
                             <a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a>
-                        {% elif chant.is_sequence %}
+                        {% elif chant.record_type == "sequence" %}
                             <a href="{% url 'sequence-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a>
                         {% endif %}
                     </td>

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -54,10 +54,10 @@
                     <td>{{ chant.marginalia|default_if_none:"" }}</td>
                     <td>{{ chant.folio|default_if_none:"" }}</td>
                     <td>
-                        {% if chant.c_sequence is not None %}
+                        {% if chant.is_chant %}
                             {{ chant.c_sequence }}
-                        {% else %}
-                            {{ chant.s_sequence|default_if_none:"" }}
+                        {% elif chant.is_sequence %}
+                            {{ chant.s_sequence }}
                         {% endif %}
                     </td>
                     <td>

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -76,7 +76,13 @@
                         </span>
                     </td>
                     <td>{{ chant.position|default_if_none:"" }}</td>
-                    <td><a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a></td>
+                    <td>
+                        {% if chant.is_chant %}
+                            <a href="{% url 'chant-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a>
+                        {% elif chant.is_sequence %}
+                            <a href="{% url 'sequence-detail' chant.id %}" target="_blank">{{ chant.incipit|default_if_none:"" }}</a>
+                        {% endif %}
+                    </td>
                     <td>{{ chant.cantus_id|default_if_none:"" }}</td>
                     <td>{{ chant.mode|default_if_none:"" }}</td>
                     <td>{{ chant.differentia|default_if_none:"" }}</td>

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -5,7 +5,7 @@ import json
 import threading
 from django.contrib import messages
 from django.contrib.postgres.search import SearchQuery, SearchRank
-from django.db.models import F, Q, QuerySet
+from django.db.models import F, Q, QuerySet, Value
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.generic import (
@@ -1389,9 +1389,17 @@ class ChantIndexView(TemplateView):
 
         # 4064 is the id for the sequence database
         if source.segment.id == 4064:
-            queryset = source.sequence_set.order_by("folio", "s_sequence")
+            queryset = source.sequence_set.annotate(
+                is_sequence=Value(True)
+            ).annotate(
+                is_chant=Value(False)
+            ).order_by("folio", "s_sequence")
         else:
-            queryset = source.chant_set.order_by("folio", "c_sequence")
+            queryset = source.chant_set.annotate(
+                is_sequence=Value(False)
+            ).annotate(
+                is_chant=Value(True)
+            ).order_by("folio", "c_sequence")
 
         context["source"] = source
         context["chants"] = queryset

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1393,7 +1393,7 @@ class ChantIndexView(TemplateView):
                 is_sequence=Value(True)
             ).annotate(
                 is_chant=Value(False)
-            ).order_by("folio", "s_sequence")
+            ).order_by("s_sequence")
         else:
             queryset = source.chant_set.annotate(
                 is_sequence=Value(False)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1390,15 +1390,11 @@ class ChantIndexView(TemplateView):
         # 4064 is the id for the sequence database
         if source.segment.id == 4064:
             queryset = source.sequence_set.annotate(
-                is_sequence=Value(True)
-            ).annotate(
-                is_chant=Value(False)
+                record_type=Value("sequence")
             ).order_by("s_sequence")
         else:
             queryset = source.chant_set.annotate(
-                is_sequence=Value(False)
-            ).annotate(
-                is_chant=Value(True)
+                record_type=Value("chant")
             ).order_by("folio", "c_sequence")
 
         context["source"] = source


### PR DESCRIPTION
Several things are happening in this PR:
- in the Full Index/Inventory view, we annotate the chant set indicating whether each object is a Chant or a Sequence
- In the template, we use these annotations to ensure we generate URLs to the right detail page (chant-detail or sequence-detail) (i.e. fixes #584)
- these annotations are also used to decide between displaying an object's `c_sequence` or `s_sequence`.
- While working in the Full Index view, I took the opportunity to fix the ordering of sequences (for chants, `c_sequence` indicates position/ordering on the folio, whereas for sequences, `s_sequence` indicates its ordering in an entire manuscript) (i.e. fixes #583)