### PR TITLE
Fix `make_fakes.py` by removing function `make_fake_text()`

### DIFF
--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -17,17 +17,8 @@ from django.contrib.auth import get_user_model
 
 from typing import Optional, List
 
-# Max values for two types of Char fields
-LONG_CHAR_FIELD_MAX = 255
-SHORT_CHAR_FIELD_MAX = 63
-
 # Max positive integer accepted by Django's positive integer field
 MAX_SEQUENCE_NUMBER = 2147483647
-
-# The smallest full text would have 10 chars at least
-MIN_NUMBER_TEXT_CHARS = 10
-# Picked 10000 for performance reasons, much bigger than that got slow
-MAX_NUMBER_TEXT_CHARS = 10000
 
 # The incipit will be up to 100 characters of the full text
 INCIPIT_LENGTH = 100

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -15,7 +15,7 @@ from main_app.models import Sequence
 from main_app.models import Source
 from django.contrib.auth import get_user_model
 
-from typing import Optional
+from typing import Optional, List
 
 # Max values for two types of Char fields
 LONG_CHAR_FIELD_MAX = 255
@@ -35,57 +35,112 @@ INCIPIT_LENGTH = 100
 # Create a Faker instance with locale set to Latin
 faker = Faker("la")
 
-
-def make_fake_text(max_size: int, min_size: int = 5) -> str:
-    """Generates fake text using with the Faker module.
-
-    Size will be a random size between ``max_size`` and ``min_size``.
-
-    Since it uses the Faker module it will ouput a random text in the language
-    of the locale set by Faker.
+def make_random_string(length: int,
+                       characters: str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"):
+    """Return a random string of a specified length.
 
     Args:
-        max_size (int): Maximum size of the text.
-        min_size (int, optional): Minimum size of the string. 
-        Defaults to 5 because `faker.text` can only generate at least 5 characters.
+        length (int): Length of the generated string.
+        characters (str, optional): Pool of characters to draw from while generating the string.
+            Defaults to string.ascii_uppercase.
 
     Returns:
-        str: The fake text.
+        str: a string composed of random characters.
     """
-    random_str = faker.text(max_nb_chars=random.randint(min_size, max_size))
-    return random_str
+    return "".join(
+        characters[random.randrange(len(characters))]
+        for _
+        in range(length)
+    )
 
+def make_fake_volpiano(words: int = 5,
+                       syllables_per_word: int = 2,
+                       neumes_per_syllable: int = 2,
+                       notes_per_neume: int = 2) -> str:
+    """Generates a random string of volpiano.
 
+    Args:
+        words (int, optional): The number of volpiano words (i.e. substrings separated by "---") to generate. 
+            Defaults to 5.
+        syllables_per_word (int, optional): The number of volpiano syllables (i.e. substrings separated by "--") to generate in each word.
+            Defaults to 2.
+        neumes_per_syllable (int, optional): The number of volpiano neumes (i.e. substrings separated by "-") to generate in each syllable.
+            Defaults to 2.
+        notes_per_neume (int, optional): The number of volpiano notes to generate in each neume.
+            Defaults to 2.
+
+    Raises:
+        ValueError if any argument is less than 1.
+
+    Returns:
+        str: A string of valid volpiano, with a treble clef at the beginning and a barline at the end.
+    """
+    NOTES = "abcdefghklmnABCDEFGHKLMN"
+    BARLINES = ("3", "4") # 3: single barline, 4: double barline
+    if not words >= 1:
+        raise ValueError("words must be >= 1")
+    elif not syllables_per_word >= 1:
+        raise ValueError("syllables_per_word must be >= 1")
+    elif not neumes_per_syllable >= 1:
+        raise ValueError("neumes_per_syllable must be >= 1")
+    elif not notes_per_neume >= 1:
+        raise ValueError("notes_per_neume must be >= 1")
+    
+    words_: List[List[List[str]]] = []
+    for _ in range(words):
+        syllables: List[List[str]]= []
+        for __ in range(syllables_per_word):
+            neumes: List[str] = []
+            for ___ in range(neumes_per_syllable):
+                notes = []
+                for ____ in range(notes_per_neume):
+                    note = random.choice(NOTES)
+                    notes.append(
+                        note
+                    )
+                neumes.append(
+                    "".join(notes)
+                )
+            syllables.append(
+                "-".join(neumes)
+            )
+        words_.append(
+            "--".join(syllables)
+        )
+    treble_clef = "1---"
+    final_barline = f"---{random.choice(BARLINES)}"
+    volpiano = treble_clef + "---".join(words_) + final_barline
+    return volpiano
+            
+            
 def make_fake_century() -> Century:
     """Generates a fake Century object."""
-    century = Century.objects.create(name=make_fake_text(LONG_CHAR_FIELD_MAX))
+    century = Century.objects.create(name=faker.sentence(nb_words=3))
     return century
 
 
-def make_fake_chant(
-    source=None,
-    marginalia=None,
-    folio=None,
-    office=None,
-    genre=None,
-    position=None,
-    c_sequence=None,
-    cantus_id=None,
-    feast=None,
-    manuscript_full_text_std_spelling=None,
-    incipit=None,
-    manuscript_full_text_std_proofread=None,
-    manuscript_full_text=None,
-    volpiano=None,
-    manuscript_syllabized_full_text=None,
-    next_chant=None,
-    differentia=None,
-) -> Chant:
+def make_fake_chant(source=None,
+                    marginalia=None,
+                    folio=None,
+                    office=None,
+                    genre=None,
+                    position=None,
+                    c_sequence=None,
+                    cantus_id=None,
+                    feast=None,
+                    manuscript_full_text_std_spelling=None,
+                    incipit=None,
+                    manuscript_full_text_std_proofread=None,
+                    manuscript_full_text=None,
+                    volpiano=None,
+                    manuscript_syllabized_full_text=None,
+                    next_chant=None,
+                    differentia=None) -> Chant:
     """Generates a fake Chant object."""
     if source is None:
         source = make_fake_source(segment_name="CANTUS Database")
     if marginalia is None:
-        marginalia = make_fake_text(63)
+        marginalia = make_random_string(1)
     if folio is None:
         # two digits and one letter
         folio = faker.bothify("##?")
@@ -94,11 +149,11 @@ def make_fake_chant(
     if genre is None:
         genre = make_fake_genre()
     if position is None:
-        position = make_fake_text(SHORT_CHAR_FIELD_MAX)
+        position = make_random_string(1)
     if c_sequence is None:
         c_sequence = random.randint(1, MAX_SEQUENCE_NUMBER)
     if cantus_id is None:
-        cantus_id = faker.numerify("######")
+        cantus_id = make_random_string(6, "0123456789")
     if feast is None:
         feast = make_fake_feast()
     if manuscript_full_text_std_spelling is None:
@@ -110,13 +165,11 @@ def make_fake_chant(
     if manuscript_full_text is None:
         manuscript_full_text = manuscript_full_text_std_spelling
     if volpiano is None:
-        volpiano = make_fake_text(20)
+        volpiano = make_fake_volpiano()
     if manuscript_syllabized_full_text is None:
-        manuscript_syllabized_full_text = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        )
+        manuscript_syllabized_full_text = faker.sentence(20)
     if differentia is None:
-        differentia = make_fake_text(SHORT_CHAR_FIELD_MAX)
+        differentia = make_random_string(2)
         
 
     chant = Chant.objects.create(
@@ -127,15 +180,19 @@ def make_fake_chant(
         office=office,
         genre=genre,
         position=position,
-        # cantus_id in the form of six digits
         cantus_id=cantus_id,
         feast=feast,
-        mode=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        mode=make_random_string(1, "0123456789*?"),
         differentia=differentia,
-        finalis=make_fake_text(SHORT_CHAR_FIELD_MAX),
-        extra=make_fake_text(SHORT_CHAR_FIELD_MAX),
-        chant_range=make_fake_text(LONG_CHAR_FIELD_MAX),
-        addendum=make_fake_text(LONG_CHAR_FIELD_MAX),
+        finalis=make_random_string(1, "abcdefg"),
+        extra=make_random_string(3, "0123456789"),
+        chant_range=make_fake_volpiano(
+            words=1,
+            syllables_per_word=1,
+            neumes_per_syllable=1,
+            notes_per_neume=1
+        ).replace("---", "-"), # chant_range is of the form "1-x-y-4", x, y are volpiano notes
+        addendum=make_random_string(3, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
         manuscript_full_text_std_spelling=manuscript_full_text_std_spelling,
         incipit=incipit,
         manuscript_full_text_std_proofread=manuscript_full_text_std_proofread,
@@ -144,12 +201,10 @@ def make_fake_chant(
         volpiano=volpiano,
         volpiano_proofread=faker.boolean(),
         image_link=faker.image_url(),
-        cao_concordances=make_fake_text(SHORT_CHAR_FIELD_MAX),
-        melody_id=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        cao_concordances=make_random_string(12, "ABCDEFGHIJKLMNOPQRSTUVWXYZ  "),
+        melody_id="m" + make_random_string(8, "0123456789."),
         manuscript_syllabized_full_text=manuscript_syllabized_full_text,
-        indexing_notes=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        indexing_notes=faker.sentence(),
         json_info=None,
         next_chant=next_chant,
     )
@@ -161,11 +216,8 @@ def make_fake_feast() -> Feast:
     feast = Feast.objects.create(
         name=faker.sentence(),
         description=faker.sentence(),
-        # feast_code in the form of eight digits
-        feast_code=faker.numerify("########"),
-        notes=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        feast_code=make_random_string(8, "0123456789"),
+        notes=faker.sentence(),
         month=random.randint(1, 12),
         day=random.randint(1, 31),
     )
@@ -179,7 +231,7 @@ def make_fake_genre(name=None) -> Genre:
     genre = Genre.objects.create(
         name=name,
         description=faker.sentence(),
-        mass_office=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        mass_office=random.choice(["Mass", "Office", "Mass, Office", "Old Hispanic"]),
     )
     return genre
 
@@ -199,7 +251,7 @@ def make_fake_user(is_indexer=True) -> get_user_model():
 
 def make_fake_notation() -> Notation:
     """Generates a fake Notation object."""
-    notation = Notation.objects.create(name=make_fake_text(SHORT_CHAR_FIELD_MAX))
+    notation = Notation.objects.create(name=faker.sentence(nb_words=3))
     return notation
 
 
@@ -214,17 +266,15 @@ def make_fake_office() -> Office:
 
 def make_fake_provenance() -> Provenance:
     """Generates a fake Provenance object."""
-    provenance = Provenance.objects.create(name=make_fake_text(SHORT_CHAR_FIELD_MAX))
+    provenance = Provenance.objects.create(name=faker.sentence(nb_words=3))
     return provenance
 
 
 def make_fake_rism_siglum() -> RismSiglum:
     """Generates a fake RismSiglum object."""
     rism_siglum = RismSiglum.objects.create(
-        name=make_fake_text(SHORT_CHAR_FIELD_MAX),
-        description=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        name=faker.sentence(nb_words=3),
+        description=faker.sentence(),
     )
     return rism_siglum
 
@@ -232,7 +282,7 @@ def make_fake_rism_siglum() -> RismSiglum:
 def make_fake_segment(name=None) -> Segment:
     """Generates a fake Segment object."""
     if not name:
-        name = make_fake_text(SHORT_CHAR_FIELD_MAX)
+        name = faker.sentence()
     segment = Segment.objects.create(name=name)
     return segment
 
@@ -242,28 +292,25 @@ def make_fake_sequence(source=None, title=None, incipit=None, cantus_id=None) ->
     if source is None:
         source = make_fake_source(segment_name="Bower Sequence Database")
     if title is None:
-        title = make_fake_text(LONG_CHAR_FIELD_MAX)
+        title = faker.sentence()
     if incipit is None:
-        incipit = make_fake_text(LONG_CHAR_FIELD_MAX)
+        incipit = title[:INCIPIT_LENGTH]
     if cantus_id is None:
-        cantus_id = faker.numerify("######")
+        cantus_id = make_random_string(6, "0123456789")
     sequence = Sequence.objects.create(
         title=title,
-        siglum=make_fake_text(LONG_CHAR_FIELD_MAX),
+        siglum=make_random_string(6),
         incipit=incipit,
         # folio in the form of two digits and one letter
         folio=faker.bothify("##?"),
-        s_sequence=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        s_sequence=make_random_string(2, "0123456789"),
         genre=make_fake_genre(),
-        rubrics=make_fake_text(LONG_CHAR_FIELD_MAX),
-        analecta_hymnica=make_fake_text(LONG_CHAR_FIELD_MAX),
-        indexing_notes=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
-        date=make_fake_text(LONG_CHAR_FIELD_MAX),
-        ah_volume=make_fake_text(LONG_CHAR_FIELD_MAX),
+        rubrics=faker.sentence(),
+        analecta_hymnica=make_random_string(6, "0123456789:"),
+        indexing_notes=faker.sentence(),
+        date=make_random_string(6, "1234567890abcdefghijklmnopqrstuvwxyz/-*"),
+        ah_volume=str(random.randint(0, 60)),
         source=source,
-        # cantus_id in the form of six digits
         cantus_id=cantus_id,
         image_link=faker.image_url(),
     )
@@ -297,19 +344,13 @@ def make_fake_source(
     if segment is None:
         segment = make_fake_segment(name=segment_name)
     if siglum is None:
-        siglum = make_fake_text(SHORT_CHAR_FIELD_MAX)
+        siglum = make_random_string(6)
     if rism_siglum is None:
         rism_siglum = make_fake_rism_siglum()
     if description is None:
-        description = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS,
-            min_size=MIN_NUMBER_TEXT_CHARS,
-        )
+        description = faker.sentence()
     if summary is None:
-        summary = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS,
-            min_size=MIN_NUMBER_TEXT_CHARS,
-        )
+        summary = faker.sentence()
     if provenance is None:
         provenance = make_fake_provenance()
     if century is None:
@@ -317,10 +358,7 @@ def make_fake_source(
     # if full_source...
     #     full_source already defaults to True
     if indexing_notes is None:
-        indexing_notes = make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS,
-            min_size=MIN_NUMBER_TEXT_CHARS,
-        )
+        indexing_notes = faker.sentence()
 
     cursus_choices = [x[0] for x in Source.cursus_choices]
     source_status_choices = [x[0] for x in Source.source_status_choices]
@@ -337,23 +375,15 @@ def make_fake_source(
         # century: ManyToManyField, must be set below
         full_source=full_source,
         indexing_notes=indexing_notes,
-        provenance_notes=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
-        date=make_fake_text(SHORT_CHAR_FIELD_MAX),
+        provenance_notes=faker.sentence(),
+        date=faker.sentence(nb_words=3),
         cursus=random.choice(cursus_choices),
         source_status=random.choice(source_status_choices),
         complete_inventory=faker.boolean(),
-        liturgical_occasions=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
-        selected_bibliography=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        liturgical_occasions=faker.sentence(),
+        selected_bibliography=faker.sentence(),
         image_link=faker.image_url(),
-        indexing_date=make_fake_text(
-            max_size=MAX_NUMBER_TEXT_CHARS, min_size=MIN_NUMBER_TEXT_CHARS
-        ),
+        indexing_date=faker.sentence(),
         json_info=None,
     )
     source.century.set([century])


### PR DESCRIPTION
This PR overhauls the `make_fakes.py` file, used to generate fake objects for our test suite.

Previously, `make_fake_text` sometimes included `\n`s in its output, which would cause tests in `test_views.py` to fail at random when we searched for a string of fake text in the content of a response. This PR removes the `make_fake_text` function. In many places, `make_fake_text` is replaced by `Faker().sentence`. I also wrote two new functions, `make_fake_volpiano` (in hindsight, I probably had more fun writing this than strictly necessary) and `make_random_string`, which are used to ensure the values of all the fields in our fake objects are more-or-less representative compared to what's currently in the actual database.

In order to test that the changes to this file have not introduced new errors, I ran `test_models.py` several times in a row.