### PR TITLE
Set unusable password for dummy users

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/sync_indexers.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_indexers.py
@@ -71,10 +71,9 @@ def get_new_indexer(indexer_id):
             email=f"{faker.lexify('????????')}@fakeemail.com",
             # leave the password empty for dummy users
             # the password can't be empty in login form, so they can't log in
-            password="",
             old_indexer_id=indexer_id,
             is_indexer=True,
-        )
+        ).set_unusable_password()
 
 
 class Command(BaseCommand):

--- a/django/cantusdb_project/main_app/management/commands/sync_indexers.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_indexers.py
@@ -69,11 +69,9 @@ def get_new_indexer(indexer_id):
             full_name=indexer_full_name,
             # assign random email to dummy users
             email=f"{faker.lexify('????????')}@fakeemail.com",
-            # leave the password empty for dummy users
-            # the password can't be empty in login form, so they can't log in
             old_indexer_id=indexer_id,
             is_indexer=True,
-        ).set_unusable_password()
+        ).set_unusable_password()  # Set unusable password so the user can't log in or access reset password page
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
This PR sets dummy users (old indexers) to have an unusable password. This should prevent them from logging in to CantusDB and also prevent them from entering the password reset page. Resolves #713 