### PR TITLE
In add_all_users.py, give new users a random password

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/add_all_users.py
+++ b/django/cantusdb_project/main_app/management/commands/add_all_users.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
                 if created:
                     user.first_name = name
                     user.last_name = surname
-                    full_name = " ".join((name, surname))
+                    full_name: str = " ".join((name, surname))
                     user.full_name = full_name
 
                     user.institution = institution

--- a/django/cantusdb_project/main_app/management/commands/add_all_users.py
+++ b/django/cantusdb_project/main_app/management/commands/add_all_users.py
@@ -3,6 +3,10 @@ from django.core.management.base import BaseCommand
 import csv
 from django.contrib.auth.models import Group
 from main_app.models import Source, Chant
+import string
+import secrets
+
+ALPHABET: str = string.ascii_letters + string.digits
 
 
 class Command(BaseCommand):
@@ -28,10 +32,14 @@ class Command(BaseCommand):
                 if created:
                     user.first_name = name
                     user.last_name = surname
+
                     user.institution = institution
                     user.city = city
                     user.country = country
-                    user.set_password("cantusdb")
+
+                    password: str = "".join(secrets.choice(ALPHABET) for _ in range(32))
+                    user.set_password(password)
+
                     user.save()
 
                 if user.groups.first() is None:

--- a/django/cantusdb_project/main_app/management/commands/add_all_users.py
+++ b/django/cantusdb_project/main_app/management/commands/add_all_users.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
                 if created:
                     user.first_name = name
                     user.last_name = surname
+                    full_name = " ".join((name, surname))
+                    user.full_name = full_name
 
                     user.institution = institution
                     user.city = city


### PR DESCRIPTION
This PR updates the `add_all_users` management command, changing it so newly created users are assigned a random password rather than the placeholder that has been used up until now.

This is a necessary step towards resolvin\g #741 

Along the way, I noticed that newly-created users' `full_name` fields were not being given a default value. The script has been updated to also populate this field.