### PR TITLE
Add parse_json_from_api function for improved code readability and reusability

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -65,13 +65,13 @@ CHANT_SEARCH_TEMPLATE_VALUES = (
 
 def parse_json_from_api(url: str) -> Union[list, None]:
     """Queries a remote api that returns a json object, processes it and returns
-    a dict or list containing its information
+    a list containing its information
 
     Args:
         url (str): Url of the API
 
     Returns:
-        dict, list, None: contents of json response in the form of a list or dict
+        list, None: contents of json response in the form of a list
     """
     try:
         response: Optional[Response] = requests.get(

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -66,7 +66,7 @@ CHANT_SEARCH_TEMPLATE_VALUES = (
 
 def parse_json_from_api(url: str) -> Union[list, dict, None]:
     """Queries a remote api that returns a json object, processes it and returns
-    a dict containing its information
+    a dict or list containing its information
 
     Args:
         url (str): Url of the API

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -184,12 +184,11 @@ def make_suggested_chant_dict(
             - how many times chants with this Cantus ID follow chants with a
                 Cantus ID of 123456 (int)
     """
-    url = f"https://cantusindex.org/json-cid/{cantus_id}"
-    cid_dict = parse_json_from_api(url)
-    # it is possible for parse_json_from_api to return a list
-    # so we must check that cid_dict is actually a dictionary
+    json_cid_url: str = f"https://cantusindex.org/json-cid/{cantus_id}"
+    cid_dict: Union[list, dict, None] = parse_json_from_api(json_cid_url)
     try:
-        assert isinstance(cid_dict, dict)
+        assert isinstance(cid_dict, list)
+        assert isinstance(cid_dict[0], dict)
     except AssertionError:
         return {}
 
@@ -237,11 +236,15 @@ class ChantDetailView(DetailView):
         # If chant has a cantus ID, Create table of concordances
         context["concordances_loaded_successfully"] = True
         if chant.cantus_id:
-            url = f"https://cantusindex.org/json-con/{chant.cantus_id}"
-            concordances = parse_json_from_api(url)
-            # parse_json_from_api may return None or dict
+            json_concordances_url: str = (
+                f"https://cantusindex.org/json-con/{chant.cantus_id}"
+            )
+            concordances: Union[list, dict, None] = parse_json_from_api(
+                json_concordances_url
+            )
             try:
                 assert isinstance(concordances, list)
+                assert isinstance(concordances[0], dict)
             except AssertionError:
                 concordances = []
                 context["concordances_loaded_successfully"] = False
@@ -1634,10 +1637,11 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             current_chant = Chant.objects.filter(pk=pk).first()
             cantus_id = current_chant.cantus_id
 
-            url = f"https://cantusindex.org/json-cid/{cantus_id}"
-            json_response = parse_json_from_api(url)
+            json_cid_url: str = f"https://cantusindex.org/json-cid/{cantus_id}"
+            json_response: Union[list, dict, None] = parse_json_from_api(json_cid_url)
             try:
                 assert isinstance(json_response, list)
+                assert isinstance(json_response[0], dict)
             except AssertionError:
                 json_response = None
             if json_response:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -186,8 +186,6 @@ def make_suggested_chant_dict(
     """
     url = f"https://cantusindex.org/json-cid/{cantus_id}"
     cid_dict = parse_json_from_api(url)
-    if cid_dict is None:
-        return {}
     # it is possible for parse_json_from_api to return a list
     # so we must check that cid_dict is actually a dictionary
     try:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -79,8 +79,6 @@ def parse_json_from_api(url: str) -> Optional[dict]:
             url,
             timeout=5,
         )
-        print("response.text:", response.text)
-        print("response.text 2:", response.text[2:])
     except (
         SSLError,
         Timeout,


### PR DESCRIPTION
This pull request introduces a new function, `parse_json_from_api`, to enhance code readability and promote code reuse within the file. The existing code had repetitive instances throughout the file, which have now been consolidated into this dedicated function.

- Introducing the `parse_json_from_api` function that takes a URL as input and queries a remote API to retrieve a JSON object. It then processes the response and returns the contents as a dictionary or list, or None in case of errors.
- Appropriate handling of None responses from `parse_json_from_api` and assertion of expected response type from the function

Thanks to @jacobdgm for their equal contributions to this PR in pair programming.