### PR TITLE
fix parse-json-from-api bug

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -100,8 +100,7 @@ def parse_json_from_api(url: str) -> Union[list, None]:
             print(  # eventually, we should log this rather than printing it to the console
                 "Encountered an error in",
                 "ChantCreateView.get_suggested_chants.make_suggested_chant_dict",
-                "while parsing the response from",
-                f"https://cantusindex.org/json-cid/{cantus_id}:",
+                f"while parsing the response from {url}",
                 exc,
             )
             return None


### PR DESCRIPTION
While browsing through the code, I came across this bug in the `parse_json_from_api` function that was left over from an older version of the code that used `cantus_id` variable that doesn't exist anymore. Modified so that it uses the url argument instead as seen in the first try/except block.