### PR TITLE
Reorder chants by folio in "Browse Chants" page

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -530,7 +530,7 @@ class ChantListView(ListView):
                 | Q(incipit__icontains=search_text)
                 | Q(manuscript_full_text__icontains=search_text)
             )
-        return chants.order_by("folio")
+        return chants.order_by("folio", "c_sequence")
 
     def get_context_data(self, **kwargs):
         def get_feast_selector_options(source, folios):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -530,7 +530,7 @@ class ChantListView(ListView):
                 | Q(incipit__icontains=search_text)
                 | Q(manuscript_full_text__icontains=search_text)
             )
-        return chants.order_by("id")
+        return chants.order_by("folio")
 
     def get_context_data(self, **kwargs):
         def get_feast_selector_options(source, folios):


### PR DESCRIPTION
This PR addresses the issue of incorrect ordering of chants on the "Browse Chants" page for a source. Currently, the chants are ordered based on the time they were added, instead of their folio. As a result, if chants were added out of order, they would be displayed in the wrong sequence. The solution is simply reordering the queryset returned in the ChantListView to be ordered by "folio" rather than "id".

As for the other comments mentioned in #524 regarding the missing siglum, I could not replicate this behaviour. When I add a chant the siglum corresponds to the source that it has been added in. Perhaps this has already been resolved.

Fixes #524 