### PR TITLE
docker-compose: change postgres version to postgres:14-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - django
 
   postgres:
-    image: postgres:alpine
+    image: postgres:14-alpine
     env_file: ./config/envs/dev_env
     volumes:
       - postgres_data:/var/lib/postgresql/data/


### PR DESCRIPTION
`postgres:alpine` used to indicate Postgres 14 in dockerhub, now it indicates Postgres 15. Specifying `postgres:14-alpine` should resolve the issue of the two versions of the database being incompatible.