### PR TITLE
Edit user source list to use siglum

### DIFF
--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -13,7 +13,7 @@
                         <tr>
                             <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0; text-align:center">
                                 <a href="{% url "source-detail" source.pk %}">
-                                    <b>{{ source.title }}</b>
+                                    <b>{{ source.siglum }}</b>
                                 </a>
                             </td>
                             <td class="h-25" style="width: 30%; text-align:center">
@@ -48,7 +48,7 @@
                                 <tr>
                                     <td class="h-25" style="width: 50%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0; text-align:center">
                                         <a href="{% url "source-detail" my_source.pk %}">
-                                            <b>&bull; {{ my_source.title }}</b>
+                                            <b>&bull; {{ my_source.siglum }}</b>
                                         </a>
                                         <br>
                                         <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">


### PR DESCRIPTION
This PR resolves #643 where the user source list would display the full title of the source list. The modification uses the siglum instead of the title in the "My Sources" table and the "Sources Created by User" sidebar.