### PR TITLE
 Fix broken link in source detail page

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -4,6 +4,7 @@ from main_app.models import *
 # these fields should not be editable by all classes
 EXCLUDE = ("created_by", "last_updated_by", "json_info")
 
+
 class BaseModelAdmin(admin.ModelAdmin):
     exclude = EXCLUDE
 
@@ -22,7 +23,15 @@ class CenturyAdmin(BaseModelAdmin):
 
 
 class ChantAdmin(BaseModelAdmin):
-    exclude = EXCLUDE + ("col1", "col2", "col3", "next_chant", "s_sequence", "is_last_chant_in_feast")
+    exclude = EXCLUDE + (
+        "col1",
+        "col2",
+        "col3",
+        "next_chant",
+        "s_sequence",
+        "is_last_chant_in_feast",
+    )
+
 
 class FeastAdmin(BaseModelAdmin):
     pass
@@ -54,6 +63,7 @@ class SegmentAdmin(BaseModelAdmin):
 
 class SequenceAdmin(BaseModelAdmin):
     exclude = EXCLUDE + ("c_sequence", "next_chant", "is_last_chant_in_feast")
+
 
 class SourceAdmin(BaseModelAdmin):
     # from the Django docs:

--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -32,8 +32,8 @@ class BaseChant(BaseModel):
     # It sometimes features non-numeric characters and leading zeroes, so it's a CharField.
     s_sequence = models.CharField("Sequence", blank=True, null=True, max_length=255)
     # The "c_sequence" integer field, used for Chants, similarly indicates the relative positions of chants on the page
-    c_sequence = models.PositiveIntegerField("Sequence",
-        help_text='Each folio starts with "1"', null=True, blank=True
+    c_sequence = models.PositiveIntegerField(
+        "Sequence", help_text='Each folio starts with "1"', null=True, blank=True
     )
     genre = models.ForeignKey("Genre", blank=True, null=True, on_delete=models.PROTECT)
     rubrics = models.CharField(blank=True, null=True, max_length=255)

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -250,9 +250,11 @@
                                 <li>
                                     <a href="{% url "chant-create" source.id%}">Add new chant</a>
                                 </li>
-                                <li>
-                                    <a href="{% url "source-edit-chants" source.id%}">Edit chants (fulltext & volpiano editor)</a>
-                                </li>
+                                {% if source.number_of_chants %}
+                                    <li>
+                                        <a href="{% url "source-edit-chants" source.id%}">Edit chants (fulltext & volpiano editor)</a>
+                                    </li>
+                                {% endif %}
                                 <li>
                                     <a href="{% url "source-edit" source.id%}">Edit source description</a>
                                 </li>


### PR DESCRIPTION
This PR addresses issue #631 when viewing the source detail page. if the user tried to enter the edit chants page when there are no chants in the source it will cause an error. The fix will only display the link to the edit chants page if there is at least one chant in the source.

Also changes black formatting on some files that were necessary before committing.