### PR TITLE
Display "No chants found" message on chant list

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -122,6 +122,8 @@
                     </tbody>
                 </table>
                 {% include "pagination.html" %}
+            {% else %}
+                No chants found.
             {% endif %}
         </div>
     


### PR DESCRIPTION
When no chants from a source meet the search criteria, we should display a message "No chants found." message.

Resolves #718 