### PR TITLE
Update `load_fixtures.sh` and create `create_fixtures.sh`

### DIFF
--- a/django/cantusdb_project/create_fixtures.sh
+++ b/django/cantusdb_project/create_fixtures.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This script runs the commands necessary to export fixtures from a working version
+# of CantusDB, putting them all in a single folder, fixtures/ .
+# They can then be unpacked in a fresh clone of CantusDB by running break_json.py
+# followed by load_fixtures.sh .
+# This file should be in the same directory as manage.py .
+# Run this file inside the django container with `bash create_fixtures.sh`.
+
+mkdir fixtures
+
+echo "creating group_fixture.json"
+python manage.py dumpdata auth.Group -o fixtures/group_fixture.json --indent 4
+
+echo "creating user_fixture.json"
+python manage.py dumpdata users.User -o fixtures/user_fixture.json --indent 4
+
+echo "creating flatpage_fixture.json"
+python manage.py dumpdata flatpages -o fixtures/flatpage_fixture.json --indent 4
+
+echo "creating article_fixture.json"
+python manage.py dumpdata articles.Article -o fixtures/article_fixture.json --indent 4
+
+echo "creating office_fixture.json"
+python manage.py dumpdata main_app.Office -o fixtures/office_fixture.json --indent 4
+
+echo "creating genre_fixture.json"
+python manage.py dumpdata main_app.Genre -o fixtures/genre_fixture.json --indent 4
+
+echo "creating feast_fixture.json"
+python manage.py dumpdata main_app.Feast -o fixtures/feast_fixture.json --indent 4
+
+echo "creating notation_fixture.json"
+python manage.py dumpdata main_app.Notation -o fixtures/notation_fixture.json --indent 4
+
+echo "creating century_fixture.json"
+python manage.py dumpdata main_app.Century -o fixtures/century_fixture.json --indent 4
+
+echo "creating provenance_fixture.json"
+python manage.py dumpdata main_app.Provenance -o fixtures/provenance_fixture.json --indent 4
+
+echo "creating rism_siglum_fixture.json"
+python manage.py dumpdata main_app.RismSiglum -o fixtures/rism_siglum_fixture.json --indent 4
+
+echo "creating segment_fixture.json"
+python manage.py dumpdata main_app.Segment -o fixtures/segment_fixture.json --indent 4
+
+echo "creating source_fixture.json"
+python manage.py dumpdata main_app.Source -o fixtures/source_fixture.json --indent 4
+
+echo "creating sequence_fixture.json"
+python manage.py dumpdata main_app.Sequence -o fixtures/sequence_fixture.json --indent 4
+
+
+echo "creating chant_fixture.json"
+python manage.py dumpdata main_app.Chant -o fixtures/chant_fixture.json --indent 4

--- a/django/cantusdb_project/load_fixtures.sh
+++ b/django/cantusdb_project/load_fixtures.sh
@@ -22,6 +22,7 @@ FIXTURES_LIST=(
    segment_fixture.json
    source_fixture.json
    sequence_fixture.json
+   article_fixture.json
 )
 
 for fixture in ${FIXTURES_LIST[*]}

--- a/django/cantusdb_project/load_fixtures.sh
+++ b/django/cantusdb_project/load_fixtures.sh
@@ -31,6 +31,11 @@ do
    python manage.py loaddata $fixture
 done
 
+# N.B. As of March 2023, the following part of this script is broken.
+# Most Chants in the database have another Chant specified as their `next_chant`.
+# If a given Chant's `next_chant` has not yet been loaded, the given Chant
+# will also fail to be loaded into the database.
+
 # load all the chants, this takes a few hours as we have half a million chants
 FILES=./main_app/fixtures/chant_fixtures/*
 for f in $FILES

--- a/django/cantusdb_project/load_fixtures.sh
+++ b/django/cantusdb_project/load_fixtures.sh
@@ -12,7 +12,6 @@ FIXTURES_LIST=(
    group_fixture.json
    user_fixture.json
    flatpage_fixture.json
-   indexer_fixture.json
    office_fixture.json
    genre_fixture.json
    feast_fixture.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - django
 
   postgres:
-    image: postgres:alpine
+    image: postgres:14-alpine
     env_file: ./config/envs/dev_env
     volumes:
       - postgres_data:/var/lib/postgresql/data/


### PR DESCRIPTION
This PR updates a script used to load data into the database and creates a new script to make it simpler to export data from a running instance of CantusDB.

It updates `load_fixtures.sh`, by:
- removing `indexer_fixture.json` from the list of fixtures to import (we no longer have an indexer model)
- adding `article_fixture.json` (this had not been updated following the introduction of the `articles` app and the `Article` model)

It adds a new file, `create_fixtures.sh`. If one is exporting data from an existing instance of CantusDB, this script can be used to ensure all the fixtures necessary for running `load_fixtures.sh` are created.

(Hopefully, once we have all the instances of CantusDB running the same version of postgres, these changes will be somewhat moot, since we'll be able to export and install the postgres database _in toto_, but the changes in this PR will at least ensure that the "The beaten path (done many times, surely works)" detailed in the [Wiki](https://github.com/DDMAL/CantusDB/wiki/Getting-Started-with-Development) are up-to-date and working.)

(Note to future Jacob: It seems that the change to `docker-compose.yml` came along for the ride too, so probably best to wait on merging this PR until #590 has been merged.)