### PR TITLE
Prevent table of concordances from displaying on Sequence Detail page when cantus_id is None

### DIFF
--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -169,52 +169,55 @@
         </div>
     </dl>
 
-    <h4>Concordances</h4>
-    <small>Concordances for Cantus ID <a href="{{ sequence.get_ci_url }}" target=_blank>{{ sequence.cantus_id }}</a>: Displaying 1 - {{ concordances.count }} of {{ concordances.count }}</small>
-    <table class="table table-sm small table-bordered">
-        <thead>
-            <tr>
-                <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Incipit</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
-                <th scope="col" class="text-wrap" style="text-align:center">AH</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for sequence in concordances %}
+    {% if sequence.cantus_id %}
+
+        <h4>Concordances</h4>
+        <small>Concordances for Cantus ID <a href="{{ sequence.get_ci_url }}" target=_blank>{{ sequence.cantus_id }}</a>: Displaying 1 - {{ concordances.count }} of {{ concordances.count }}</small>
+        <table class="table table-sm small table-bordered">
+            <thead>
                 <tr>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if sequence.source %}
-                            <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}"><b>{{ sequence.siglum }}</b></a>
-                            <br>
-                            <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        <a href="{% url 'sequence-detail' sequence.id %}">{{ sequence.incipit|default:"" }}</a>
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {{ sequence.rubrics|default:"" }}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {{ sequence.analecta_hymnica|default:"" }}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {{ sequence.col1|default:"" }}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {{ sequence.col2|default:"" }}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {{ sequence.col3|default:"" }}
-                    </td>
+                    <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Incipit</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">AH</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                {% for sequence in concordances %}
+                    <tr>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if sequence.source %}
+                                <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}"><b>{{ sequence.siglum }}</b></a>
+                                <br>
+                                <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{% url 'sequence-detail' sequence.id %}">{{ sequence.incipit|default:"" }}</a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.rubrics|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.analecta_hymnica|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.col1|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.col2|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.col3|default:"" }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
 </div>
 
 {% endblock %}

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2702,6 +2702,21 @@ class SequenceDetailViewTest(TestCase):
         response = self.client.get(reverse("sequence-detail", args=[sequence.id]))
         concordances = response.context["concordances"]
         self.assertIn(sequence_with_same_cantus_id, concordances)
+    
+    def test_sequence_without_cantus_id(self):
+        sequence = make_fake_sequence()
+        sequence.cantus_id = None
+        sequence.save()
+        response = self.client.get(reverse("sequence-detail", args=[sequence.id]))
+        html = str(response.content)
+        # Since sequence's cantus_id is None, there should be no table of
+        # concordances displayed, and we shouldn't display "None" anywhere
+        self.assertNotIn("Concordances", html)
+        self.assertNotIn("None", html)
+        # This is just to ensure that `html`, `response`, etc. are working
+        # correctly, i.e. that the `self.assertNotIn`s above are not passing
+        # for an unrelated reason
+        self.assertIn("Siglum", html)
 
 
 class SequenceEditViewTest(TestCase):


### PR DESCRIPTION
fixes #597 

This fix was not the highest priority, but it was simple to do so I figured I'd just get it out of the way. I also added a test to SequenceDetailViewTest to ensure this bug doesn't re-emerge.