### PR TITLE
Fix bug in CI Input Tool where table would be very narrow in Firefox

### DIFF
--- a/django/cantusdb_project/main_app/templates/ci_search.html
+++ b/django/cantusdb_project/main_app/templates/ci_search.html
@@ -13,7 +13,8 @@
         <a href="https://cantusindex.org/">Cantus Index</a> or contact the <a
             href="mailto:kolacek2010@gmail.com">administrator</a>
     </p>
-    <table class="table table-responsive table-sm small table-bordered table-striped table-hover">
+    <table class="table table-responsive table-sm small table-bordered table-striped table-hover" style="display: table;">
+        {# if we don't include 'style="display: table;"', the table is very narrow when viewed in certain browsers (e.g. Firefox) #}
         <thead class="thead-dark">
             <tr>
                 <th width="50">Select</th>


### PR DESCRIPTION
Fixes #639

The screenshots below are from Firefox; I've tested this in Safari and Chrome too. `test_views.py` runs as expected.

Before (screenshots from Firefox):
![Screenshot 2023-05-25 at 9 18 32 AM](https://github.com/DDMAL/CantusDB/assets/58090591/69005b16-ff0f-49b9-a34b-daa226e8ac98)

After:
![Screenshot 2023-05-25 at 9 17 39 AM](https://github.com/DDMAL/CantusDB/assets/58090591/7a2142f4-3d70-4cb5-a454-6b0f0166c886)
