### PR TITLE
Bring Article List / News page into alignment with OldCantus

### DIFF
--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -14,7 +14,9 @@
                 <a href="{% url 'article-detail' article.id %}">{{ article.title }}</a>
             </h4>
             <div class="container">
-                {{ article.body|safe|truncatechars_html:3000 }}
+                <small>
+                {{ article.body.html|safe|truncatechars_html:3000 }}
+                </small>
             </div>
         </div>
     </div>

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -19,6 +19,7 @@
         </div>
     </div>
     {% endfor %}
+    {% include "pagination.html" %}
     <br>
 </div>
 {% endblock %}

--- a/django/cantusdb_project/articles/urls.py
+++ b/django/cantusdb_project/articles/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
-from articles.views import ArticleDetailView
-from articles.views import ArticleListView
+from articles.views import (
+    ArticleDetailView,
+    ArticleListView,
+    article_list_redirect_from_old_path,
+)
 
 urlpatterns = [
     path("articles/", ArticleListView.as_view(), name="article-list"),
     path("article/<int:pk>", ArticleDetailView.as_view(), name="article-detail"),
+    path("news/", article_list_redirect_from_old_path),
 ]

--- a/django/cantusdb_project/articles/views.py
+++ b/django/cantusdb_project/articles/views.py
@@ -12,6 +12,6 @@ class ArticleDetailView(DetailView):
 class ArticleListView(ListView):
     model = Article
     queryset = Article.objects.order_by("-date_created")
-    paginate_by = 100
+    paginate_by = 10
     context_object_name = "articles"
     template_name = "article_list.html"

--- a/django/cantusdb_project/articles/views.py
+++ b/django/cantusdb_project/articles/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.urls.base import reverse
 from django.views.generic import DetailView, ListView
 from articles.models import Article
 
@@ -15,3 +16,7 @@ class ArticleListView(ListView):
     paginate_by = 10
     context_object_name = "articles"
     template_name = "article_list.html"
+
+
+def article_list_redirect_from_old_path(request):
+    return redirect(reverse("article-list"))

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -34,6 +34,11 @@
             /* Margin bottom by footer height */
             background-image: url('{% static "background.jpg" %}');
         }
+        
+        .container {
+            /* this is relevant for the Article List page */
+            overflow-wrap: break-word;
+        }
 
         .footer {
             position: absolute;


### PR DESCRIPTION
Fixes #674

This PR:
- adds a redirect from `/news/` (as the article list page is accessed by in OldCantus) to `/articles/`
- adds pagination links to the bottom of the Article List page
- changes pagination from 100 to 10, to match OldCantus
- adds a preview for each article (actually it displays in full, as in OldCantus)

Previously:
![Screenshot 2023-06-06 at 4 36 48 PM](https://github.com/DDMAL/CantusDB/assets/58090591/ea462c86-3ac0-4902-bd00-cc2527ef00f4)

Now:
![Screenshot 2023-06-06 at 4 36 32 PM](https://github.com/DDMAL/CantusDB/assets/58090591/135cceb2-f952-433c-8226-a0ce019ccb07)

OldCantus: 
![Screenshot 2023-06-06 at 4 37 52 PM](https://github.com/DDMAL/CantusDB/assets/58090591/40d5990a-0eca-4e9e-94a0-1493ce3e6422)

