### PR TITLE
Fix f-string that had been a normal string

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -361,9 +361,9 @@ class ChantDetailView(DetailView):
             t = threading.Thread(
                 target=requests.get,
                 args={
-                    "url":f"https://cantusindex.org/json-con/{chant.cantus_id}/refresh",
-                    "timeout":5,
-                }
+                    "url": f"https://cantusindex.org/json-con/{chant.cantus_id}/refresh",
+                    "timeout": 5,
+                },
             )
             t.start()
 
@@ -1633,7 +1633,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             cantus_id = current_chant.cantus_id
 
             request = requests.get(
-                "https://cantusindex.org/json-cid/{cantus_id}",
+                f"https://cantusindex.org/json-cid/{cantus_id}",
                 timeout=5,
             )
             request_text = json.loads(request.text[2:])


### PR DESCRIPTION
While trying to fix #607, @MrMondrian and I found a string that was meant to be an f-string but had been encoded without the leading `f`. This fix appears to convert a reliably-failing test into an occasionally-failing test.

At some point, a `"string".format()` got refactored into an `f"string"`, probably while our tests were already failing sporadically, and the additional test failure didn't register among the noise of all the other failing tests.

Along the way, Black decided further formatting improvements should be implemented, so these came along for the ride.