### PR TITLE
bump python from 3.8 to 3.9

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 # start from an official image
-FROM python:3.8
+FROM python:3.9
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
Evidently I forgot to run tests for one of my recent PRs, because type hints of the form `foo: dict[str]` (as opposed to `Dict`) causes errors in python<=3.8... 