### PR TITLE
Add django debug toolbar

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -165,6 +165,25 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
+# automatically disable all panels which user can then manually enable
+DEBUG_TOOLBAR_CONFIG = {
+    "DISABLE_PANELS": {
+        "debug_toolbar.panels.history.HistoryPanel",
+        "debug_toolbar.panels.versions.VersionsPanel",
+        "debug_toolbar.panels.timer.TimerPanel",
+        "debug_toolbar.panels.settings.SettingsPanel",
+        "debug_toolbar.panels.headers.HeadersPanel",
+        "debug_toolbar.panels.request.RequestPanel",
+        "debug_toolbar.panels.sql.SQLPanel",
+        "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+        "debug_toolbar.panels.templates.TemplatesPanel",
+        "debug_toolbar.panels.cache.CachePanel",
+        "debug_toolbar.panels.signals.SignalsPanel",
+        "debug_toolbar.panels.logging.LoggingPanel",
+        "debug_toolbar.panels.redirects.RedirectsPanel",
+        "debug_toolbar.panels.profiling.ProfilingPanel",
+    },
+}
 
 INTERNAL_IPS = [
     "127.0.0.1",


### PR DESCRIPTION
This PR introduces the necessary changes to settings.py for setting up the Django Debug Toolbar in development projects. The `DEBUG` environment variable is still set using `bool(strtobool(os.getenv("CANTUSDB_DEBUG", "False")))` which maintains the ability to set `DEBUG` to True/False in the staging and production servers using this environment variable.

In addition, the `DEBUG_TOOLBAR_CONFIG` setting has been modified. By default, all panels in the debug toolbar are now disabled. This decision was made to prevent any potential impact on page loading times, as some panels like the `SQLPanel` can significantly slow down page loading. The user has the flexibility to manually enable specific panels they wish to use during development.
