### PR TITLE
Update ports in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - 8000:80
+      - 80:80
     volumes:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static


### PR DESCRIPTION
This PR changes the ports in our `docker-compose.yml` file. This change is already present, as an uncommitted change, on staging and production (or at least, it is present when the apps are running and reachable). I don't know why the ports were set to `8000:80` in the first place, but testing this locally, upon running `docker-compose up -d`, I'm able to reach the app directly at `localhost`, rather than having to run `python manage.py runserver <a port that isn't 8000>`.