### PR TITLE
Auto-populate Syllabized Full Text field

### DIFF
--- a/django/cantusdb_project/align_text_mel.py
+++ b/django/cantusdb_project/align_text_mel.py
@@ -327,7 +327,7 @@ def syllabize_text_and_melody(text, pre_syllabized, melody):
 
     Args:
         text (str): The input text to be syllabized.
-        pre_syllabized (list): A list of pre-syllabized words corresponding to the input text.
+        pre_syllabized (bool): A list of pre-syllabized words corresponding to the input text.
         melody (list): A list representing the melody.
     Returns:
         list: A list of tuples containing the aligned words and syllables.

--- a/django/cantusdb_project/align_text_mel.py
+++ b/django/cantusdb_project/align_text_mel.py
@@ -314,3 +314,40 @@ def align(syls_text, syls_melody):
         list_of_zips.append(word_zip)
 
     return list_of_zips
+
+
+def syllabize_text_and_melody(text, pre_syllabized, melody):
+    """Syllabizes the given text and melody, aligns the syllables, and returns a zip of words and syllables.
+
+    This function takes a text, pre-syllabized text, and a melody as input. It performs syllabization on the text
+    and melody separately based on the volpiano protocols. The syllabized text and melody are then postprocessed,
+    and syllables of the text and melody are aligned to create a zip
+    of words and syllables.
+
+
+    Args:
+        text (str): The input text to be syllabized.
+        pre_syllabized (list): A list of pre-syllabized words corresponding to the input text.
+        melody (list): A list representing the melody.
+    Returns:
+        list: A list of tuples containing the aligned words and syllables.
+    """
+    syls_melody = syllabize_melody(melody)
+    syls_text = syllabize_text(text, pre_syllabized=pre_syllabized)
+    syls_text, syls_melody = postprocess(syls_text, syls_melody)
+    word_zip = align(syls_text, syls_melody)
+    return word_zip
+
+
+def syllabize_text_to_string(text, pre_syllabized):
+    """Syllabizes the given text using pre-syllabized information and returns a human-readable string.
+
+    Args:
+        text (str): The input text to be syllabized.
+        pre_syllabized (bool): Indicates whether the input text is already pre-syllabized.
+    Returns:
+        str: The syllabized text as a human-readable string.
+    """
+    syls_text = syllabize_text(text, pre_syllabized)
+    human_readable_text = " ".join(["".join(word) for word in syls_text])
+    return human_readable_text

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -22,7 +22,6 @@ class CenturyAdmin(BaseModelAdmin):
     pass
 
 
-@admin.register(Chant)
 class ChantAdmin(BaseModelAdmin):
     list_display = ("incipit", "siglum", "genre")
     search_fields = ("title", "incipit", "cantus_id")
@@ -86,6 +85,7 @@ class SourceAdmin(BaseModelAdmin):
 
 
 admin.site.register(Century, CenturyAdmin)
+admin.site.register(Chant, ChantAdmin)
 admin.site.register(Feast, FeastAdmin)
 admin.site.register(Genre, GenreAdmin)
 admin.site.register(Notation, NotationAdmin)

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -22,7 +22,11 @@ class CenturyAdmin(BaseModelAdmin):
     pass
 
 
+@admin.register(Chant)
 class ChantAdmin(BaseModelAdmin):
+    list_display = ("incipit", "siglum", "genre")
+    search_fields = ("title", "incipit", "cantus_id")
+    list_filter = ("genre",)
     exclude = EXCLUDE + (
         "col1",
         "col2",
@@ -82,7 +86,6 @@ class SourceAdmin(BaseModelAdmin):
 
 
 admin.site.register(Century, CenturyAdmin)
-admin.site.register(Chant, ChantAdmin)
 admin.site.register(Feast, FeastAdmin)
 admin.site.register(Genre, GenreAdmin)
 admin.site.register(Notation, NotationAdmin)

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -1,5 +1,6 @@
 from django.db.models.query import QuerySet
 from main_app.models.base_chant import BaseChant
+from align_text_mel import *
 
 
 class Chant(BaseChant):
@@ -148,3 +149,62 @@ class Chant(BaseChant):
             next_chant = None
 
         return next_chant
+
+    def get_syllabized_text_and_melody(self):
+        """Returns the syllabized text with the melody of a chant. If volpiano is not established return None
+
+        Returns:
+            list: Returns a list of zip_longest objects containing syllabized melody and corresponding
+            syllabized text elements
+        """
+
+        if self.volpiano:
+            syls_melody = syllabize_melody(self.volpiano)
+
+            if self.manuscript_syllabized_full_text:
+                syls_text = syllabize_text(
+                    self.manuscript_syllabized_full_text, pre_syllabized=True
+                )
+            elif self.manuscript_full_text:
+                syls_text = syllabize_text(
+                    self.manuscript_full_text, pre_syllabized=False
+                )
+                syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            elif self.manuscript_full_text_std_spelling:
+                syls_text = syllabize_text(
+                    self.manuscript_full_text_std_spelling, pre_syllabized=False
+                )
+            elif self.incipit:
+                syls_text = syllabize_text(self.incipit, pre_syllabized=False)
+                syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            else:
+                syls_text = [[""]]
+
+            word_zip = align(syls_text, syls_melody)
+            return word_zip
+
+    def get_syllabized_text(self):
+        """Returns the syllabized text of a chant
+
+        Returns:
+            String: A String with words separated by spaces and syllables separated by "-"
+
+        """
+        if self.manuscript_syllabized_full_text:
+            print("hello")
+            syls_text = syllabize_text(
+                self.manuscript_syllabized_full_text, pre_syllabized=True
+            )
+        elif self.manuscript_full_text:
+            syls_text = syllabize_text(self.manuscript_full_text, pre_syllabized=False)
+        elif self.manuscript_full_text_std_spelling:
+            syls_text = syllabize_text(
+                self.manuscript_full_text_std_spelling, pre_syllabized=False
+            )
+        elif self.incipit:
+            syls_text = syllabize_text(self.incipit, pre_syllabized=False)
+        else:
+            return [[""]]
+
+        human_readable_text = " ".join(["".join(word) for word in syls_text])
+        return human_readable_text

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -1,6 +1,5 @@
 from django.db.models.query import QuerySet
 from main_app.models.base_chant import BaseChant
-from align_text_mel import *
 
 
 class Chant(BaseChant):

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -149,7 +149,7 @@ class Chant(BaseChant):
 
         return next_chant
 
-    def get_most_descriptive_text(self):
+    def get_best_text_for_syllabizing(self):
         """Finds the most descriptive text from the available fields of the chant.
 
         Preview of melody and text:

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -150,48 +150,28 @@ class Chant(BaseChant):
 
         return next_chant
 
-    def get_syllabized_text_and_melody(self, text_only=False):
-        """Returns the syllabized text with the melody of a chant. Syllabized text splits the words from the
-         full text into its syllable components based on the volpiano protocols
-         (ex: Hanc vero quam lucas peccatricem => Hanc ve-ro quam lu-cas pec-ca-tri-cem)
-         If volpiano is not established return None
+    def get_most_descriptive_text(self):
+        """Finds the most descriptive text from the available fields of the chant.
 
-                        Preview of melody and text:
-         'manuscript_syllabized_full_text' exists =>
-           preview constructed from 'manuscript_syllabized_full_text'
-         no 'manuscript_syllabized_full_text', but 'manuscript_full_text' exists =>
-           preview constructed from 'manuscript_full_text'
-         no 'manuscript_syllabized_full_text' and no 'manuscript_full_text' =>
-           preview constructed from 'manuscript_full_text_std_spelling'
-        to this we add:
-        no full text of any kind => preview constructed from `incipit`
-        none of the above => show message explaining why melody preview has no text
-
+        Preview of melody and text:
+            - If 'manuscript_syllabized_full_text' exists, the preview is constructed from it.
+            - If 'manuscript_syllabized_full_text' doesn't exist but 'manuscript_full_text' exists,
+              the preview is constructed from 'manuscript_full_text'.
+            - If neither 'manuscript_syllabized_full_text' nor 'manuscript_full_text' exist but
+              'manuscript_full_text_std_spelling' exists, the preview is constructed from 'manuscript_full_text_std_spelling'.
+            - If none of the above fields exist, the preview is constructed from 'incipit'.
+            - If there is no available text, return None
         Returns:
-            list/string: Returns a list of zip_longest objects containing syllabized melody and corresponding
-            syllabized text elements. If text_only=True return a String with words separated by spaces and
-            syllables separated by "-"
+            String: The most descriptive text from the available fields of the chant.
         """
-        if self.manuscript_syllabized_full_text:
-            syls_text = syllabize_text(
-                self.manuscript_syllabized_full_text, pre_syllabized=True
-            )
-        elif self.manuscript_full_text:
-            syls_text = syllabize_text(self.manuscript_full_text, pre_syllabized=False)
-        elif self.manuscript_full_text_std_spelling:
-            syls_text = syllabize_text(
-                self.manuscript_full_text_std_spelling, pre_syllabized=False
-            )
-        elif self.incipit:
-            syls_text = syllabize_text(self.incipit, pre_syllabized=False)
-        else:
-            syls_text = [[""]]
 
-        if not text_only and self.volpiano:
-            syls_melody = syllabize_melody(self.volpiano)
-            syls_text, syls_melody = postprocess(syls_text, syls_melody)
-            word_zip = align(syls_text, syls_melody)
-            return word_zip
-        elif text_only:
-            human_readable_text = " ".join(["".join(word) for word in syls_text])
-            return human_readable_text
+        if self.manuscript_syllabized_full_text:
+            return self.manuscript_syllabized_full_text
+        elif self.manuscript_full_text:
+            return self.manuscript_full_text
+        elif self.manuscript_full_text_std_spelling:
+            return self.manuscript_full_text_std_spelling
+        elif self.incipit:
+            return self.incipit
+        else:
+            return None

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -153,7 +153,7 @@ class Chant(BaseChant):
     def get_syllabized_text_and_melody(self, text_only=False):
         """Returns the syllabized text with the melody of a chant. Syllabized text splits the words from the
          full text into its syllable components based on the volpiano protocols
-         (ex: Ocundare plebs fidelis cuius pater => I-O-cun-da-re plebs fi-de-lis cu-ius pa-ter)
+         (ex: IOcundare plebs fidelis cuius pater => I-O-cun-da-re plebs fi-de-lis cu-ius pa-ter)
          If volpiano is not established return None
 
                         Preview of melody and text:

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -150,48 +150,29 @@ class Chant(BaseChant):
 
         return next_chant
 
-    def get_syllabized_text_and_melody(self):
-        """Returns the syllabized text with the melody of a chant. If volpiano is not established return None
+    def get_syllabized_text_and_melody(self, text_only=False):
+        """Returns the syllabized text with the melody of a chant. Syllabized text splits the words from the
+         full text into its syllable components based on the volpiano protocols
+         (ex: Ocundare plebs fidelis cuius pater => I-O-cun-da-re plebs fi-de-lis cu-ius pa-ter)
+         If volpiano is not established return None
+
+                        Preview of melody and text:
+         'manuscript_syllabized_full_text' exists =>
+           preview constructed from 'manuscript_syllabized_full_text'
+         no 'manuscript_syllabized_full_text', but 'manuscript_full_text' exists =>
+           preview constructed from 'manuscript_full_text'
+         no 'manuscript_syllabized_full_text' and no 'manuscript_full_text' =>
+           preview constructed from 'manuscript_full_text_std_spelling'
+        to this we add:
+        no full text of any kind => preview constructed from `incipit`
+        none of the above => show message explaining why melody preview has no text
 
         Returns:
-            list: Returns a list of zip_longest objects containing syllabized melody and corresponding
-            syllabized text elements
-        """
-
-        if self.volpiano:
-            syls_melody = syllabize_melody(self.volpiano)
-
-            if self.manuscript_syllabized_full_text:
-                syls_text = syllabize_text(
-                    self.manuscript_syllabized_full_text, pre_syllabized=True
-                )
-            elif self.manuscript_full_text:
-                syls_text = syllabize_text(
-                    self.manuscript_full_text, pre_syllabized=False
-                )
-                syls_text, syls_melody = postprocess(syls_text, syls_melody)
-            elif self.manuscript_full_text_std_spelling:
-                syls_text = syllabize_text(
-                    self.manuscript_full_text_std_spelling, pre_syllabized=False
-                )
-            elif self.incipit:
-                syls_text = syllabize_text(self.incipit, pre_syllabized=False)
-                syls_text, syls_melody = postprocess(syls_text, syls_melody)
-            else:
-                syls_text = [[""]]
-
-            word_zip = align(syls_text, syls_melody)
-            return word_zip
-
-    def get_syllabized_text(self):
-        """Returns the syllabized text of a chant
-
-        Returns:
-            String: A String with words separated by spaces and syllables separated by "-"
-
+            list/string: Returns a list of zip_longest objects containing syllabized melody and corresponding
+            syllabized text elements. If text_only=True return a String with words separated by spaces and
+            syllables separated by "-"
         """
         if self.manuscript_syllabized_full_text:
-            print("hello")
             syls_text = syllabize_text(
                 self.manuscript_syllabized_full_text, pre_syllabized=True
             )
@@ -204,7 +185,13 @@ class Chant(BaseChant):
         elif self.incipit:
             syls_text = syllabize_text(self.incipit, pre_syllabized=False)
         else:
-            return [[""]]
+            syls_text = [[""]]
 
-        human_readable_text = " ".join(["".join(word) for word in syls_text])
-        return human_readable_text
+        if not text_only and self.volpiano:
+            syls_melody = syllabize_melody(self.volpiano)
+            syls_text, syls_melody = postprocess(syls_text, syls_melody)
+            word_zip = align(syls_text, syls_melody)
+            return word_zip
+        elif text_only:
+            human_readable_text = " ".join(["".join(word) for word in syls_text])
+            return human_readable_text

--- a/django/cantusdb_project/main_app/models/chant.py
+++ b/django/cantusdb_project/main_app/models/chant.py
@@ -153,7 +153,7 @@ class Chant(BaseChant):
     def get_syllabized_text_and_melody(self, text_only=False):
         """Returns the syllabized text with the melody of a chant. Syllabized text splits the words from the
          full text into its syllable components based on the volpiano protocols
-         (ex: IOcundare plebs fidelis cuius pater => I-O-cun-da-re plebs fi-de-lis cu-ius pa-ter)
+         (ex: Hanc vero quam lucas peccatricem => Hanc ve-ro quam lu-cas pec-ca-tri-cem)
          If volpiano is not established return None
 
                         Preview of melody and text:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -24,7 +24,7 @@ from main_app.forms import (
     ChantEditSyllabificationForm,
 )
 from main_app.models import Chant, Feast, Genre, Source, Sequence
-from align_text_mel import *
+from align_text_mel import syllabize_text_and_melody, syllabize_text_to_string
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404
 from next_chants import next_chants

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1697,7 +1697,7 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
     def get_initial(self):
         initial = super().get_initial()
         chant = self.get_object()
-        syls_text = chant.get_syllabized_text()
+        syls_text = chant.get_syllabized_text_and_melody(text_only=True)
         initial["manuscript_syllabized_full_text"] = syls_text
         return initial
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -86,7 +86,10 @@ class ChantDetailView(DetailView):
 
         # syllabification section
         if chant.volpiano:
-            text_and_mel = chant.get_syllabized_text_and_melody()
+            has_syl_text = bool(chant.manuscript_syllabized_full_text)
+            text_and_mel = syllabize_text_and_melody(
+                chant.get_most_descriptive_text(), has_syl_text, chant.volpiano
+            )
             context["syllabized_text_with_melody"] = text_and_mel
 
         # If chant has a cantus ID, Create table of concordances
@@ -1624,7 +1627,10 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         chant = self.get_object()
 
         if chant.volpiano:
-            text_and_mel = chant.get_syllabized_text_and_melody()
+            has_syl_text = bool(chant.manuscript_syllabized_full_text)
+            text_and_mel = syllabize_text_and_melody(
+                chant.get_most_descriptive_text(), has_syl_text, chant.volpiano
+            )
             context["syllabized_text_with_melody"] = text_and_mel
 
         return context
@@ -1689,7 +1695,10 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
         chant = self.get_object()
 
         if chant.volpiano:
-            text_and_mel = chant.get_syllabized_text_and_melody()
+            has_syl_text = bool(chant.manuscript_syllabized_full_text)
+            text_and_mel = syllabize_text_and_melody(
+                chant.get_most_descriptive_text(), has_syl_text, chant.volpiano
+            )
             context["syllabized_text_with_melody"] = text_and_mel
 
         return context
@@ -1697,7 +1706,10 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
     def get_initial(self):
         initial = super().get_initial()
         chant = self.get_object()
-        syls_text = chant.get_syllabized_text_and_melody(text_only=True)
+        has_syl_text = bool(chant.manuscript_syllabized_full_text)
+        syls_text = syllabize_text_to_string(
+            chant.get_most_descriptive_text(), has_syl_text
+        )
         initial["manuscript_syllabized_full_text"] = syls_text
         return initial
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -88,7 +88,9 @@ class ChantDetailView(DetailView):
         if chant.volpiano:
             has_syl_text = bool(chant.manuscript_syllabized_full_text)
             text_and_mel = syllabize_text_and_melody(
-                chant.get_most_descriptive_text(), has_syl_text, chant.volpiano
+                chant.get_best_text_for_syllabizing(),
+                pre_syllabized=has_syl_text,
+                melody=chant.volpiano,
             )
             context["syllabized_text_with_melody"] = text_and_mel
 
@@ -1629,7 +1631,9 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         if chant.volpiano:
             has_syl_text = bool(chant.manuscript_syllabized_full_text)
             text_and_mel = syllabize_text_and_melody(
-                chant.get_most_descriptive_text(), has_syl_text, chant.volpiano
+                chant.get_best_text_for_syllabizing(),
+                pre_syllabized=has_syl_text,
+                melody=chant.volpiano,
             )
             context["syllabized_text_with_melody"] = text_and_mel
 
@@ -1697,7 +1701,9 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
         if chant.volpiano:
             has_syl_text = bool(chant.manuscript_syllabized_full_text)
             text_and_mel = syllabize_text_and_melody(
-                chant.get_most_descriptive_text(), has_syl_text, chant.volpiano
+                chant.get_best_text_for_syllabizing(),
+                pre_syllabized=has_syl_text,
+                melody=chant.volpiano,
             )
             context["syllabized_text_with_melody"] = text_and_mel
 
@@ -1708,7 +1714,7 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
         chant = self.get_object()
         has_syl_text = bool(chant.manuscript_syllabized_full_text)
         syls_text = syllabize_text_to_string(
-            chant.get_most_descriptive_text(), has_syl_text
+            chant.get_best_text_for_syllabizing(), pre_syllabized=has_syl_text
         )
         initial["manuscript_syllabized_full_text"] = syls_text
         return initial


### PR DESCRIPTION
This PR addressed issue #610 where the "Edit Syllabification" view shows an empty field for the syllabized text. The modifications allow this field to be populated by the syllabification generated from the full text (or other resources available if `manuscript_full_text` is not provided)

- add `get_initial()` function to `ChantEditSyllabificationView` to initialize `manuscript_syllabized_full_text` 
- modify `chant.py` by adding method `syllabize_text_and_melody` (used for populating the volpiano section)
- modify `chant.py` by adding method to `syllabize_text_to_string` (used for populating the manuscript_syllabized_full_text field)
- remove redundant code in chant views
- fixes #610 

Example syllabification:

![image](https://github.com/DDMAL/CantusDB/assets/71031342/88c6831b-6ca3-4595-a2b2-909dbadb7547)
