### PR TITLE
Notation detail page: add title attribute to all sources, displaying the sources' sigla

### DIFF
--- a/django/cantusdb_project/main_app/templates/notation_detail.html
+++ b/django/cantusdb_project/main_app/templates/notation_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in notation.sources.all|dictsort:"title" %}
             <li>
-                <a href="{% url 'source-detail' source.id %}">
+                <a href="{% url 'source-detail' source.id %}" title="{{ source.siglum }}">
                     {{ source.title }}
                 </a>
             </li>


### PR DESCRIPTION
This PR adds a tiny UI enhancement - on the Notation Detail page, if you hover over one of the listed sources, it now display's the source's Siglum.