### PR TITLE
Fix queryset filtering

### DIFF
--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -120,7 +120,7 @@ class Source(BaseModel):
     number_of_melodies = models.IntegerField(blank=True, null=True)
 
     def __str__(self):
-        string = '[{s}] {t} ({i})'.format(s=self.siglum, t=self.title, i=self.id)
+        string = "[{s}] {t} ({i})".format(s=self.siglum, t=self.title, i=self.id)
         return string
 
     def save(self, *args, **kwargs):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1064,7 +1064,7 @@ class ChantSearchMSView(ListView):
                 )
                 incipit_filter = Q(incipit__istartswith=keyword)
             keyword_filter = ms_spelling_filter | std_spelling_filter | incipit_filter
-            queryset.filter(keyword_filter)
+            queryset = queryset.filter(keyword_filter)
         # ordering with the folio string gives wrong order
         # old cantus is also not strictly ordered by folio (there are outliers)
         # so we order by id for now, which is the order that the chants are entered into the DB


### PR DESCRIPTION
This pull request resolves a critical bug affecting the staging and develop environments, where the search filters were not functioning as expected. The root cause of this issue was identified as the lack of reinstantiation of the queryset object. Additionally, this PR includes updates made by Black in the source.py file.

Fixes #614 