### PR TITLE
Ensure unpublished sources don't appear on Provenance Detail page

### DIFF
--- a/django/cantusdb_project/main_app/templates/century_detail.html
+++ b/django/cantusdb_project/main_app/templates/century_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in sources|dictsort:"title" %}
             <li>
-                <a href="{% url 'source-detail' source.id %}">
+                <a href="{% url 'source-detail' source.id %}" title="{{ source.siglum }}">
                     {{ source.title }}
                 </a>
             </li>

--- a/django/cantusdb_project/main_app/templates/provenance_detail.html
+++ b/django/cantusdb_project/main_app/templates/provenance_detail.html
@@ -9,7 +9,7 @@
     <ul>
         {% for source in provenance.sources.all|dictsort:"title" %}
             <li>
-                <a href="{% url 'source-detail' source.id %}">
+                <a href="{% url 'source-detail' source.id %}" title="{{ source.siglum }}">
                     {{ source.title }}
                 </a>
             </li>

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2747,6 +2747,31 @@ class ProvenanceDetailViewTest(TestCase):
         self.assertTemplateUsed(response, "base.html")
         self.assertTemplateUsed(response, "provenance_detail.html")
 
+    def test_listed_sources(self):
+        provenance = make_fake_provenance()
+        provenance_sources = [
+            make_fake_source(provenance=provenance, published=True) for _ in range(5)
+        ]
+        response = self.client.get(reverse("provenance-detail", args=[provenance.id]))
+        returned_sources = response.context["sources"]
+        for source in provenance_sources:
+            self.assertIn(source, returned_sources)
+
+    def test_unpublished_sources_not_listed(self):
+        provenance = make_fake_provenance()
+        published_sources = [
+            make_fake_source(provenance=provenance, published=True) for _ in range(5)
+        ]
+        unpublished_sources = [
+            make_fake_source(provenance=provenance, published=False) for _ in range(5)
+        ]
+        response = self.client.get(reverse("provenance-detail", args=[provenance.id]))
+        returned_sources = response.context["sources"]
+        for source in published_sources:
+            self.assertIn(source, returned_sources)
+        for source in unpublished_sources:
+            self.assertNotIn(source, returned_sources)
+
 
 class SequenceListViewTest(TestCase):
     def setUp(self):

--- a/django/cantusdb_project/main_app/views/century.py
+++ b/django/cantusdb_project/main_app/views/century.py
@@ -16,6 +16,6 @@ class CenturyDetailView(DetailView):
         sources = Source.objects.filter(century=century)
         if not display_unpublished:
             sources = sources.filter(published=True)
-        sources = sources.only("title", "id")
+        sources = sources.only("title", "id", "siglum")
         context["sources"] = sources
         return context

--- a/django/cantusdb_project/main_app/views/provenance.py
+++ b/django/cantusdb_project/main_app/views/provenance.py
@@ -1,8 +1,21 @@
 from django.views.generic import DetailView
-from main_app.models import Provenance
+from main_app.models import Provenance, Source
+from typing import Any
 
 
 class ProvenanceDetailView(DetailView):
     model = Provenance
     context_object_name = "provenance"
     template_name = "provenance_detail.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        provenance = self.get_object()
+        user = self.request.user
+        display_unpublished = user.is_authenticated
+        sources = Source.objects.filter(provenance=provenance)
+        if not display_unpublished:
+            sources = sources.filter(published=True)
+        sources = sources.only("title", "id", "siglum")
+        context["sources"] = sources
+        return context


### PR DESCRIPTION
This PR ensures that unpublished sources don't appear on Provenance Detail pages (i.e. it fixes #724). It also adds tests to ensure that this is the case.

To set this up, I mostly copied code from the Century Detail view/template. As I was working on it, it was simple to add `title` attributes to each of the sources allowing the source's siglum to be viewed when the user hovers over the source, so I took the opportunity to add this small enhancement.