### PR TITLE
Bring CSV export view into alignment with OldCantus

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -163,7 +163,7 @@
                         <br>
                         <a href="{% url "chant-list" %}?source={{ source.id }}" class="guillemet" target="_blank">View all chants</a>
                         <a href="{% url "chant-index" %}?source={{ source.id }}" class="guillemet" target="_blank">View full inventory</a>
-                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
+                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
                         <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
                         {% if source.image_link %}
                             <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -301,6 +301,11 @@ urlpatterns = [
         name="csv-export",
     ),
     path(
+        "sites/default/files/csv/<str:source_id>.csv",
+        views.csv_export_redirect_from_old_path,
+        name="csv-export-old-path",
+    ),
+    path(
         "ajax/concordance/<str:cantus_id>",
         views.ajax_concordance_list,
         name="ajax-concordance",

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -296,7 +296,7 @@ urlpatterns = [
         name="items-count",
     ),
     path(
-        "csv/<str:source_id>",
+        "csv/<str:source_id>.csv",
         views.csv_export,
         name="csv-export",
     ),

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -296,7 +296,7 @@ urlpatterns = [
         name="items-count",
     ),
     path(
-        "csv/<str:source_id>.csv",
+        "source/<str:source_id>/csv/",
         views.csv_export,
         name="csv-export",
     ),

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1,7 +1,7 @@
 import csv
 from django.http.response import JsonResponse
 from django.http import HttpResponse, HttpResponseNotFound
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.urls.base import reverse
 from main_app.models import (
     Century,
@@ -252,6 +252,10 @@ def csv_export(request, source_id):
         )
 
     return response
+
+
+def csv_export_redirect_from_old_path(request, source_id):
+    return redirect(reverse("csv-export", args=[source_id]))
 
 
 def contact(request):

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -175,7 +175,9 @@ def csv_export(request, source_id):
     except:
         raise Http404("This source does not exist")
 
-    if not source.published:
+    display_unpublished = request.user.is_authenticated
+
+    if (not source.published) and (not display_unpublished):
         raise PermissionDenied
 
     # "4064" is the segment id of the sequence DB, sources in that segment have sequences instead of chants


### PR DESCRIPTION
This PR makes two changes:

- fixes #698 - now, any logged-in user can download any source's CSV, whether it is published or not. Anonymous users can only download published sources' CSV files
- for backwards compatibility, set up a redirect from OldCantus's path to the new path for the API
  - OldCantus's path is much more complicated, and rather opaque: `https://cantus.uwaterloo.ca/sites/default/files/csv/<source id>.csv`
- reworks the URL path to access the CSV Export API.
  - previously on NewCantus, you would access it via `/csv/<source id>`
  - now, you access it via `source/<source id>/csv/`, which should work better as a URI
- On the Source Detail page, where the link to the CSV Export API is displayed, the link now automatically downloads the file rather than opening the csv file in a new tab
  - why this was implemented: with OldCantus's path, if you were viewing the CSV Export view in the browser and then tried to save the page, the filename would be `<source id>.csv`. With the improved pathname in NewCantus, the filename would default to `csv.csv` (or possibly just `csv`, depending on your operating system / browser?). Using a `download` attribute in the `<a>` tag on the Source Detail page allows us to specify a default filename, so when you click on it, you get `<source id>.csv` just as you would on OldCantus.

