### PR TITLE
Improve query optimization

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -61,11 +61,9 @@ INSTALLED_APPS = [
     "articles",
     "django_quill",  # to provide rich-text field for articles
     "users",
-    "debug_toolbar",
 ]
 
 MIDDLEWARE = [
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -171,3 +169,7 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+if DEBUG:
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -62,12 +62,12 @@ INSTALLED_APPS = [
     "django_quill",  # to provide rich-text field for articles
     "users",
     "debug_toolbar",
-    "silk",
+    # "silk",
 ]
 
 MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
-    "silk.middleware.SilkyMiddleware",
+    # "silk.middleware.SilkyMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -174,3 +174,7 @@ if DEBUG:
 
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1"]
+
+SILKY_MAX_REQUEST_BODY_SIZE = -1  # Silk takes anything <0 as no limit
+SILKY_MAX_RESPONSE_BODY_SIZE = 1024  # If response body>1024 bytes, ignore
+SILKY_META = True

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -62,12 +62,10 @@ INSTALLED_APPS = [
     "django_quill",  # to provide rich-text field for articles
     "users",
     "debug_toolbar",
-    # "silk",
 ]
 
 MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
-    # "silk.middleware.SilkyMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -170,11 +168,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 if DEBUG:
-    import socket  # only if you haven't already imported this
+    import socket
 
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1"]
-
-SILKY_MAX_REQUEST_BODY_SIZE = -1  # Silk takes anything <0 as no limit
-SILKY_MAX_RESPONSE_BODY_SIZE = 1024  # If response body>1024 bytes, ignore
-SILKY_META = True

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -167,8 +167,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-if DEBUG:
-    import socket
 
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1"]
+INTERNAL_IPS = [
+    "127.0.0.1",
+]

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -62,10 +62,12 @@ INSTALLED_APPS = [
     "django_quill",  # to provide rich-text field for articles
     "users",
     "debug_toolbar",
+    "silk",
 ]
 
 MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "silk.middleware.SilkyMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -172,4 +172,5 @@ INTERNAL_IPS = [
 
 if DEBUG:
     INSTALLED_APPS.append("debug_toolbar")
+    # debug toolbar must be inserted as early in the middleware as possible
     MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
     "articles",
     "django_quill",  # to provide rich-text field for articles
     "users",
+    "debug_toolbar",
 ]
 
 MIDDLEWARE = [
@@ -72,6 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "cantusdb.urls"
@@ -164,3 +166,5 @@ SITE_ID = 4
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+INTERNAL_IPS = ["127.0.0.1"]

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -172,4 +172,4 @@ INTERNAL_IPS = [
 
 if DEBUG:
     INSTALLED_APPS.append("debug_toolbar")
-    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -73,7 +74,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "cantusdb.urls"
@@ -167,4 +167,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-INTERNAL_IPS = ["127.0.0.1"]
+if DEBUG:
+    import socket  # only if you haven't already imported this
+
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1"]

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -59,6 +59,7 @@ from main_app.views.user import (
 
 urlpatterns = [
     path("__debug__/", include(debug_toolbar.urls)),
+    path("silk/", include("silk.urls", namespace="silk")),
     path(
         "contact/",
         views.contact,

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -59,7 +59,7 @@ from main_app.views.user import (
 
 urlpatterns = [
     path("__debug__/", include(debug_toolbar.urls)),
-    path("silk/", include("silk.urls", namespace="silk")),
+    # path("silk/", include("silk.urls", namespace="silk")),
     path(
         "contact/",
         views.contact,

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -59,7 +59,6 @@ from main_app.views.user import (
 
 urlpatterns = [
     path("__debug__/", include(debug_toolbar.urls)),
-    # path("silk/", include("silk.urls", namespace="silk")),
     path(
         "contact/",
         views.contact,

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -1,5 +1,6 @@
-from django.urls import path
+from django.urls import include, path
 from main_app.views import views
+import debug_toolbar
 from main_app.views.century import (
     CenturyDetailView,
 )
@@ -57,6 +58,7 @@ from main_app.views.user import (
 )
 
 urlpatterns = [
+    path("__debug__/", include(debug_toolbar.urls)),
     path(
         "contact/",
         views.contact,

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -553,7 +553,7 @@ class ChantListView(ListView):
             chants_in_source = (
                 source.chant_set.exclude(feast=None)
                 .order_by("folio", "c_sequence")
-                .prefetch_related(Prefetch("feast", queryset=Feast.objects.all()))
+                .select_related("feast")
             )
             # initialize the feast selector options with the first chant in the source that has a feast
             first_feast_chant = chants_in_source.first()
@@ -1471,7 +1471,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             chants_in_source = (
                 source.chant_set.exclude(feast=None)
                 .order_by("folio", "c_sequence")
-                .prefetch_related(Prefetch("feast", queryset=Feast.objects.all()))
+                .select_related("feast")
             )
             # initialize the feast selector options with the first chant in the source that has a feast
             first_feast_chant = chants_in_source.first()

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -226,30 +226,29 @@ def get_feast_selector_options(source, folios):
     # initialize the feast selector options with the first chant in the source that has a feast
     first_feast_chant = chants_in_source.first()
     if not first_feast_chant:
-        # if none of the chants in this source has a feast, return an empty zip
-        folios_with_feasts = []
-    else:
-        # if there is at least one chant that has a feast
-        current_feast = first_feast_chant.feast
-        feast_selector_feasts.append(current_feast)
-        current_folio = first_feast_chant.folio
-        feast_selector_folios.append(current_folio)
+        # if none of the chants in this source has a feast, return an empty list
+        return []
+    # if there is at least one chant that has a feast
+    current_feast = first_feast_chant.feast
+    feast_selector_feasts.append(current_feast)
+    current_folio = first_feast_chant.folio
+    feast_selector_folios.append(current_folio)
 
-        chants_by_folio = chants_in_source.filter(folio__in=folios).order_by("folio")
-        for chant in chants_by_folio:
-            if chant.feast != current_feast:
-                # if the feast changes, add the new feast and the corresponding folio to the lists
-                feast_selector_feasts.append(chant.feast)
-                feast_selector_folios.append(chant.folio)
-                # update the current_feast to track future changes
-                current_feast = chant.feast
-        # as the two lists will always be of the same length, no need for zip,
-        # just naively combine them
-        # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value
-        folios_with_feasts = [
-            (feast_selector_folios[i], feast_selector_feasts[i])
-            for i in range(len(feast_selector_folios))
-        ]
+    chants_by_folio = chants_in_source.filter(folio__in=folios).order_by("folio")
+    for chant in chants_by_folio:
+        if chant.feast != current_feast:
+            # if the feast changes, add the new feast and the corresponding folio to the lists
+            feast_selector_feasts.append(chant.feast)
+            feast_selector_folios.append(chant.folio)
+            # update the current_feast to track future changes
+            current_feast = chant.feast
+    # as the two lists will always be of the same length, no need for zip,
+    # just naively combine them
+    # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value
+    folios_with_feasts = [
+        (feast_selector_folios[i], feast_selector_feasts[i])
+        for i in range(len(feast_selector_folios))
+    ]
     return folios_with_feasts
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -515,7 +515,7 @@ class ChantListView(ListView):
         search_text = self.request.GET.get("search_text")
 
         # get all chants in the specified source
-        chants = source.chant_set
+        chants = source.chant_set.select_related("feast", "office", "genre")
         # filter the chants with optional search params
         if feast_id:
             chants = chants.filter(feast__id=feast_id)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -100,8 +100,7 @@ def parse_json_from_api(url: str) -> Union[list, None]:
             print(  # eventually, we should log this rather than printing it to the console
                 "Encountered an error in",
                 "ChantCreateView.get_suggested_chants.make_suggested_chant_dict",
-                "while parsing the response from",
-                f"https://cantusindex.org/json-cid/{cantus_id}:",
+                f"while parsing the response from {url}",
                 exc,
             )
             return None

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -553,7 +553,7 @@ class ChantListView(ListView):
             chants_in_source = (
                 source.chant_set.exclude(feast=None)
                 .order_by("folio", "c_sequence")
-                .select_related("feast")
+                .prefetch_related("feast", "folio")
             )
             # initialize the feast selector options with the first chant in the source that has a feast
             first_feast_chant = chants_in_source.first()
@@ -567,9 +567,12 @@ class ChantListView(ListView):
                 current_folio = first_feast_chant.folio
                 feast_selector_folios.append(current_folio)
 
+                chants_by_folio = chants_in_source.filter(folio__in=folios).order_by(
+                    "folio"
+                )
                 for folio in folios:
                     # get all chants on each folio
-                    chants_on_folio = chants_in_source.filter(folio=folio)
+                    chants_on_folio = chants_by_folio[folio]
                     for chant in chants_on_folio:
                         if chant.feast != current_feast:
                             # if the feast changes, add the new feast and the corresponding folio to the lists

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -577,17 +577,6 @@ class ChantListView(ListView):
                         feast_selector_folios.append(chant.folio)
                         # update the current_feast to track future changes
                         current_feast = chant.feast
-
-                # for folio in folios:
-                #     # get all chants on each folio
-                #     chants_on_folio = chants_by_folio[folio]
-                #     for chant in chants_on_folio:
-                #         if chant.feast != current_feast:
-                #             # if the feast changes, add the new feast and the corresponding folio to the lists
-                #             feast_selector_feasts.append(chant.feast)
-                #             feast_selector_folios.append(folio)
-                #             # update the current_feast to track future changes
-                #             current_feast = chant.feast
                 # as the two lists will always be of the same length, no need for zip,
                 # just naively combine them
                 # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -5,7 +5,7 @@ import json
 import threading
 from django.contrib import messages
 from django.contrib.postgres.search import SearchQuery, SearchRank
-from django.db.models import F, Q, QuerySet, Value, Prefetch
+from django.db.models import F, Q, QuerySet, Value
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.generic import (

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -544,7 +544,7 @@ class ChantListView(ListView):
                 folios (list of strs): A list of folios in the source.
 
             Returns:
-                zip object: A zip object combining a list of folios and Feast objects, to be unpacked in template.
+                list of tuples: A list of folios and Feast objects, to be unpacked in template.
             """
             # the two lists to be zipped
             feast_selector_feasts = []
@@ -1462,7 +1462,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
                 folios (list of strs): A list of folios in the source.
 
             Returns:
-                zip object: A zip object combining a list of folios and Feast objects, to be unpacked in template.
+                list of tuples: A list of folios and Feast objects, to be unpacked in template.
             """
             # the two lists to be zipped
             feast_selector_feasts = []

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -201,6 +201,58 @@ def make_suggested_chant_dict(
     return cid_dict
 
 
+def get_feast_selector_options(source, folios):
+    """Generate folio-feast pairs as options for the feast selector
+
+    Going through all chants in the source, folio by folio,
+    a new entry (in the form of folio-feast) is added when the feast changes.
+
+    Args:
+        source (Source object): The source that the user is browsing in.
+        folios (list of strs): A list of folios in the source.
+
+    Returns:
+        list of tuples: A list of folios and Feast objects, to be unpacked in template.
+    """
+    # the two lists to be zipped
+    feast_selector_feasts = []
+    feast_selector_folios = []
+    # get all chants in the source, select those that have a feast
+    chants_in_source = (
+        source.chant_set.exclude(feast=None)
+        .order_by("folio", "c_sequence")
+        .select_related("feast")
+    )
+    # initialize the feast selector options with the first chant in the source that has a feast
+    first_feast_chant = chants_in_source.first()
+    if not first_feast_chant:
+        # if none of the chants in this source has a feast, return an empty zip
+        folios_with_feasts = []
+    else:
+        # if there is at least one chant that has a feast
+        current_feast = first_feast_chant.feast
+        feast_selector_feasts.append(current_feast)
+        current_folio = first_feast_chant.folio
+        feast_selector_folios.append(current_folio)
+
+        chants_by_folio = chants_in_source.filter(folio__in=folios).order_by("folio")
+        for chant in chants_by_folio:
+            if chant.feast != current_feast:
+                # if the feast changes, add the new feast and the corresponding folio to the lists
+                feast_selector_feasts.append(chant.feast)
+                feast_selector_folios.append(chant.folio)
+                # update the current_feast to track future changes
+                current_feast = chant.feast
+        # as the two lists will always be of the same length, no need for zip,
+        # just naively combine them
+        # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value
+        folios_with_feasts = [
+            (feast_selector_folios[i], feast_selector_feasts[i])
+            for i in range(len(feast_selector_folios))
+        ]
+    return folios_with_feasts
+
+
 class ChantDetailView(DetailView):
     """
     Displays a single Chant object. Accessed with ``chants/<int:pk>``
@@ -533,59 +585,6 @@ class ChantListView(ListView):
         return chants.order_by("id")
 
     def get_context_data(self, **kwargs):
-        def get_feast_selector_options(source, folios):
-            """Generate folio-feast pairs as options for the feast selector
-
-            Going through all chants in the source, folio by folio,
-            a new entry (in the form of folio-feast) is added when the feast changes.
-
-            Args:
-                source (Source object): The source that the user is browsing in.
-                folios (list of strs): A list of folios in the source.
-
-            Returns:
-                list of tuples: A list of folios and Feast objects, to be unpacked in template.
-            """
-            # the two lists to be zipped
-            feast_selector_feasts = []
-            feast_selector_folios = []
-            # get all chants in the source, select those that have a feast
-            chants_in_source = (
-                source.chant_set.exclude(feast=None)
-                .order_by("folio", "c_sequence")
-                .select_related("feast")
-            )
-            # initialize the feast selector options with the first chant in the source that has a feast
-            first_feast_chant = chants_in_source.first()
-            if not first_feast_chant:
-                # if none of the chants in this source has a feast, return an empty zip
-                folios_with_feasts = []
-            else:
-                # if there is at least one chant that has a feast
-                current_feast = first_feast_chant.feast
-                feast_selector_feasts.append(current_feast)
-                current_folio = first_feast_chant.folio
-                feast_selector_folios.append(current_folio)
-
-                chants_by_folio = chants_in_source.filter(folio__in=folios).order_by(
-                    "folio"
-                )
-                for chant in chants_by_folio:
-                    if chant.feast != current_feast:
-                        # if the feast changes, add the new feast and the corresponding folio to the lists
-                        feast_selector_feasts.append(chant.feast)
-                        feast_selector_folios.append(chant.folio)
-                        # update the current_feast to track future changes
-                        current_feast = chant.feast
-                # as the two lists will always be of the same length, no need for zip,
-                # just naively combine them
-                # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value
-                folios_with_feasts = [
-                    (feast_selector_folios[i], feast_selector_feasts[i])
-                    for i in range(len(feast_selector_folios))
-                ]
-            return folios_with_feasts
-
         context = super().get_context_data(**kwargs)
         # these are needed in the selectors on the left side of the page
         context["sources"] = Source.objects.order_by("siglum")
@@ -1451,59 +1450,6 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         return queryset.get()
 
     def get_context_data(self, **kwargs):
-        def get_feast_selector_options(source, folios):
-            """Generate folio-feast pairs as options for the feast selector
-
-            Going through all chants in the source, folio by folio,
-            a new entry (in the form of folio-feast) is added when the feast changes.
-
-            Args:
-                source (Source object): The source that the user is browsing in.
-                folios (list of strs): A list of folios in the source.
-
-            Returns:
-                list of tuples: A list of folios and Feast objects, to be unpacked in template.
-            """
-            # the two lists to be zipped
-            feast_selector_feasts = []
-            feast_selector_folios = []
-            # get all chants in the source, select those that have a feast
-            chants_in_source = (
-                source.chant_set.exclude(feast=None)
-                .order_by("folio", "c_sequence")
-                .select_related("feast")
-            )
-            # initialize the feast selector options with the first chant in the source that has a feast
-            first_feast_chant = chants_in_source.first()
-            if not first_feast_chant:
-                # if none of the chants in this source has a feast, return an empty zip
-                folios_with_feasts = []
-            else:
-                # if there is at least one chant that has a feast
-                current_feast = first_feast_chant.feast
-                feast_selector_feasts.append(current_feast)
-                current_folio = first_feast_chant.folio
-                feast_selector_folios.append(current_folio)
-
-                chants_by_folio = chants_in_source.filter(folio__in=folios).order_by(
-                    "folio"
-                )
-                for chant in chants_by_folio:
-                    if chant.feast != current_feast:
-                        # if the feast changes, add the new feast and the corresponding folio to the lists
-                        feast_selector_feasts.append(chant.feast)
-                        feast_selector_folios.append(chant.folio)
-                        # update the current_feast to track future changes
-                        current_feast = chant.feast
-                # as the two lists will always be of the same length, no need for zip,
-                # just naively combine them
-                # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value
-                folios_with_feasts = [
-                    (feast_selector_folios[i], feast_selector_feasts[i])
-                    for i in range(len(feast_selector_folios))
-                ]
-            return folios_with_feasts
-
         def get_chants_with_feasts(chants_in_folio):
             # this will be a nested list of the following format:
             # [

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -515,7 +515,7 @@ class ChantListView(ListView):
         search_text = self.request.GET.get("search_text")
 
         # get all chants in the specified source
-        chants = source.chant_set.select_related("feast", "office", "genre")
+        chants = source.chant_set.select_related("feast", "office", "genre", "folio")
         # filter the chants with optional search params
         if feast_id:
             chants = chants.filter(feast__id=feast_id)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -515,7 +515,7 @@ class ChantListView(ListView):
         search_text = self.request.GET.get("search_text")
 
         # get all chants in the specified source
-        chants = source.chant_set.select_related("feast", "office", "genre", "folio")
+        chants = source.chant_set.select_related("feast", "office", "genre")
         # filter the chants with optional search params
         if feast_id:
             chants = chants.filter(feast__id=feast_id)

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -220,7 +220,14 @@ class SourceListView(ListView):
             )
             q_obj_filter &= indexing_search_q
 
-        return queryset.filter(q_obj_filter).distinct()
+        print(Century.objects.all().order_by("name").values("id", "name"))
+        return (
+            queryset.filter(q_obj_filter)
+            .distinct()
+            .prefetch_related(
+                Prefetch("century", queryset=Century.objects.all().order_by("name"))
+            )
+        )
 
 
 class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -220,12 +220,11 @@ class SourceListView(ListView):
             )
             q_obj_filter &= indexing_search_q
 
-        print(Century.objects.all().order_by("name").values("id", "name"))
         return (
             queryset.filter(q_obj_filter)
             .distinct()
             .prefetch_related(
-                Prefetch("century", queryset=Century.objects.all().order_by("name"))
+                Prefetch("century", queryset=Century.objects.all().order_by("id"))
             )
         )
 

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -9,6 +9,7 @@ from django.http import HttpResponseRedirect
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
+from main_app.views.chant import get_feast_selector_options
 
 
 class SourceDetailView(DetailView):
@@ -17,59 +18,6 @@ class SourceDetailView(DetailView):
     template_name = "source_detail.html"
 
     def get_context_data(self, **kwargs):
-        def get_feast_selector_options(source, folios):
-            """Generate folio-feast pairs as options for the feast selector
-
-            Going through all chants in the source, folio by folio,
-            a new entry (in the form of folio-feast) is added when the feast changes.
-
-            Args:
-                source (Source object): The source object for this source detail page.
-                folios (list of strs): A list of folios in the source.
-
-            Returns:
-                list of tuples: A list of folios and Feast objects, to be unpacked in template.
-            """
-            # the two lists to be zipped
-            feast_selector_feasts = []
-            feast_selector_folios = []
-            # get all chants in the source, select those that have a feast
-            chants_in_source = (
-                source.chant_set.exclude(feast=None)
-                .order_by("folio", "c_sequence")
-                .select_related("feast")
-            )
-            # initialize the feast selector options with the first chant in the source that has a feast
-            first_feast_chant = chants_in_source.first()
-            if not first_feast_chant:
-                # if none of the chants in this source has a feast, return an empty list
-                folios_with_feasts = []
-            else:
-                # if there is at least one chant that has a feast
-                current_feast = first_feast_chant.feast
-                feast_selector_feasts.append(current_feast)
-                current_folio = first_feast_chant.folio
-                feast_selector_folios.append(current_folio)
-
-                chants_by_folio = chants_in_source.filter(folio__in=folios).order_by(
-                    "folio"
-                )
-                for chant in chants_by_folio:
-                    if chant.feast != current_feast:
-                        # if the feast changes, add the new feast and the corresponding folio to the lists
-                        feast_selector_feasts.append(chant.feast)
-                        feast_selector_folios.append(chant.folio)
-                        # update the current_feast to track future changes
-                        current_feast = chant.feast
-                # as the two lists will always be of the same length, no need for zip,
-                # just naively combine them
-                # if we use zip, the returned generator will be exhausted in rendering templates, making it hard to test the returned value
-                folios_with_feasts = [
-                    (feast_selector_folios[i], feast_selector_feasts[i])
-                    for i in range(len(feast_selector_folios))
-                ]
-            return folios_with_feasts
-
         source = self.get_object()
         display_unpublished = self.request.user.is_authenticated
         if (source.published is False) and (not display_unpublished):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -168,12 +168,8 @@ class SourceListView(ListView):
             )
             q_obj_filter &= indexing_search_q
 
-        return (
-            queryset.filter(q_obj_filter)
-            .distinct()
-            .prefetch_related(
-                Prefetch("century", queryset=Century.objects.all().order_by("id"))
-            )
+        return queryset.filter(q_obj_filter).prefetch_related(
+            Prefetch("century", queryset=Century.objects.all().order_by("id"))
         )
 
 

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -42,7 +42,7 @@ class SourceDetailView(DetailView):
             # initialize the feast selector options with the first chant in the source that has a feast
             first_feast_chant = chants_in_source.first()
             if not first_feast_chant:
-                # if none of the chants in this source has a feast, return an empty zip
+                # if none of the chants in this source has a feast, return an empty list
                 folios_with_feasts = []
             else:
                 # if there is at least one chant that has a feast

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -37,7 +37,7 @@ class SourceDetailView(DetailView):
             chants_in_source = (
                 source.chant_set.exclude(feast=None)
                 .order_by("folio", "c_sequence")
-                .prefetch_related(Prefetch("feast", queryset=Feast.objects.all()))
+                .select_related("feast")
             )
             # initialize the feast selector options with the first chant in the source that has a feast
             first_feast_chant = chants_in_source.first()

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -1,6 +1,6 @@
 from django.views.generic import DetailView, ListView, CreateView, UpdateView
 from django.db.models import Q, Prefetch
-from main_app.models import Source, Provenance, Century, Feast
+from main_app.models import Source, Provenance, Century
 from main_app.forms import SourceCreateForm, SourceEditForm
 from django.contrib import messages
 from django.urls import reverse


### PR DESCRIPTION
This PR is a step in the process of improving our query optimization for slow-loading pages. Previously, certain pages such as source-detail and chant-list would take a significant amount of time to load due to a large number of similar or duplicate SQL queries. The solution mainly involves the use of django's `select_related` and `prefetch_related` methods that allow for improvements in the number of database hits. More specifically:
- add debug toolbar settings for development
- refactor `feast_selector_options` method to remove unnecessary nested loop
- use `select_related` and `prefetch_related` mothods to retrieve relevant data and optimize database queries by reduce the number of database hits when accessing related objects.

Here is an example of an improved query optimization on the source-detail page.

Before:
![Screenshot 2023-05-30 at 11 05 06 AM copy](https://github.com/DDMAL/CantusDB/assets/71031342/34cca68b-af38-432c-b9e1-d1dce88eb9bb)


After:
![Screenshot 2023-05-30 at 11 05 53 AM copy](https://github.com/DDMAL/CantusDB/assets/71031342/50a5f6de-a54a-4fd8-a0cb-11708b11b205)