### PR TITLE
Improve layout/etc. of Feast Detail page

### DIFF
--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -32,8 +32,10 @@
             </div>
         {% endif %}
         {% if feast.notes %}
-            <dt>Notes</dt>
-            <dd>{{ feast.notes }}</dd>
+            <div class="col">
+                <dt>Notes</dt>
+                <dd>{{ feast.notes }}</dd>
+            </div>
         {% endif %}
     </div>
 

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -41,56 +41,60 @@
 
     <br>
     <div class="row">
-        <div class="col">
-            <h4>The most frequent chants</h4>
-            <small>Displaying 1 - {{ frequent_chants_zip|length }} of <b>{{ frequent_chants_zip|length }}</b></small>
-            <table class="table table-bordered table-sm small">
-                <thead>
-                    <tr>
-                        <th scope="col" class="text-wrap" style="text-align:center">CantusID</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Incipit</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Genre</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Chants</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for cantus_id, incipit, genre, count in frequent_chants_zip %}
-                    <tr>
-                        {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
-                        <td><a href="{% url 'chant-by-cantus-id' cantus_id|urlencode:"" %}">{{ cantus_id|default:"" }}</a></td>
-                        <td>{{ incipit }}</td>
-                        <td>
-                            {% if genre %}
-                                <a href="{% url 'genre-detail' genre.id %}" title="{{ genre.description }}">{{ genre.name }}</a>
-                            {% endif %}
-                        </td>
-                        <td>{{ count }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-
-        <div class="col">
-            <h4>Sources containing the feast</h4>
-            <small>Displaying 1 - {{ sources_zip|length }} of <b>{{ sources_zip|length }}</b></small>
-            <table class="table table-bordered table-sm small">
-                <thead>
-                    <tr>
-                        <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                        <th scope="col" class="text-wrap" style="text-align:center">Chants</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for source, count in sources_zip %}
+        {% if frequent_chants_zip %}
+            <div class="col">
+                <h4>Most frequent chants</h4>
+                <small>Displaying 1 - {{ frequent_chants_zip|length }} of <b>{{ frequent_chants_zip|length }}</b></small>
+                <table class="table table-bordered table-sm small">
+                    <thead>
                         <tr>
-                            <td><a href="{% url 'chant-list' %}?source={{ source.id }}" title="{{ source.title }}">{{ source.siglum }}</a></td>
-                            <td><a href="{% url 'chant-list' %}?source={{ source.id }}&feast={{ feast.id }}">{{ count }}</a></td>
+                            <th scope="col" class="text-wrap" style="text-align:center">CantusID</th>
+                            <th scope="col" class="text-wrap" style="text-align:center">Incipit</th>
+                            <th scope="col" class="text-wrap" style="text-align:center">Genre</th>
+                            <th scope="col" class="text-wrap" style="text-align:center">Chants</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                        {% for cantus_id, incipit, genre, count in frequent_chants_zip %}
+                        <tr>
+                            {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
+                            <td><a href="{% url 'chant-by-cantus-id' cantus_id|urlencode:"" %}">{{ cantus_id|default:"" }}</a></td>
+                            <td>{{ incipit }}</td>
+                            <td>
+                                {% if genre %}
+                                    <a href="{% url 'genre-detail' genre.id %}" title="{{ genre.description }}">{{ genre.name }}</a>
+                                {% endif %}
+                            </td>
+                            <td>{{ count }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+
+        {% if sources_zip %}
+            <div class="col">
+                <h4>Sources containing the feast</h4>
+                <small>Displaying 1 - {{ sources_zip|length }} of <b>{{ sources_zip|length }}</b></small>
+                <table class="table table-bordered table-sm small">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                            <th scope="col" class="text-wrap" style="text-align:center">Chants</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for source, count in sources_zip %}
+                            <tr>
+                                <td><a href="{% url 'chant-list' %}?source={{ source.id }}" title="{{ source.title }}">{{ source.siglum }}</a></td>
+                                <td><a href="{% url 'chant-list' %}?source={{ source.id }}&feast={{ feast.id }}">{{ count }}</a></td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR improves some buggy formatting on the Feast detail page. Previously, "Notes" would run right up against the value in the `notes` field. Also, even if there were no "most frequent chants", we would try to display a table with the first 1 to 0 of those chants. This PR improves the formatting of the Notes area, and hides the two tables if there are no frequent chants or sources containing the feast.

Previously:
![Screenshot 2023-06-05 at 4 04 13 PM](https://github.com/DDMAL/CantusDB/assets/58090591/85525beb-b5f1-4bb5-8a96-93df910bb351)

Now (actually, now it says "Most frequent chants" rather than "The most..."):
![Screenshot 2023-06-05 at 4 07 45 PM](https://github.com/DDMAL/CantusDB/assets/58090591/c6aecc78-85ce-4055-9efd-0ac4b7333019)

Previously:
![Screenshot 2023-06-05 at 4 15 56 PM](https://github.com/DDMAL/CantusDB/assets/58090591/cca7fc12-0bc4-442d-8e13-4062f57c2c6b)

Now:
![Screenshot 2023-06-05 at 4 15 07 PM](https://github.com/DDMAL/CantusDB/assets/58090591/738afaba-8687-4973-9b05-f2d36ef0fefd)