### PR TITLE
Reorder chant edit fields

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -277,6 +277,7 @@ class ChantEditForm(forms.ModelForm):
             "extra",
             "image_link",
             "indexing_notes",
+            "addendum",
         ]
         widgets = {
             # manuscript_full_text_std_spelling: defined below (required)
@@ -298,6 +299,7 @@ class ChantEditForm(forms.ModelForm):
             "extra": TextInputWidget(),
             "image_link": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
+            "addendum": TextInputWidget(),
         }
 
     manuscript_full_text_std_spelling = forms.CharField(

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -152,7 +152,7 @@
                         {{ form.melody_id }}
                     </div>
 
-                    <div class="form-row align-items-top"> <!-- the Addendum field is no longer there in OldCantus... -->
+                    <div class="form-row align-items-top">
                         <div class="form-group m-1 col-lg">
                             <small>{{ form.addendum.label_tag }}</small>
                             {{ form.addendum }}

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -152,6 +152,13 @@
                         {{ form.melody_id }}
                     </div>
 
+                    <div class="form-row align-items-top"> <!-- the Addendum field is no longer there in OldCantus... -->
+                        <div class="form-group m-1 col-lg">
+                            <small>{{ form.addendum.label_tag }}</small>
+                            {{ form.addendum }}
+                        </div>
+                    </div>
+
                 </div>
             
                 <div class="form-row align-items-end">
@@ -208,13 +215,6 @@
                     <div class="form-group m-1 col-lg">
                         <small>{{ form.indexing_notes.label_tag }}</small>
                         {{ form.indexing_notes }}
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end"> <!-- the Addendum field is no longer there in OldCantus... -->
-                    <div class="form-group m-1 col-lg">
-                        <small>{{ form.addendum.label_tag }}</small>
-                        {{ form.addendum }}
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -112,6 +112,14 @@
                             {{ form.extra }}
                         </div>
                     </div>
+                    <div class="form-row">
+                        <div class="form-row align-items-top"> 
+                            <div class="form-group m-1 col-lg-8">
+                                <small>{{ form.addendum.label_tag }}</small>
+                                {{ form.addendum }}
+                            </div>
+                        </div>
+                    </div>
                                         
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -39,77 +39,7 @@
                 {% endif %}
                 <form method="post" style="line-height: normal">{% csrf_token %}
                     <input type="hidden" name="referrer" value="{{ request.META.HTTP_REFERER }}">
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                <small>Manuscript Reading Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
-                            </label>
-                            {{ form.manuscript_full_text_std_spelling }}
-                            <script>
-                                function autoFillSuggestedFulltext() {
-                                    if (document.getElementById('id_manuscript_full_text_std_spelling').value == "") {
-                                        document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ suggested_fulltext }}";
-                                    }
-                                }
-                                autoFillSuggestedFulltext();
-                            </script>
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-4">
-                            <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.manuscript_full_text.id_for_label }}">
-                                <small>Manuscript Reading Full Text (MS spelling):</small>
-                            </label>
-                            {{ form.manuscript_full_text }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.volpiano.id_for_label }}">
-                                <small>Volpiano:</small>
-                            </label>
-                            {{ form.volpiano }}
-                        </div>
-                    </div>
-
-                    {% if chant.volpiano %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <small>Preview of melody with text:</small>
-                                {% if chant.manuscript_syllabized_full_text %}
-                                    <p><small>Syllabification is based on saved syllabized text.</small></p>
-                                {% endif %}
-                                <dd>
-                                    {% for zip in syllabized_text_with_melody %}
-                                        {% for syl_mel, syl_text in zip %}
-                                            <span style="float: left">
-                                                <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
-                                                <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
-                                                <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
-                                            </span>
-                                        {% endfor %}
-                                    {% endfor %}
-                                </dd>
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-4">
-                            <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
-                                <small>Edit syllabification (new window)</small>
-                            </a>
-                        </div>
-                    </div>
-
+                    
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-2">
                             <small>{{ form.marginalia.label_tag }}</small>
@@ -180,6 +110,77 @@
                         <div class="form-group m-1 col-lg-2">
                             <small>{{ form.extra.label_tag }}</small>
                             {{ form.extra }}
+                        </div>
+                    </div>
+                                        
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-12">
+                            <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
+                                <small>Manuscript Reading Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
+                            </label>
+                            {{ form.manuscript_full_text_std_spelling }}
+                            <script>
+                                function autoFillSuggestedFulltext() {
+                                    if (document.getElementById('id_manuscript_full_text_std_spelling').value == "") {
+                                        document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ suggested_fulltext }}";
+                                    }
+                                }
+                                autoFillSuggestedFulltext();
+                            </script>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-4">
+                            <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-12">
+                            <label for="{{ form.manuscript_full_text.id_for_label }}">
+                                <small>Manuscript Reading Full Text (MS spelling):</small>
+                            </label>
+                            {{ form.manuscript_full_text }}
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-12">
+                            <label for="{{ form.volpiano.id_for_label }}">
+                                <small>Volpiano:</small>
+                            </label>
+                            {{ form.volpiano }}
+                        </div>
+                    </div>
+
+                    {% if chant.volpiano %}
+                        <div class="form-row">
+                            <div class="form-group m-1 col-lg-12">
+                                <small>Preview of melody with text:</small>
+                                {% if chant.manuscript_syllabized_full_text %}
+                                    <p><small>Syllabification is based on saved syllabized text.</small></p>
+                                {% endif %}
+                                <dd>
+                                    {% for zip in syllabized_text_with_melody %}
+                                        {% for syl_mel, syl_text in zip %}
+                                            <span style="float: left">
+                                                <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
+                                                <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
+                                                <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
+                                            </span>
+                                        {% endfor %}
+                                    {% endfor %}
+                                </dd>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-4">
+                            <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
+                                <small>Edit syllabification (new window)</small>
+                            </a>
                         </div>
                     </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -211,22 +211,8 @@
 
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
-                            <small>{{ form.siglum.label_tag }}</small>
-                            {{ form.siglum }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
                             <small>{{ form.proofread_by.label_tag }}</small>
                             {{ form.proofread_by }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <small>{{ form.manuscript_syllabized_full_text.label_tag }}</small>
-                            {{ form.manuscript_syllabized_full_text }}
                         </div>
                     </div>
 


### PR DESCRIPTION
This PR improves organization of fields in the chant edit page. The current order of fields is adjusted to match the order displayed in the chant detail page and aligns with the behaviour of oldCantus.

![image](https://github.com/DDMAL/CantusDB/assets/71031342/72440b2d-396e-49ee-9ed2-ca7dbde722bf)

Resolves #517 