### PR TITLE
Allow option to edit from "view all chants"

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -38,7 +38,7 @@
                     </p>
                 {% endif %}
                 <form method="post" style="line-height: normal">{% csrf_token %}
-                    <input type="hidden" name="referrer" value="{{ referrer }}">
+                    <input type="hidden" name="referrer" value="{{ request.META.HTTP_REFERER }}">
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -38,6 +38,7 @@
                     </p>
                 {% endif %}
                 <form method="post" style="line-height: normal">{% csrf_token %}
+                    <input type="hidden" name="referrer" value="{{ referrer }}">
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -113,7 +113,7 @@
                         </td>
                         {% if user_can_edit_chant %}
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}">Edit</a>
+                                <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}&ref=chant-list">Edit</a>
                             </td>
                         {% endif %}
                     </tr>

--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -67,6 +67,9 @@
                         <th scope="col" class="text-wrap" title="Cantus ID">CantusID</th>
                         <th scope="col" class="text-wrap" title="Mode">Mode</th>
                         <th scope="col" class="text-wrap" title="Image link"></th>
+                        {% if user_can_edit_chant %}
+                            <th scope="col" class="text-wrap" title="Edit Chant"></th>
+                        {% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -108,6 +111,11 @@
                                 <a href="{{ chant.image_link }}" target="_blank">Image</a>
                             {% endif %}
                         </td>
+                        {% if user_can_edit_chant %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}">Edit</a>
+                            </td>
+                        {% endif %}
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1700,7 +1700,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
     def get_success_url(self):
         next_url = self.request.GET.get("ref")
-        if next_url:
+        if next_url == "chant-list":
             return self.request.POST.get("referrer")
         else:
             # stay on the same page after save

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1699,6 +1699,8 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             return super().form_invalid(form)
 
     def get_success_url(self):
+        # Take user back to chant list page if that is the referrer page
+        # `ref` url parameter is used to indicate referring page
         next_url = self.request.GET.get("ref")
         if next_url == "chant-list":
             return self.request.POST.get("referrer")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1699,8 +1699,12 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             return super().form_invalid(form)
 
     def get_success_url(self):
-        # stay on the same page after save
-        return self.request.get_full_path()
+        next_url = self.request.GET.get("ref")
+        if next_url:
+            return self.request.POST.get("referrer")
+        else:
+            # stay on the same page after save
+            return self.request.get_full_path()
 
 
 class ChantProofreadView(SourceEditChantsView):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -573,6 +573,9 @@ class ChantListView(ListView):
         source = Source.objects.get(id=source_id)
         context["source"] = source
 
+        user = self.request.user
+        context["user_can_edit_chant"] = user_can_edit_chants_in_source(user, source)
+
         chants_in_source = source.chant_set
         if chants_in_source.count() == 0:
             # these are needed in the selectors and hyperlinks on the right side of the page


### PR DESCRIPTION
This PR resolves #442 where there was no option to go to the edit page of a chant from the "view all chants" page of a source. This feature was available in OldCantus as an extra column on the table with an edit link. 

The implementation in NewCantus adds the same column to the table with the edit link
- the edit link is only shown if the use has editing permission
- after the user finishes editing the chant and clicks save, they will be taken back to the "view all chants" page

![image](https://github.com/DDMAL/CantusDB/assets/71031342/75d5924d-d381-4668-b93e-dcc1f0666e8e)
