### PR TITLE
Hide unnecessary fields in admin area - fixes #604

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -6,7 +6,7 @@ from main_app.models import *
 
 class BaseModelAdmin(admin.ModelAdmin):
     # these fields should not be editable
-    exclude = ("created_by", "last_updated_by")
+    exclude = ("created_by", "last_updated_by", "json_info", "col1", "col2", "col3", "next_chant", "number_of_chants", "number_of_melodies")
 
     # if an object is created in the admin interface, assign the user to the created_by field
     # else if an object is updated in the admin interface, assign the user to the last_updated_by field
@@ -23,8 +23,7 @@ class CenturyAdmin(BaseModelAdmin):
 
 
 class ChantAdmin(BaseModelAdmin):
-    pass
-
+    exclude = BaseModelAdmin.exclude + ("s_sequence",)
 
 class FeastAdmin(BaseModelAdmin):
     pass
@@ -55,8 +54,7 @@ class SegmentAdmin(BaseModelAdmin):
 
 
 class SequenceAdmin(BaseModelAdmin):
-    pass
-
+    exclude = BaseModelAdmin.exclude + ("c_sequence",)
 
 class SourceAdmin(BaseModelAdmin):
     # from the Django docs:

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -1,12 +1,11 @@
 from django.contrib import admin
 from main_app.models import *
 
-# Register your models here.
-
+# these fields should not be editable by all classes
+EXCLUDE = ("created_by", "last_updated_by", "json_info")
 
 class BaseModelAdmin(admin.ModelAdmin):
-    # these fields should not be editable
-    exclude = ("created_by", "last_updated_by", "json_info", "col1", "col2", "col3", "next_chant", "number_of_chants", "number_of_melodies")
+    exclude = EXCLUDE
 
     # if an object is created in the admin interface, assign the user to the created_by field
     # else if an object is updated in the admin interface, assign the user to the last_updated_by field
@@ -23,7 +22,7 @@ class CenturyAdmin(BaseModelAdmin):
 
 
 class ChantAdmin(BaseModelAdmin):
-    exclude = BaseModelAdmin.exclude + ("s_sequence",)
+    exclude = EXCLUDE + ("col1", "col2", "col3", "next_chant", "s_sequence")
 
 class FeastAdmin(BaseModelAdmin):
     pass
@@ -54,7 +53,7 @@ class SegmentAdmin(BaseModelAdmin):
 
 
 class SequenceAdmin(BaseModelAdmin):
-    exclude = BaseModelAdmin.exclude + ("c_sequence",)
+    exclude = EXCLUDE + ("c_sequence", "next_chant")
 
 class SourceAdmin(BaseModelAdmin):
     # from the Django docs:

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -22,7 +22,7 @@ class CenturyAdmin(BaseModelAdmin):
 
 
 class ChantAdmin(BaseModelAdmin):
-    exclude = EXCLUDE + ("col1", "col2", "col3", "next_chant", "s_sequence")
+    exclude = EXCLUDE + ("col1", "col2", "col3", "next_chant", "s_sequence", "is_last_chant_in_feast")
 
 class FeastAdmin(BaseModelAdmin):
     pass
@@ -53,7 +53,7 @@ class SegmentAdmin(BaseModelAdmin):
 
 
 class SequenceAdmin(BaseModelAdmin):
-    exclude = EXCLUDE + ("c_sequence", "next_chant")
+    exclude = EXCLUDE + ("c_sequence", "next_chant", "is_last_chant_in_feast")
 
 class SourceAdmin(BaseModelAdmin):
     # from the Django docs:

--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -30,9 +30,9 @@ class BaseChant(BaseModel):
     )
     # The "s_sequence" char field, used for Sequences, is used to indicate the relative positions of sequences on the page.
     # It sometimes features non-numeric characters and leading zeroes, so it's a CharField.
-    s_sequence = models.CharField(blank=True, null=True, max_length=255)
+    s_sequence = models.CharField("Sequence", blank=True, null=True, max_length=255)
     # The "c_sequence" integer field, used for Chants, similarly indicates the relative positions of chants on the page
-    c_sequence = models.PositiveIntegerField(
+    c_sequence = models.PositiveIntegerField("Sequence",
         help_text='Each folio starts with "1"', null=True, blank=True
     )
     genre = models.ForeignKey("Genre", blank=True, null=True, on_delete=models.PROTECT)


### PR DESCRIPTION
Hide unnecessary fields in admin area

- `BaseModelAdmin` class contains updated list of fields to ignore
- `ChantAdmin` excludes `s_sequence`, `SequenceAdmin` excludes `c_sequence`
- `base_chant` includes verbose name argument to Hide unnecessary fields in admin area

Fixes #604 