### PR TITLE
Improved Dropdown Menu Display for Genre and Office

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -45,6 +45,17 @@ class CommentForm(forms.ModelForm):
 """
 
 
+class NameModelChoiceField(forms.ModelChoiceField):
+    """
+    A custom ModelChoiceField that overrides the label_from_instance method
+    to display the object's name attribute instead of str(object).
+    This field is specifically designed for handling genre and office objects.
+    """
+
+    def label_from_instance(self, obj):
+        return obj.name
+
+
 # 3 best
 class ChantCreateForm(forms.ModelForm):
     class Meta:
@@ -115,14 +126,14 @@ class ChantCreateForm(forms.ModelForm):
         help_text="Each folio starts with '1'.",
     )
 
-    office = forms.ModelChoiceField(
-        queryset=Office.objects.all().order_by("name").values_list("name", flat=True),
+    office = NameModelChoiceField(
+        queryset=Office.objects.all().order_by("name"),
         required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
-    genre = forms.ModelChoiceField(
-        queryset=Genre.objects.all().order_by("name").values_list("name", flat=True),
+    genre = NameModelChoiceField(
+        queryset=Genre.objects.all().order_by("name"),
         required=False,
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
@@ -331,14 +342,14 @@ class ChantEditForm(forms.ModelForm):
     )
     feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
-    office = forms.ModelChoiceField(
-        queryset=Office.objects.all().order_by("name").values_list("name", flat=True),
+    office = NameModelChoiceField(
+        queryset=Office.objects.all().order_by("name"),
         required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
-    genre = forms.ModelChoiceField(
-        queryset=Genre.objects.all().order_by("name").values_list("name", flat=True),
+    genre = NameModelChoiceField(
+        queryset=Genre.objects.all().order_by("name"),
         required=False,
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
@@ -434,13 +445,13 @@ class ChantProofreadForm(forms.ModelForm):
     )
     feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
-    office = forms.ModelChoiceField(
+    office = NameModelChoiceField(
         queryset=Office.objects.all().order_by("name"),
         required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
-    genre = forms.ModelChoiceField(
+    genre = NameModelChoiceField(
         queryset=Genre.objects.all().order_by("name"), required=False
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
@@ -598,7 +609,7 @@ class SequenceEditForm(forms.ModelForm):
             "image_link": TextInputWidget(),
         }
 
-    genre = forms.ModelChoiceField(
+    genre = NameModelChoiceField(
         queryset=Genre.objects.all().order_by("name"), required=False
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -116,12 +116,14 @@ class ChantCreateForm(forms.ModelForm):
     )
 
     office = forms.ModelChoiceField(
-        queryset=Office.objects.all().order_by("name"), required=False
+        queryset=Office.objects.all().order_by("name").values_list("name", flat=True),
+        required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     genre = forms.ModelChoiceField(
-        queryset=Genre.objects.all().order_by("name"), required=False
+        queryset=Genre.objects.all().order_by("name").values_list("name", flat=True),
+        required=False,
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
@@ -330,12 +332,14 @@ class ChantEditForm(forms.ModelForm):
     feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     office = forms.ModelChoiceField(
-        queryset=Office.objects.all().order_by("name"), required=False
+        queryset=Office.objects.all().order_by("name").values_list("name", flat=True),
+        required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     genre = forms.ModelChoiceField(
-        queryset=Genre.objects.all().order_by("name"), required=False
+        queryset=Genre.objects.all().order_by("name").values_list("name", flat=True),
+        required=False,
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -50,6 +50,9 @@ class NameModelChoiceField(forms.ModelChoiceField):
     A custom ModelChoiceField that overrides the label_from_instance method
     to display the object's name attribute instead of str(object).
     This field is specifically designed for handling genre and office objects.
+    Rather than displaying the name along with its description, sometimes we
+    only want the shorthand notation for the genre and office objects.
+    (Eg. [AV] Antiphon verse --> AV)
     """
 
     def label_from_instance(self, obj):

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -129,12 +129,16 @@ class ChantCreateForm(forms.ModelForm):
         help_text="Each folio starts with '1'.",
     )
 
+    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
+    # instead of [name] + description
     office = NameModelChoiceField(
         queryset=Office.objects.all().order_by("name"),
         required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
+    # We use NameModelChoiceField here so the dropdown list of genres displays the name
+    # instead of [name] + description
     genre = NameModelChoiceField(
         queryset=Genre.objects.all().order_by("name"),
         required=False,
@@ -345,12 +349,16 @@ class ChantEditForm(forms.ModelForm):
     )
     feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
+    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
+    # instead of [name] + description
     office = NameModelChoiceField(
         queryset=Office.objects.all().order_by("name"),
         required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
+    # We use NameModelChoiceField here so the dropdown list of genres displays the name
+    # instead of [name] + description
     genre = NameModelChoiceField(
         queryset=Genre.objects.all().order_by("name"),
         required=False,
@@ -448,12 +456,16 @@ class ChantProofreadForm(forms.ModelForm):
     )
     feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
+    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
+    # instead of [name] + description
     office = NameModelChoiceField(
         queryset=Office.objects.all().order_by("name"),
         required=False,
     )
     office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
+    # We use NameModelChoiceField here so the dropdown list of genres displays the name
+    # instead of [name] + description
     genre = NameModelChoiceField(
         queryset=Genre.objects.all().order_by("name"), required=False
     )
@@ -612,6 +624,8 @@ class SequenceEditForm(forms.ModelForm):
             "image_link": TextInputWidget(),
         }
 
+    # We use NameModelChoiceField here so the dropdown list of genres displays the name
+    # instead of [name] + description
     genre = NameModelChoiceField(
         queryset=Genre.objects.all().order_by("name"), required=False
     )


### PR DESCRIPTION
This PR resolves the problem with the dropdown menu in the ChantCreate and ChantEdit views. Previously, the menu displayed the complete string description of the genre and office objects, which was not desired. To address this, the template forms were modified to use the "name" attribute of the objects in the dropdown menu. This was achieved by introducing a custom `NameModelChoiceField` that overrides the `label_from_instance` method to specifically display the `name` attribute of the genre and office objects. The modification applies to the following pages:
- Chant create
- Chant edit
- Chant proofread
- Sequence edit

Fixes #512, #699