### PR TITLE
Improve keyword search testing in test_views.py

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1178,18 +1178,28 @@ class ChantSearchMSViewTest(TestCase):
 
     def test_keyword_search_starts_with(self):
         source = make_fake_source()
-        chant = Chant.objects.create(
+        search_term = "quick"
+
+        # We have three chants to make sure the result is only chant 1 where quick is the first word
+        chant_1 = make_fake_chant(
             source=source,
-            incipit=faker.sentence(),
+            manuscript_full_text_std_spelling="quick brown fox jumps over the lazy dog",
         )
-        # use the beginning part of the incipit as search term
-        search_term = chant.incipit[0 : random.randint(1, len(chant.incipit))]
+        chant_2 = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling="brown fox jumps over the lazy dog",
+        )
+        chant_3 = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling="lazy brown fox jumps quick over the dog",
+        )
         response = self.client.get(
             reverse("chant-search-ms", args=[source.id]),
             {"keyword": search_term, "op": "starts_with"},
         )
+        self.assertEqual(len(response.context["chants"]), 1)
         context_chant_id = response.context["chants"][0]["id"]
-        self.assertEqual(chant.id, context_chant_id)
+        self.assertEqual(chant_1.id, context_chant_id)
 
     def test_keyword_search_contains(self):
         source = make_fake_source()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1225,6 +1225,46 @@ class ChantSearchMSViewTest(TestCase):
         second_context_chant_id = response.context["chants"][1]["id"]
         self.assertEqual(chant_3.id, second_context_chant_id)
 
+    def test_keyword_search_searching_all_fields(self):
+        search_term = "brevity"
+        includes_search_term = "brevity is the soul of wit"
+        doesnt_include_search_term = "longevity is the soul of wit"
+        source = make_fake_source()
+        chant_incipit = make_fake_chant(
+            source=source,
+            incipit=includes_search_term,  # <==
+            manuscript_full_text=doesnt_include_search_term,
+            manuscript_full_text_std_spelling=doesnt_include_search_term,
+        )
+        chant_ms_spelling = make_fake_chant(
+            source=source,
+            incipit=doesnt_include_search_term,
+            manuscript_full_text=includes_search_term,  # <==
+            manuscript_full_text_std_spelling=doesnt_include_search_term,
+        )
+        chant_std_spelling = make_fake_chant(
+            source=source,
+            incipit=doesnt_include_search_term,
+            manuscript_full_text=doesnt_include_search_term,
+            manuscript_full_text_std_spelling=includes_search_term,  # <==
+        )
+        chant_without_search_term = make_fake_chant(
+            source=source,
+            incipit=doesnt_include_search_term,
+            manuscript_full_text=doesnt_include_search_term,
+            manuscript_full_text_std_spelling=doesnt_include_search_term,
+        )
+        response_starts_with = self.client.get(
+            reverse("chant-search-ms", args=[source.id]),
+            {"keyword": search_term, "op": "starts_with"},
+        )
+        self.assertEqual(len(response_starts_with.context["chants"]), 3)
+        response_contains = self.client.get(
+            reverse("chant-search-ms", args=[source.id]),
+            {"keyword": search_term, "op": "contains"},
+        )
+        self.assertEqual(len(response_contains.context["chants"]), 3)
+
     def test_source_link_column(self):
         siglum = "Sigl-01"
         source = make_fake_source(published=True, siglum=siglum)

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1203,21 +1203,27 @@ class ChantSearchMSViewTest(TestCase):
 
     def test_keyword_search_contains(self):
         source = make_fake_source()
-        chant = make_fake_chant(source=source)
-        # split full text into words
-        full_text_words = chant.manuscript_full_text.split(" ")
-        # use a random subset of words as search term
-        search_term = " ".join(
-            random.choices(
-                full_text_words, k=random.randint(1, max(len(full_text_words) - 1, 1))
-            )
+        search_term = "quick"
+        chant_1 = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling="Quick brown fox jumps over the lazy dog",
+        )
+        chant_2 = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling="brown fox jumps over the lazy dog",
+        )
+        chant_3 = make_fake_chant(
+            source=source,
+            manuscript_full_text_std_spelling="lazy brown fox jumps quickly over the dog",
         )
         response = self.client.get(
             reverse("chant-search-ms", args=[source.id]),
             {"keyword": search_term, "op": "contains"},
         )
-        context_chant_id = response.context["chants"][0]["id"]
-        self.assertEqual(chant.id, context_chant_id)
+        first_context_chant_id = response.context["chants"][0]["id"]
+        self.assertEqual(chant_1.id, first_context_chant_id)
+        second_context_chant_id = response.context["chants"][1]["id"]
+        self.assertEqual(chant_3.id, second_context_chant_id)
 
     def test_source_link_column(self):
         siglum = "Sigl-01"

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1193,10 +1193,7 @@ class ChantSearchMSViewTest(TestCase):
 
     def test_keyword_search_contains(self):
         source = make_fake_source()
-        chant = Chant.objects.create(
-            source=source,
-            manuscript_full_text=faker.sentence(),
-        )
+        chant = make_fake_chant(source=source)
         # split full text into words
         full_text_words = chant.manuscript_full_text.split(" ")
         # use a random subset of words as search term


### PR DESCRIPTION
This PR resolves #659 where we discovered that the keyword search functionality only verifies if the expected results are retrieved. This solution improves existing test functions and adds a new test function to ensure that unwanted results are not being returned.
- remove the use of random generator for chants which resulted in indexing errors
- hard code `manuscript_full_text_std_spelling` in three different chants in `test_keyword_search_starts_with` and `test_keyword_search_contains` so we can check that the response only returns the desired number of results
- add `test_keyword_search_searching_all_fields` to make sure that the keyword search is using all the search columns

Thanks to @jacobdgm for their contributions in pair programming