### PR TITLE
Hide table in Source and Sequence list pages if no search results found

### DIFF
--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -27,60 +27,62 @@
             </div>
         </div>
     </form>
-
-    <table class="table table-bordered table-sm small">
-        <thead>
-            <tr>
-                <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
-                <th scope="col" class="text-wrap" style="text-align:center">AH</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for sequence in sequences %}
-                <tr style="text-align:center">
-                    <td class="text-wrap">
-                        {% if sequence.source %}
-                            <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}">
-                                <b>{{ sequence.source.siglum }}</b><br>
-                            </a>
-                        {% endif %}
-                        <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}
-                    </td>
-                    <td class="text-wrap">
-                        <a href="{% url 'sequence-detail' sequence.id %}">
-                            {{ sequence.incipit|default:"" }}
-                        </a>
-                    </td>
-                    <td class="text-wrap">
-                        {{ sequence.rubrics|default:"" }}
-                    </td>
-                    <td class="text-wrap">
-                        {{ sequence.analecta_hymnica|default:"" }}
-                    </td>
-                    <td class="text-wrap">
-                        {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
-                        <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
-                    </td>
-                    <td class="text-wrap">
-                        {{ sequence.col1 |default:"" }}
-                    </td>
-                    <td class="text-wrap">
-                        {{ sequence.col2 |default:"" }}
-                    </td>
-                    <td class="text-wrap">
-                        {{ sequence.col3 |default:"" }}
-                    </td>
+    {% if sequences %}
+        <table class="table table-bordered table-sm small">
+            <thead>
+                <tr>
+                    <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">AH</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-
+            </thead>
+            <tbody>
+                {% for sequence in sequences %}
+                    <tr style="text-align:center">
+                        <td class="text-wrap">
+                            {% if sequence.source %}
+                                <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}">
+                                    <b>{{ sequence.source.siglum }}</b><br>
+                                </a>
+                            {% endif %}
+                            <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}
+                        </td>
+                        <td class="text-wrap">
+                            <a href="{% url 'sequence-detail' sequence.id %}">
+                                {{ sequence.incipit|default:"" }}
+                            </a>
+                        </td>
+                        <td class="text-wrap">
+                            {{ sequence.rubrics|default:"" }}
+                        </td>
+                        <td class="text-wrap">
+                            {{ sequence.analecta_hymnica|default:"" }}
+                        </td>
+                        <td class="text-wrap">
+                            {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
+                            <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
+                        </td>
+                        <td class="text-wrap">
+                            {{ sequence.col1 |default:"" }}
+                        </td>
+                        <td class="text-wrap">
+                            {{ sequence.col2 |default:"" }}
+                        </td>
+                        <td class="text-wrap">
+                            {{ sequence.col3 |default:"" }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        No sequences found.
+    {% endif %}
     {% include "pagination.html" %}
 </div>
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -63,52 +63,55 @@
             <div class="form-group m-1 col-lg">
                 <button type="submit" class="btn btn-dark btn-sm" id="btn-submit"> Apply </button>
                 <a href="/sources/?segment={{ request.GET.segment }}" class="btn btn-dark btn-sm" id="btn-reset"> Reset </a>
-            </div>
+            </div> 
         </div>
     </form>
-
-    <table class="table table-sm small table-bordered">
-        <thead>
-            <tr>
-                <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Chants/Melodies</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for source in sources %}
+    {% if sources %}
+        <table class="table table-sm small table-bordered">
+            <thead>
                 <tr>
-                    <td class="text-wrap" style="text-align:center">
-                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"><b>{{ source.siglum }}</b></a>
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {{ source.summary|default:""|truncatechars_html:140 }}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if source.century.all %}
-                            <b><a href="{% url 'century-detail' source.century.first.id %}">{{ source.century.first.name }}</a></b><br>
-                        {% endif %}
-                        {% if source.provenance %}
-                            <a href="{% url 'provenance-detail' source.provenance.id %}">{{ source.provenance.name }}</a>
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if source.image_link %}
-                            <a href="{{ source.image_link }}" target="_blank">Images</a>
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                        {% if source.number_of_melodies %}
-                            <br>/ {{ source.number_of_melodies }}
-                        {% endif %}
-                    </td>
+                    <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Chants/Melodies</th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                {% for source in sources %}
+                    <tr>
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"><b>{{ source.siglum }}</b></a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ source.summary|default:""|truncatechars_html:140 }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if source.century.all %}
+                                <b><a href="{% url 'century-detail' source.century.first.id %}">{{ source.century.first.name }}</a></b><br>
+                            {% endif %}
+                            {% if source.provenance %}
+                                <a href="{% url 'provenance-detail' source.provenance.id %}">{{ source.provenance.name }}</a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if source.image_link %}
+                                <a href="{{ source.image_link }}" target="_blank">Images</a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
+                            {% if source.number_of_melodies %}
+                                <br>/ {{ source.number_of_melodies }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        No sources found.
+    {% endif %}
     {% include "pagination.html" %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Here we are hiding the table in source and sequence list pages if no search results are found from the general search term (Like on OldCantus). We also display a message such as "No sources found." to the user. This message, however, is not currently displayed in OldCantus on the source and sequence list pages, but it does appear on the chant list page. This enhancement ensures consistency across the pages.

Resolves #730 