### PR TITLE
Redirect /node/ urls to their corresponding detail page in NewCantus

### DIFF
--- a/django/cantusdb_project/articles/tests/test_articles.py
+++ b/django/cantusdb_project/articles/tests/test_articles.py
@@ -17,7 +17,7 @@ def make_fake_article(user=None):
         user = make_fake_user()
     article = Article.objects.create(
         # updated to use Faker (previously called method from make_fakes that no longer exists)
-        title=faker.text(12),
+        title=faker.sentence(),
         author=make_fake_user(),
     )
     return article

--- a/django/cantusdb_project/articles/tests/test_articles.py
+++ b/django/cantusdb_project/articles/tests/test_articles.py
@@ -1,20 +1,23 @@
 from django.test import TestCase
 from django.urls import reverse
 from articles.models import Article
+from faker import Faker
 from main_app.tests.make_fakes import (
-    make_fake_text,
     make_fake_user,
 )
 
 # run with `python -Wa manage.py test articles.tests.test_articles`
 # the -Wa flag tells Python to display deprecation warnings
 
+# Create a Faker instance with locale set to Latin
+faker = Faker("la")
 
 def make_fake_article(user=None):
     if user is None:
         user = make_fake_user()
     article = Article.objects.create(
-        title=make_fake_text(max_size=12),
+        # updated to use Faker (previously called method from make_fakes that no longer exists)
+        title=faker.text(12),
         author=make_fake_user(),
     )
     return article

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3864,7 +3864,9 @@ class NodeURLRedirectTest(TestCase):
         self.assertEqual(response_1.status_code, 404)
 
     def test_redirect_above_limit(self):
+        # generate dummy object with ID outside of valid range
         over_limit_node_id = 1000001
+        Chant.objects.create(id=over_limit_node_id)
 
         # ID above limit
         response_1 = self.client.get(reverse("redirect-node-url", args=[over_limit_node_id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1,6 +1,7 @@
 import random
 from django.urls import reverse
 from django.test import TestCase
+from articles.tests.test_articles import make_fake_article
 from main_app.views.feast import FeastListView
 from django.http.response import JsonResponse
 import json
@@ -3790,43 +3791,81 @@ class NodeURLRedirectTest(TestCase):
         self.client = Client()
 
     def test_chant_redirect(self):
-        example_chant_id = 243652  # from issue #563
+        # generate dummy object with ID in valid range
+        example_chant_id = random.randrange(1, 1000000)
         Chant.objects.create(id=example_chant_id)
+
+        # find dummy object using /node/ path
         response_1 = self.client.get(reverse("redirect-node-url", args=[example_chant_id]))
+        expected_url = reverse("chant-detail", args=[example_chant_id])
+        
         self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_1.url, expected_url)
     
     def test_source_redirect(self):
-        fake = make_fake_source()
-        example_source_id = fake.id
+        # generate dummy object with ID in valid range
+        example_source_id = random.randrange(1, 1000000)
+        source_1 = make_fake_source()
+        source_1.id = example_source_id
+        source_1.save()
+
+        # find dummy object using /node/ path
         response_1 = self.client.get(reverse("redirect-node-url", args=[example_source_id]))
+        expected_url = reverse("source-detail", args=[example_source_id])
+        
         self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_1.url, expected_url)
     
     def test_sequence_redirect(self):
-        example_sequence_id = 628334 # from issue #563
+        # generate dummy object with ID in valid range
+        example_sequence_id = random.randrange(1, 1000000)
         Sequence.objects.create(id=example_sequence_id)
+
+        # find dummy object using /node/ path
         response_1 = self.client.get(reverse("redirect-node-url", args=[example_sequence_id]))
+        expected_url = reverse("sequence-detail", args=[example_sequence_id])
+        
         self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_1.url, expected_url)
+
     
     def test_article_redirect(self):
-        # there is no way to generate a fake article, nor get an existing one here
-        # instead, this has been tested locally by updating the id of a NewCantus source manually to match OldCantus, and the redirect works
-        self.assertTrue(True)
+        # generate dummy object with ID in valid range
+        example_article_id = random.randrange(1, 1000000)
+        article_1 = make_fake_article()
+        article_1.id = example_article_id
+        article_1.save()
+
+        # find dummy object using /node/ path
+        response_1 = self.client.get(reverse("redirect-node-url", args=[example_article_id]))
+        expected_url = reverse("article-detail", args=[example_article_id])
+        
+        self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_1.url, expected_url)
     
     def test_indexer_redirect(self):
-        example_indexer_id = 706860 # from issue #563
-        example_matching_user_id = 251425 # from issue #563
+        # generate dummy object with ID in valid range
+        example_indexer_id = random.randrange(1, 1000000)
+        example_matching_user_id = random.randrange(1, 1000000)
         User.objects.create(id=example_matching_user_id, old_indexer_id=example_indexer_id)
+        
+        # find dummy object using /node/ path
         response_1 = self.client.get(reverse("redirect-node-url", args=[example_indexer_id]))
+        expected_url = reverse("user-detail", args=[example_matching_user_id])
+        
         self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_1.url, expected_url)
 
     def test_bad_redirect(self):
-        invalid_node_id = 123456
+        invalid_node_id = random.randrange(1, 1000000)
+        
+        # try to find object that doesn't exist
         response_1 = self.client.get(reverse("redirect-node-url", args=[invalid_node_id]))
         self.assertEqual(response_1.status_code, 404)
 
     def test_redirect_above_limit(self):
         over_limit_node_id = 1000001
-        url = reverse("redirect-node-url", args=[over_limit_node_id])
-        print(f'url: {url}')
+
+        # ID above limit
         response_1 = self.client.get(reverse("redirect-node-url", args=[over_limit_node_id]))
         self.assertEqual(response_1.status_code, 404)

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -311,6 +311,12 @@ urlpatterns = [
         views.content_overview,
         name="content-overview",
     ),
+    # /node/ url redirects
+    path(
+        "node/<int:pk>",
+        views.redirect_node_url,
+        name="redirect-node-url",
+    ),
 ]
 
 handler404 = "main_app.views.views.handle404"

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -27,8 +27,7 @@ from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import PasswordChangeForm
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
-
-from users.models import User
+from django.contrib.auth import get_user_model
 
 
 @login_required
@@ -652,8 +651,8 @@ def redirect_node_url(request, pk: int) -> HttpResponse:
         (Article, 'article-detail')
     ]
 
-    user_id = get_user_id(pk)
-    if get_user_id(pk) is not None:
+    user_id = get_user_id_from_old_indexer_id(pk)
+    if get_user_id_from_old_indexer_id(pk) is not None:
         return redirect('user-detail', user_id)
     
     for (rec_type, view) in possible_types:
@@ -667,13 +666,12 @@ def redirect_node_url(request, pk: int) -> HttpResponse:
 # used to determine whether record of specific type (chant, source, sequence, article) exists for a given pk
 def record_exists(rec_type: BaseModel, pk: int) -> bool:
     try:
-        result = rec_type.objects.get(id=pk)
-        print(f'result: {result}')
+        rec_type.objects.get(id=pk)
         return True
     except rec_type.DoesNotExist:
         return False
 
-def get_user_id(pk: int) -> Optional[int]:
+def get_user_id_from_old_indexer_id(pk: int) -> Optional[int]:
     """
     A function that and finds the matching User ID in NewCantus for an Indexer ID in OldCantus.
     This is stored in the User table's old_indexer_id column.
@@ -683,7 +681,7 @@ def get_user_id(pk: int) -> Optional[int]:
     Returns the user ID from NewCantus if a match is found and None otherwise.
     """
     try:
-        result = User.objects.get(old_indexer_id=pk)
+        result = get_user_model().objects.get(old_indexer_id=pk)
         return result.id
-    except User.DoesNotExist:
+    except get_user_model().DoesNotExist:
         return None


### PR DESCRIPTION
This fix allows users with previously bookmarked URLs from OldCantus using the /node/ path to view the appropriate Chant, Source, Sequence, User/Indexer or Article page in NewCantus. Note that the Indexer pages are now redirected to User pages (since indexers are users in NewCantus).