### PR TITLE
Add link on Chant Proofread page to Edit Syllabification page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -195,6 +195,14 @@
                     {% endif %}
 
                     <div class="form-row">
+                        <div class="form-group m-1 col-lg-4">
+                            <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
+                                <small>Edit syllabification (new window)</small>
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <small>{{ form.image_link.label_tag }}</small>
                             {{ form.image_link }}


### PR DESCRIPTION
fixes #573.

This PR just takes a few lines of code from `chant_edit.html` and adds them in the appropriate place on `chant_proofread.html`.