### PR TITLE
Hide Full text & volpiano editor and proofreading links

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -256,10 +256,6 @@
                                             Full text &amp; volpiano editor
                                         </a>
                                     </li>
-                                {% else %}
-                                    <li>
-                                        <span title= "Full text &amp; volpiano editor not available - source contains no chants">Full text &amp; volpiano editor</span>
-                                    </li>
                                 {% endif %}
                                 <li>
                                     <a href="{% url "source-edit" source.id%}">Edit source description</a>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -250,9 +250,15 @@
                                 <li>
                                     <a href="{% url "chant-create" source.id%}">Add new chant</a>
                                 </li>
-                                {% if source.number_of_chants %}
+                                {% if source.chant_set.all %}
                                     <li>
-                                        <a href="{% url "source-edit-chants" source.id%}">Edit chants (fulltext & volpiano editor)</a>
+                                        <a href="{% url "source-edit-chants" source.pk %}">
+                                            Full text &amp; volpiano editor
+                                        </a>
+                                    </li>
+                                {% else %}
+                                    <li>
+                                        <span title= "Full text &amp; volpiano editor not available - source contains no chants">Full text &amp; volpiano editor</span>
                                     </li>
                                 {% endif %}
                                 <li>

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -16,24 +16,23 @@
                                     <b>{{ source.siglum }}</b>
                                 </a>
                             </td>
-                            <td class="h-25" style="width: 30%; text-align:center">
-                                {% if source.chant_set.all %}
+                            {% if source.chant_set.all%}
+                                <td class="h-25" style="width: 30%; text-align:center">
                                     <a href="{% url "source-edit-chants" source.pk %}">
                                         Full text &amp; volpiano editor
                                     </a>
-                                {% else %}
-                                    <span title= "Full text &amp; volpiano editor not available - source contains no chants">Full text &amp; volpiano editor</span>
-                                {% endif %}
-                            </td>
-                            <td class="h-25" style="width: 30%; text-align:center">
-                                {% if source.chant_set.all %}
+                                </td>
+                                <td class="h-25" style="width: 30%; text-align:center">
                                     <a href="{% url "chant-proofread" source.pk %}">
                                         Proofreading form
                                     </a>
-                                {% else %}
-                                    <span title= "Proofreading form not available - source contains no chants">Proofreading form</span>
-                                {% endif %}
-                            </td>
+                                </td>
+                            {% else %}
+                            <td class="h-25" style="width: 30%; text-align:center" colspan="2">
+                                Source contains no chants –
+                                <a href="{% url "chant-create" source.pk %}">Add new chant</a> 
+                            </td> 
+                            {% endif %}
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -67,8 +66,6 @@
                                             <a href="{% url "source-edit-chants" my_source.pk %}">
                                                 Full text &amp; volpiano editor
                                             </a>
-                                        {% else %}
-                                            <span title= "Full text &amp; volpiano editor not available - source contains no chants">Full text &amp; volpiano editor</span>
                                         {% endif %}
                                     </td>
                                 </tr>

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -17,14 +17,22 @@
                                 </a>
                             </td>
                             <td class="h-25" style="width: 30%; text-align:center">
-                                <a href="{% url "source-edit-chants" source.pk %}">
-                                    Full text &amp; volpiano editor
-                                </a>
+                                {% if source.chant_set.all %}
+                                    <a href="{% url "source-edit-chants" source.pk %}">
+                                        Full text &amp; volpiano editor
+                                    </a>
+                                {% else %}
+                                    <span title= "Full text &amp; volpiano editor not available - source contains no chants">Full text &amp; volpiano editor</span>
+                                {% endif %}
                             </td>
                             <td class="h-25" style="width: 30%; text-align:center">
-                                <a href="{% url "chant-proofread" source.pk %}">
-                                    Proofreading form
-                                </a>
+                                {% if source.chant_set.all %}
+                                    <a href="{% url "chant-proofread" source.pk %}">
+                                        Proofreading form
+                                    </a>
+                                {% else %}
+                                    <span title= "Proofreading form not available - source contains no chants">Proofreading form</span>
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}
@@ -55,9 +63,13 @@
                                             &plus; Add new chant
                                         </a>
                                         <br>
-                                        <a href="{% url "source-edit-chants" my_source.pk %}">
-                                            &bull; Full text &amp; volpiano editor
-                                        </a>
+                                        {% if my_source.chant_set.all %}
+                                            <a href="{% url "source-edit-chants" my_source.pk %}">
+                                                Full text &amp; volpiano editor
+                                            </a>
+                                        {% else %}
+                                            <span title= "Full text &amp; volpiano editor not available - source contains no chants">Full text &amp; volpiano editor</span>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}


### PR DESCRIPTION
This PR introduces improvements to the templates used for the user source list and source detail pages. Previously, links leading to the Full text & volpiano editor or proofreading pages would remain active if no chants were present in the source, leading to a 404 error. The modification removes the link and displays a message that can be viewed by hovering over the original link location.

This issue fixes some of the pages listed in issue #735, but we still need to remove this link from the home page My Sources sidebar