### PR TITLE
Fix BaseChant.get_ci_url

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -4,6 +4,7 @@ from main_app.models import *
 # these fields should not be editable by all classes
 EXCLUDE = ("created_by", "last_updated_by", "json_info")
 
+
 class BaseModelAdmin(admin.ModelAdmin):
     exclude = EXCLUDE
 
@@ -22,7 +23,15 @@ class CenturyAdmin(BaseModelAdmin):
 
 
 class ChantAdmin(BaseModelAdmin):
-    exclude = EXCLUDE + ("col1", "col2", "col3", "next_chant", "s_sequence", "is_last_chant_in_feast")
+    exclude = EXCLUDE + (
+        "col1",
+        "col2",
+        "col3",
+        "next_chant",
+        "s_sequence",
+        "is_last_chant_in_feast",
+    )
+
 
 class FeastAdmin(BaseModelAdmin):
     pass
@@ -54,6 +63,7 @@ class SegmentAdmin(BaseModelAdmin):
 
 class SequenceAdmin(BaseModelAdmin):
     exclude = EXCLUDE + ("c_sequence", "next_chant", "is_last_chant_in_feast")
+
 
 class SourceAdmin(BaseModelAdmin):
     # from the Django docs:

--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -32,8 +32,8 @@ class BaseChant(BaseModel):
     # It sometimes features non-numeric characters and leading zeroes, so it's a CharField.
     s_sequence = models.CharField("Sequence", blank=True, null=True, max_length=255)
     # The "c_sequence" integer field, used for Chants, similarly indicates the relative positions of chants on the page
-    c_sequence = models.PositiveIntegerField("Sequence",
-        help_text='Each folio starts with "1"', null=True, blank=True
+    c_sequence = models.PositiveIntegerField(
+        "Sequence", help_text='Each folio starts with "1"', null=True, blank=True
     )
     genre = models.ForeignKey("Genre", blank=True, null=True, on_delete=models.PROTECT)
     rubrics = models.CharField(blank=True, null=True, max_length=255)
@@ -138,7 +138,7 @@ class BaseChant(BaseModel):
         Returns:
             str: The url to the Cantus Index page
         """
-        return f"http://cantusindex.org/id/{self.cantus_id}"
+        return f"https://cantusindex.org/id/{self.cantus_id}"
 
     def __str__(self):
         incipit = ""


### PR DESCRIPTION
This PR fixes the `BaseChant.get_ci_url()` method. Whereas in many places (including the tests), Cantus Index urls had been updated to use `https://`, this method had been missed. Applying this update fixes the tests that are failing (rather than erroring) - in conjunction with #646, which fixes our erroring tests, this PR thus fixes #607.