### PR TITLE
Update Django version to 4.2.1, and fix bug in ChantSearchView

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -831,7 +831,7 @@ class ChantSearchView(ListView):
                 else:
                     order = order_get_param
             else:
-                order = "siglum"
+                order = "source__siglum"
 
             # sort values: "asc" and "desc". Default is "asc"
             if sort_get_param and sort_get_param == "desc":

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-asgiref==3.5.2
+asgiref==3.6.0
 astroid==2.4.2
 attrs==19.3.0
 backports.zoneinfo==0.2.1
@@ -9,7 +9,7 @@ chardet==3.0.4
 charset-normalizer==2.0.12
 click==7.1.2
 coverage==5.3.1
-Django==4.1.9
+Django==4.2.1
 django-autocomplete-light==3.5.1
 django-extra-views==0.13.0
 django-quill-editor==0.1.40


### PR DESCRIPTION
This PR updates the Django version from 4.1.9 to 4.2.1.

It appears that, in Django 4.2, if you try to `order_by` a column not in the queryset, Django throws an error (whereas in 4.1, this would pass silently). So as part of upgrading Django, we fixed a bug in the ChantSearchView where we thought we were ordering by a chant's source's `siglum` but we in fact weren't.

fixes #624, fixes #655

Credit to @PythonSemicolon for his help in debugging this!