### PR TITLE
Write tests for Full Inventory view

### DIFF
--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -62,7 +62,9 @@ def make_fake_century() -> Century:
     return century
 
 
-def make_fake_chant(source=None,
+def make_fake_chant(
+    source=None,
+    marginalia=None,
     folio=None,
     office=None,
     genre=None,
@@ -81,6 +83,8 @@ def make_fake_chant(source=None,
     """Generates a fake Chant object."""
     if source is None:
         source = make_fake_source(segment_name="CANTUS Database")
+    if marginalia is None:
+        marginalia = make_fake_text(63)
     if folio is None:
         # two digits and one letter
         folio = faker.bothify("##?")
@@ -116,7 +120,7 @@ def make_fake_chant(source=None,
 
     chant = Chant.objects.create(
         source=source,
-        marginalia=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        marginalia=marginalia,
         folio=folio,
         c_sequence=c_sequence,
         office=office,

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -79,6 +79,7 @@ def make_fake_chant(
     volpiano=None,
     manuscript_syllabized_full_text=None,
     next_chant=None,
+    differentia=None,
 ) -> Chant:
     """Generates a fake Chant object."""
     if source is None:
@@ -101,9 +102,7 @@ def make_fake_chant(
     if feast is None:
         feast = make_fake_feast()
     if manuscript_full_text_std_spelling is None:
-        manuscript_full_text_std_spelling = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        )
+        manuscript_full_text_std_spelling = faker.sentence()
     if incipit is None:
         incipit = manuscript_full_text_std_spelling[0:INCIPIT_LENGTH]
     if manuscript_full_text_std_proofread is None:
@@ -116,6 +115,8 @@ def make_fake_chant(
         manuscript_syllabized_full_text = make_fake_text(
             max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
         )
+    if differentia is None:
+        differentia = make_fake_text(SHORT_CHAR_FIELD_MAX)
         
 
     chant = Chant.objects.create(
@@ -130,7 +131,7 @@ def make_fake_chant(
         cantus_id=cantus_id,
         feast=feast,
         mode=make_fake_text(SHORT_CHAR_FIELD_MAX),
-        differentia=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        differentia=differentia,
         finalis=make_fake_text(SHORT_CHAR_FIELD_MAX),
         extra=make_fake_text(SHORT_CHAR_FIELD_MAX),
         chant_range=make_fake_text(LONG_CHAR_FIELD_MAX),
@@ -252,7 +253,7 @@ def make_fake_sequence(source=None, title=None, incipit=None, cantus_id=None) ->
         incipit=incipit,
         # folio in the form of two digits and one letter
         folio=faker.bothify("##?"),
-        s_sequence=make_fake_text(LONG_CHAR_FIELD_MAX),
+        s_sequence=make_fake_text(SHORT_CHAR_FIELD_MAX),
         genre=make_fake_genre(),
         rubrics=make_fake_text(LONG_CHAR_FIELD_MAX),
         analecta_hymnica=make_fake_text(LONG_CHAR_FIELD_MAX),


### PR DESCRIPTION
fixes #586

Note: in several places I build an `expected_html_substring` and test that the response content includes it. But in some tests, I don't. In the situations where I don't include an expected substring, it's because there's messy whitespace in the template at that point.