### PR TITLE
Take user back to chant detail page after chant edit

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -18,7 +18,7 @@
             
             {% if user_can_edit_chant %}
                 <p>
-                    View | <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}">Edit</a>
+                    View | <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}&ref=chant-detail">Edit</a>
                 </p>
             {% endif %}
             

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1673,13 +1673,13 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             return super().form_invalid(form)
 
     def get_success_url(self):
-        # Take user back to chant list page if that is the referrer page
+        # Take user back to the referring page
         # `ref` url parameter is used to indicate referring page
         next_url = self.request.GET.get("ref")
-        if next_url == "chant-list":
+        if next_url:
             return self.request.POST.get("referrer")
         else:
-            # stay on the same page after save
+            # ref not found, stay on the same page after save
             return self.request.get_full_path()
 
 


### PR DESCRIPTION
This PR resolves #653, where the user was not redirected to the referring page after saving changes on the chant edit page. Building upon the solution implemented in PR #650, we use a ref parameter in the URL to indicate the referring page. This allows us to retrieve the referring page information from request.META.HTTP_REFERER and properly redirect the user after saving.

Instead of using a boolean flag, we utilize the ref parameter to differentiate between referring pages such as "chant-list" or "chant-detail". This approach offers flexibility for potential future developments that may require specific operations based on the referring page.