### PR TITLE
Fix CI input tool populate and popup bugs

### DIFF
--- a/django/cantusdb_project/main_app/templates/ci_search.html
+++ b/django/cantusdb_project/main_app/templates/ci_search.html
@@ -42,8 +42,9 @@
             var cantus_id = document.getElementById(rowId).cells[1].innerText;
             var genre = document.getElementById(rowId).cells[2].innerText;
             var full_text = document.getElementById(rowId).cells[3].innerText;
-            var genres = {{ genres|safe }}; // genres contains "id" and "name" of Genre model
-            var genreId = (genres.find(item => item.name === genre) ?? {}).id;
+            var genres = {{ genres|safe }}; // genres contains "id" and "name" of all Genre objects in the database
+            var genreObj = genres.find(item => item.name === genre);
+            var genreId = genreId = genreObj ? genreObj.id : null;
 
             opener.document.getElementById('id_cantus_id').value = cantus_id;
             opener.document.getElementById('id_genre').value = genreId;

--- a/django/cantusdb_project/main_app/templates/ci_search.html
+++ b/django/cantusdb_project/main_app/templates/ci_search.html
@@ -42,6 +42,8 @@
             var cantus_id = document.getElementById(rowId).cells[1].innerText;
             var genre = document.getElementById(rowId).cells[2].innerText;
             var full_text = document.getElementById(rowId).cells[3].innerText;
+
+            // get the option value corresponding to the genre name
             var genres = {{ genres|safe }}; // genres contains "id" and "name" of all Genre objects in the database
             var genreObj = genres.find(item => item.name === genre);
             var genreId = genreId = genreObj ? genreObj.id : null;

--- a/django/cantusdb_project/main_app/templates/ci_search.html
+++ b/django/cantusdb_project/main_app/templates/ci_search.html
@@ -42,12 +42,11 @@
             var cantus_id = document.getElementById(rowId).cells[1].innerText;
             var genre = document.getElementById(rowId).cells[2].innerText;
             var full_text = document.getElementById(rowId).cells[3].innerText;
-
-            // get the option value corresponding to the genre name
-            const genreId = Array.prototype.find.call(opener.document.getElementById('id_genre').children, ({ textContent }) => textContent === genre);
+            var genres = {{ genres|safe }}; // genres contains "id" and "name" of Genre model
+            var genreId = (genres.find(item => item.name === genre) ?? {}).id;
 
             opener.document.getElementById('id_cantus_id').value = cantus_id;
-            opener.document.getElementById('id_genre').value = genreId.value;
+            opener.document.getElementById('id_genre').value = genreId;
             opener.document.getElementById('id_manuscript_full_text_std_spelling').value = full_text;
             close()
         }

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3665,6 +3665,7 @@ class CISearchViewTest(TestCase):
         fake_search_term = faker.word()
         response = self.client.get(f"/ci-search/{fake_search_term}")
         self.assertTrue("results" in response.context)
+        self.assertTrue("genres" in response.context)
 
 
 class CsvExportTest(TestCase):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1290,8 +1290,10 @@ class CISearchView(TemplateView):
 
     def get_context_data(self, **kwargs):
         MAX_PAGE_NUMBER_CI = 5
-
         context = super().get_context_data(**kwargs)
+        context["genres"] = list(
+            Genre.objects.all().order_by("name").values("id", "name")
+        )
         search_term = kwargs["search_term"]
         search_term = search_term.replace(" ", "+")  # for multiple keywords
         # Create empty list for the 3 types of info


### PR DESCRIPTION
This PR addresses a bug in the CI input tool on the create chant page. Previously, the window wouldn't close after using the tool, and the "Genre:" and "Text:" fields wouldn't populate correctly. The issue stemmed from a mismatch between genre names in the autoFill function. This PR introduces a solution by passing a "genres" list to the context data, containing the id and name of the Genre model. Now, the autoFill function can directly match the genre name with the corresponding id from the genres list.

Fixes #637, fixes #638 