### PR TITLE
Fix formatting for narrow windows in several pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -152,13 +152,11 @@
                         {{ form.melody_id }}
                     </div>
 
-                    <div class="form-row align-items-top">
-                        <div class="form-group m-1 col-lg">
-                            <small>{{ form.addendum.label_tag }}</small>
-                            {{ form.addendum }}
-                        </div>
+                    <div class="form-group m-1 col-lg">
+                        <small>{{ form.addendum.label_tag }}</small>
+                        {{ form.addendum }}
                     </div>
-
+                    
                 </div>
             
                 <div class="form-row align-items-end">

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -43,59 +43,59 @@
                     {% endif %}
                 </div>
 
-                <div class="row">
+                <div class="form-row">
                     {% if chant.folio %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2  col-sm-6 col-6">
                             <dt>Folio</dt>
                             <dd>{{ chant.folio }}</dd>
                         </div>
                     {% endif %}
 
                     {% if chant.c_sequence is not None %} {# check that it isn't None, since sometimes c_sequence is 0 #}
-                        <div class="col-10">
+                        <div class="form-group col-lg-2  col-sm-6 col-6">
                             <dt>Sequence</dt>
                             <dd>{{ chant.c_sequence }}</dd>
                         </div>
                     {% endif %}
                 </div>
                 
-                <div class="row">
+                <div class="form-row">
                     {% if chant.feast %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2  col-sm-6 col-6">
                             <dt>Feast</dt>
                             <dd>
                                 <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
-
+                
                     {% if chant.office %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2 col-sm-6 col-6">
                             <dt>Office/Mass</dt>
                             <dd>
                                 <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
-
+                
                     {% if chant.genre %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2 col-sm-6 col-6">
                             <dt>Genre</dt>
                             <dd>
                                 <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
                             </dd>
                         </div>
                     {% endif %}
-
+                
                     {% if chant.position %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2 col-sm-6 col-6">
                             <dt>Position</dt>
                             <dd>{{ chant.position }}</dd>
                         </div>
                     {% endif %}
-
+                
                     {% if chant.cantus_id %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2 col-sm-6 col-6">
                             <dt>Cantus ID</dt>
                             <dd>
                                 <a href="{{ chant.get_ci_url }}" target="_blank">
@@ -104,14 +104,15 @@
                             </dd>
                         </div>
                     {% endif %}
-
+                
                     {% if chant.mode %}
-                        <div class="col-2">
+                        <div class="form-group col-lg-2 col-sm-6 col-6">
                             <dt>Mode</dt>
                             <dd>{{ chant.mode }}</dd>
                         </div>
                     {% endif %}
                 </div>
+                
 
                 <div class="row">
                     {% if chant.finalis %}
@@ -237,7 +238,7 @@
                             </tbody>
                         </table>
                     </small>
-                    <table id="concordanceTable" class="table table-bordered table-sm small" style="table-layout: fixed; width: 100%;">
+                    <table id="concordanceTable" class="table table-responsive table-bordered table-sm small" style="table-layout: fixed; width: 100%;">
                         <thead>
                             <tr>
                                 <th scope="col" class="text-wrap" style="width:15%" title="Siglum">Siglum</th>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -113,11 +113,9 @@
                         </div>
                     </div>
                     <div class="form-row">
-                        <div class="form-row align-items-top"> 
-                            <div class="form-group m-1 col-lg-8">
-                                <small>{{ form.addendum.label_tag }}</small>
-                                {{ form.addendum }}
-                            </div>
+                        <div class="form-group m-1 col-lg">
+                            <small>{{ form.addendum.label_tag }}</small>
+                            {{ form.addendum }}
                         </div>
                     </div>
                                         

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -92,189 +92,191 @@
 
     {% if chants.all %}
         <small>
-            <table class="table table-sm small table-bordered">
-                <thead>
-                    <tr>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">
-                            {% if order == "siglum" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=siglum&sort=desc">Siglum</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Folio">
-                            Folio
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Incipit/Full Text">
-                            {% if order == "incipit" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Feast">
-                            Feast
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Office">
-                            {% if order == "office" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=office&sort=desc">Office<br>/Mass</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Genre">
-                            {% if order == "genre" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=genre&sort=desc">Genre</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Position">
-                            Position
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">
-                            {% if order == "cantus_id" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=desc">Cantus ID</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Mode">
-                            {% if order == "mode" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=mode&sort=desc">Mode</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Manuscript Full Text">
-                            {% if order == "has_fulltext" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">MsFt</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Volpiano Melody">
-                            {% if order == "has_melody" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=desc">Mel</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
-                            {% endif %}
-                        </th>
-                        <th scope="col" class="text-wrap" style="text-align:center" title="Image Link">
-                            {% if order == "has_image" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_image&sort=desc">Image</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a>
-                            {% endif %}
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for chant in chants %}
+            <div style="overflow-x:auto">
+                <table class="table table-sm small table-bordered">
+                    <thead>
                         <tr>
-                            <td class="text-wrap" style="text-align:left">
-                                {% if chant.source__id %}
-                                    <a href="{% url 'source-detail' chant.source__id %}" title="{{ chant.source__title }}">{{ chant.source__siglum }}</a>
-                                {% endif %}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {{ chant.folio|default:""|truncatechars_html:140 }}
-                            </td>
-
-                            <td class="text-wrap" style="text-align:left">
-                                {% comment %} this is used for distinguishing chants from sequences,
-                                if the object is chant, use chant-detail view,
-                                otherwise, use sequence-detail view.
-                                the combined queryset turned all objects into chants
-                                so this is the only way to make the distinction {% endcomment %}
-                                {% if chant.search_vector %}
-                                    <b><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">
+                                {% if order == "siglum" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=siglum&sort=desc">Siglum</a> ▲
+                                    {% endif %}
                                 {% else %}
-                                    <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                    <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
                                 {% endif %}
-                                <p>
-                                    {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
-                                </p>           
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {% if chant.feast__id %}
-                                    <a href="{% url 'feast-detail' chant.feast__id %}" title="{{ chant.feast__description }}">{{ chant.feast__name|default:"" }}</a>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Folio">
+                                Folio
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Incipit/Full Text">
+                                {% if order == "incipit" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
                                 {% endif %}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {% if chant.office__id %}
-                                    <a href="{% url 'office-detail' chant.office__id %}" title="{{ chant.office__description }}">{{ chant.office__name|default:"" }}</a>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Feast">
+                                Feast
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Office">
+                                {% if order == "office" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=office&sort=desc">Office<br>/Mass</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
                                 {% endif %}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {% if chant.genre__id %}
-                                    <a href="{% url 'genre-detail' chant.genre__id %}" title="{{ chant.genre__description }}">{{ chant.genre__name|default:"" }}</a>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Genre">
+                                {% if order == "genre" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=genre&sort=desc">Genre</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
                                 {% endif %}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {{ chant.position|default:"" }}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                <a href="https://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {{ chant.mode|default:"" }}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {% if chant.manuscript_full_text %}
-                                    <span title="Chant record includes Manuscript Full Text">✔</span>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Position">
+                                Position
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">
+                                {% if order == "cantus_id" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=cantus_id&sort=desc">Cantus ID</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
                                 {% endif %}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {% if chant.volpiano %}
-                                    <span title="Chant record has Volpiano melody">♫</span>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Mode">
+                                {% if order == "mode" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=mode&sort=desc">Mode</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
                                 {% endif %}
-                            </td>
-                            <td class="text-wrap" style="text-align:center">
-                                {% if chant.image_link %}
-                                    <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Manuscript Full Text">
+                                {% if order == "has_fulltext" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">MsFt</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
                                 {% endif %}
-                            </td>
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Volpiano Melody">
+                                {% if order == "has_melody" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=has_melody&sort=desc">Mel</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
+                                {% endif %}
+                            </th>
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Image Link">
+                                {% if order == "has_image" %}
+                                    {% if sort == "desc" %}
+                                        <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼
+                                    {% else %}
+                                        <a href="{{ url_with_search_params }}&order=has_image&sort=desc">Image</a> ▲
+                                    {% endif %}
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a>
+                                {% endif %}
+                            </th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {% for chant in chants %}
+                            <tr>
+                                <td class="text-wrap" style="text-align:left">
+                                    {% if chant.source__id %}
+                                        <a href="{% url 'source-detail' chant.source__id %}" title="{{ chant.source__title }}">{{ chant.source__siglum }}</a>
+                                    {% endif %}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {{ chant.folio|default:""|truncatechars_html:140 }}
+                                </td>
+
+                                <td class="text-wrap" style="text-align:left">
+                                    {% comment %} this is used for distinguishing chants from sequences,
+                                    if the object is chant, use chant-detail view,
+                                    otherwise, use sequence-detail view.
+                                    the combined queryset turned all objects into chants
+                                    so this is the only way to make the distinction {% endcomment %}
+                                    {% if chant.search_vector %}
+                                        <b><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                    {% else %}
+                                        <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                    {% endif %}
+                                    <p>
+                                        {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
+                                    </p>           
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if chant.feast__id %}
+                                        <a href="{% url 'feast-detail' chant.feast__id %}" title="{{ chant.feast__description }}">{{ chant.feast__name|default:"" }}</a>
+                                    {% endif %}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if chant.office__id %}
+                                        <a href="{% url 'office-detail' chant.office__id %}" title="{{ chant.office__description }}">{{ chant.office__name|default:"" }}</a>
+                                    {% endif %}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if chant.genre__id %}
+                                        <a href="{% url 'genre-detail' chant.genre__id %}" title="{{ chant.genre__description }}">{{ chant.genre__name|default:"" }}</a>
+                                    {% endif %}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {{ chant.position|default:"" }}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="https://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {{ chant.mode|default:"" }}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if chant.manuscript_full_text %}
+                                        <span title="Chant record includes Manuscript Full Text">✔</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if chant.volpiano %}
+                                        <span title="Chant record has Volpiano melody">♫</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if chant.image_link %}
+                                        <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </small>
 
         {% include "pagination.html" %}

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -92,191 +92,189 @@
 
     {% if chants.all %}
         <small>
-            <div style="overflow-x:auto">
-                <table class="table table-sm small table-bordered">
-                    <thead>
+            <table class="table table-responsive table-sm small table-bordered">
+                <thead>
+                    <tr>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">
+                            {% if order == "siglum" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=siglum&sort=desc">Siglum</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Folio">
+                            Folio
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Incipit/Full Text">
+                            {% if order == "incipit" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Feast">
+                            Feast
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Office">
+                            {% if order == "office" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=office&sort=desc">Office<br>/Mass</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Genre">
+                            {% if order == "genre" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=genre&sort=desc">Genre</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Position">
+                            Position
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">
+                            {% if order == "cantus_id" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=desc">Cantus ID</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Mode">
+                            {% if order == "mode" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=mode&sort=desc">Mode</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Manuscript Full Text">
+                            {% if order == "has_fulltext" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">MsFt</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Volpiano Melody">
+                            {% if order == "has_melody" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=desc">Mel</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="text-wrap" style="text-align:center" title="Image Link">
+                            {% if order == "has_image" %}
+                                {% if sort == "desc" %}
+                                    <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼
+                                {% else %}
+                                    <a href="{{ url_with_search_params }}&order=has_image&sort=desc">Image</a> ▲
+                                {% endif %}
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a>
+                            {% endif %}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for chant in chants %}
                         <tr>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">
-                                {% if order == "siglum" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=siglum&sort=desc">Siglum</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
+                            <td class="text-wrap" style="text-align:left">
+                                {% if chant.source__id %}
+                                    <a href="{% url 'source-detail' chant.source__id %}" title="{{ chant.source__title }}">{{ chant.source__siglum }}</a>
                                 {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Folio">
-                                Folio
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Incipit/Full Text">
-                                {% if order == "incipit" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Feast">
-                                Feast
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Office">
-                                {% if order == "office" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=office&sort=desc">Office<br>/Mass</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Genre">
-                                {% if order == "genre" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=genre&sort=desc">Genre</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Position">
-                                Position
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">
-                                {% if order == "cantus_id" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=cantus_id&sort=desc">Cantus ID</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Mode">
-                                {% if order == "mode" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=mode&sort=desc">Mode</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Manuscript Full Text">
-                                {% if order == "has_fulltext" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">MsFt</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Volpiano Melody">
-                                {% if order == "has_melody" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=has_melody&sort=desc">Mel</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
-                                {% endif %}
-                            </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Image Link">
-                                {% if order == "has_image" %}
-                                    {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼
-                                    {% else %}
-                                        <a href="{{ url_with_search_params }}&order=has_image&sort=desc">Image</a> ▲
-                                    {% endif %}
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a>
-                                {% endif %}
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for chant in chants %}
-                            <tr>
-                                <td class="text-wrap" style="text-align:left">
-                                    {% if chant.source__id %}
-                                        <a href="{% url 'source-detail' chant.source__id %}" title="{{ chant.source__title }}">{{ chant.source__siglum }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {{ chant.folio|default:""|truncatechars_html:140 }}
-                                </td>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {{ chant.folio|default:""|truncatechars_html:140 }}
+                            </td>
 
-                                <td class="text-wrap" style="text-align:left">
-                                    {% comment %} this is used for distinguishing chants from sequences,
-                                    if the object is chant, use chant-detail view,
-                                    otherwise, use sequence-detail view.
-                                    the combined queryset turned all objects into chants
-                                    so this is the only way to make the distinction {% endcomment %}
-                                    {% if chant.search_vector %}
-                                        <b><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
-                                    {% else %}
-                                        <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
-                                    {% endif %}
-                                    <p>
-                                        {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
-                                    </p>           
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.feast__id %}
-                                        <a href="{% url 'feast-detail' chant.feast__id %}" title="{{ chant.feast__description }}">{{ chant.feast__name|default:"" }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.office__id %}
-                                        <a href="{% url 'office-detail' chant.office__id %}" title="{{ chant.office__description }}">{{ chant.office__name|default:"" }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.genre__id %}
-                                        <a href="{% url 'genre-detail' chant.genre__id %}" title="{{ chant.genre__description }}">{{ chant.genre__name|default:"" }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {{ chant.position|default:"" }}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    <a href="https://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {{ chant.mode|default:"" }}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.manuscript_full_text %}
-                                        <span title="Chant record includes Manuscript Full Text">✔</span>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.volpiano %}
-                                        <span title="Chant record has Volpiano melody">♫</span>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.image_link %}
-                                        <a href="{{ chant.image_link }}" target="_blank">Image</a>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+                            <td class="text-wrap" style="text-align:left">
+                                {% comment %} this is used for distinguishing chants from sequences,
+                                if the object is chant, use chant-detail view,
+                                otherwise, use sequence-detail view.
+                                the combined queryset turned all objects into chants
+                                so this is the only way to make the distinction {% endcomment %}
+                                {% if chant.search_vector %}
+                                    <b><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                {% else %}
+                                    <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                {% endif %}
+                                <p>
+                                    {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
+                                </p>           
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.feast__id %}
+                                    <a href="{% url 'feast-detail' chant.feast__id %}" title="{{ chant.feast__description }}">{{ chant.feast__name|default:"" }}</a>
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.office__id %}
+                                    <a href="{% url 'office-detail' chant.office__id %}" title="{{ chant.office__description }}">{{ chant.office__name|default:"" }}</a>
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.genre__id %}
+                                    <a href="{% url 'genre-detail' chant.genre__id %}" title="{{ chant.genre__description }}">{{ chant.genre__name|default:"" }}</a>
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {{ chant.position|default:"" }}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="https://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{chant.cantus_id|default:"" }}</a>
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {{ chant.mode|default:"" }}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.manuscript_full_text %}
+                                    <span title="Chant record includes Manuscript Full Text">✔</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.volpiano %}
+                                    <span title="Chant record has Volpiano melody">♫</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% if chant.image_link %}
+                                    <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </small>
 
         {% include "pagination.html" %}


### PR DESCRIPTION
This PR addresses many of the styling and formatting errors in the chant search, chant detail, and chant edit pages. The changes are outlined as follows:

- Chant Detail:
    - Applied the table-responsive class to the concordances table in the chant detail page to allow horizontal scrolling on small windows.
    - Adjusted the formatting of the chant detail page so that it displays two columns per row when the window is narrowed.  Fixes #493 
![image](https://github.com/DDMAL/CantusDB/assets/71031342/d6e16fcd-74fb-4703-9f8b-de88900f3ec6)

- Chant Search:
    -  Applied the table-responsive class to the table in the chant detail page to allow horizontal scrolling on small windows. Fixes #690, #367
- Chant Create:
    - Fix addendum field formatting
- Chant Edit:
    - Fix addendum field formatting
 