### PR TITLE
Update tests for `users` app

### DIFF
--- a/django/cantusdb_project/articles/tests/test_articles.py
+++ b/django/cantusdb_project/articles/tests/test_articles.py
@@ -12,6 +12,7 @@ from main_app.tests.make_fakes import (
 # Create a Faker instance with locale set to Latin
 faker = Faker("la")
 
+
 def make_fake_article(user=None):
     if user is None:
         user = make_fake_user()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3808,7 +3808,8 @@ class ChangePasswordViewTest(TestCase):
         self.assertEqual(
             response_2.status_code, 200
         )  # if login failed, status code will be 302
-    
+
+
 class NodeURLRedirectTest(TestCase):
     def setUp(self):
         self.client = Client()
@@ -3819,12 +3820,14 @@ class NodeURLRedirectTest(TestCase):
         Chant.objects.create(id=example_chant_id)
 
         # find dummy object using /node/ path
-        response_1 = self.client.get(reverse("redirect-node-url", args=[example_chant_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[example_chant_id])
+        )
         expected_url = reverse("chant-detail", args=[example_chant_id])
-        
+
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_1.url, expected_url)
-    
+
     def test_source_redirect(self):
         # generate dummy object with ID in valid range
         example_source_id = random.randrange(1, 1000000)
@@ -3833,25 +3836,28 @@ class NodeURLRedirectTest(TestCase):
         source_1.save()
 
         # find dummy object using /node/ path
-        response_1 = self.client.get(reverse("redirect-node-url", args=[example_source_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[example_source_id])
+        )
         expected_url = reverse("source-detail", args=[example_source_id])
-        
+
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_1.url, expected_url)
-    
+
     def test_sequence_redirect(self):
         # generate dummy object with ID in valid range
         example_sequence_id = random.randrange(1, 1000000)
         Sequence.objects.create(id=example_sequence_id)
 
         # find dummy object using /node/ path
-        response_1 = self.client.get(reverse("redirect-node-url", args=[example_sequence_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[example_sequence_id])
+        )
         expected_url = reverse("sequence-detail", args=[example_sequence_id])
-        
+
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_1.url, expected_url)
 
-    
     def test_article_redirect(self):
         # generate dummy object with ID in valid range
         example_article_id = random.randrange(1, 1000000)
@@ -3860,30 +3866,38 @@ class NodeURLRedirectTest(TestCase):
         article_1.save()
 
         # find dummy object using /node/ path
-        response_1 = self.client.get(reverse("redirect-node-url", args=[example_article_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[example_article_id])
+        )
         expected_url = reverse("article-detail", args=[example_article_id])
-        
+
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_1.url, expected_url)
-    
+
     def test_indexer_redirect(self):
         # generate dummy object with ID in valid range
         example_indexer_id = random.randrange(1, 1000000)
         example_matching_user_id = random.randrange(1, 1000000)
-        User.objects.create(id=example_matching_user_id, old_indexer_id=example_indexer_id)
-        
+        User.objects.create(
+            id=example_matching_user_id, old_indexer_id=example_indexer_id
+        )
+
         # find dummy object using /node/ path
-        response_1 = self.client.get(reverse("redirect-node-url", args=[example_indexer_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[example_indexer_id])
+        )
         expected_url = reverse("user-detail", args=[example_matching_user_id])
-        
+
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_1.url, expected_url)
 
     def test_bad_redirect(self):
         invalid_node_id = random.randrange(1, 1000000)
-        
+
         # try to find object that doesn't exist
-        response_1 = self.client.get(reverse("redirect-node-url", args=[invalid_node_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[invalid_node_id])
+        )
         self.assertEqual(response_1.status_code, 404)
 
     def test_redirect_above_limit(self):
@@ -3892,8 +3906,11 @@ class NodeURLRedirectTest(TestCase):
         Chant.objects.create(id=over_limit_node_id)
 
         # ID above limit
-        response_1 = self.client.get(reverse("redirect-node-url", args=[over_limit_node_id]))
+        response_1 = self.client.get(
+            reverse("redirect-node-url", args=[over_limit_node_id])
+        )
         self.assertEqual(response_1.status_code, 404)
+
 
 class IndexerRedirectTest(TestCase):
     def setUp(self):
@@ -3903,16 +3920,22 @@ class IndexerRedirectTest(TestCase):
         # generate dummy object
         example_indexer_id = random.randrange(1, 1000000)
         example_matching_user_id = random.randrange(1, 1000000)
-        User.objects.create(id=example_matching_user_id, old_indexer_id=example_indexer_id)
-        
+        User.objects.create(
+            id=example_matching_user_id, old_indexer_id=example_indexer_id
+        )
+
         # find dummy object using /indexer/ path
-        response_1 = self.client.get(reverse("redirect-indexer", args=[example_indexer_id]))
+        response_1 = self.client.get(
+            reverse("redirect-indexer", args=[example_indexer_id])
+        )
         expected_url = reverse("user-detail", args=[example_matching_user_id])
-       
+
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_1.url, expected_url)
-    
+
     def test_indexer_redirect_bad(self):
         example_bad_indexer_id = random.randrange(1, 1000000)
-        response_1 = self.client.get(reverse("redirect-indexer", args=[example_bad_indexer_id]))
+        response_1 = self.client.get(
+            reverse("redirect-indexer", args=[example_bad_indexer_id])
+        )
         self.assertEqual(response_1.status_code, 404)

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -632,6 +632,7 @@ def content_overview(request):
         request, "content_overview.html", {"objects": recently_updated_50_objects}
     )
 
+
 def redirect_node_url(request, pk: int) -> HttpResponse:
     """
     A function that will redirect /node/ URLs from OldCantus to their corresponding page in NewCantus.
@@ -642,32 +643,33 @@ def redirect_node_url(request, pk: int) -> HttpResponse:
     Returns the matching page in NewCantus if it exists and a 404 otherwise.
     """
     not_found = HttpResponseNotFound()
-    
+
     # all IDs above this value are created in NewCantus and thus could have conflicts between types.
     # this number is a placeholder and will be updated post-migration.
     # we will manually create (unpublished) dummy objects in the database to ensure that all subqequent objects created will have IDs above this number.
     if pk >= 1_000_000:
         return not_found
-    
+
     # chant, source, sequence, article
     possible_types = [
-        (Chant, 'chant-detail'),
-        (Source, 'source-detail'),
-        (Sequence, 'sequence-detail'),
-        (Article, 'article-detail')
+        (Chant, "chant-detail"),
+        (Source, "source-detail"),
+        (Sequence, "sequence-detail"),
+        (Article, "article-detail"),
     ]
 
     user_id = get_user_id_from_old_indexer_id(pk)
     if get_user_id_from_old_indexer_id(pk) is not None:
-        return redirect('user-detail', user_id)
-    
+        return redirect("user-detail", user_id)
+
     for (rec_type, view) in possible_types:
         if record_exists(rec_type, pk):
             # if an object is found, a redirect() call to the appropriate view is returned
             return redirect(view, pk)
-        
+
     # if it reaches the end of the types with finding an existing object, a 404 will be returned
     return not_found
+
 
 # used to determine whether record of specific type (chant, source, sequence, article) exists for a given pk
 def record_exists(rec_type: BaseModel, pk: int) -> bool:
@@ -677,12 +679,13 @@ def record_exists(rec_type: BaseModel, pk: int) -> bool:
     except rec_type.DoesNotExist:
         return False
 
+
 def get_user_id_from_old_indexer_id(pk: int) -> Optional[int]:
     """
     A function that and finds the matching User ID in NewCantus for an Indexer ID in OldCantus.
     This is stored in the User table's old_indexer_id column.
     This is necessary because indexers were originally stored in the general Node table in OldCantus, but are now represented as users in NewCantus.
-    
+
     Takes in an indexer ID from OldCantus as an argument.
     Returns the user ID from NewCantus if a match is found and None otherwise.
     """
@@ -692,6 +695,7 @@ def get_user_id_from_old_indexer_id(pk: int) -> Optional[int]:
         return result.id
     except User.DoesNotExist:
         return None
+
 
 def redirect_indexer(request, pk: int) -> HttpResponse:
     """
@@ -703,6 +707,6 @@ def redirect_indexer(request, pk: int) -> HttpResponse:
     """
     user_id = get_user_id_from_old_indexer_id(pk)
     if get_user_id_from_old_indexer_id(pk) is not None:
-        return redirect('user-detail', user_id)
-    
+        return redirect("user-detail", user_id)
+
     return HttpResponseNotFound()

--- a/django/cantusdb_project/users/tests.py
+++ b/django/cantusdb_project/users/tests.py
@@ -3,7 +3,7 @@ from django.test import Client
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from main_app.models import Segment, Source
-from main_app.tests.make_fakes import make_fake_user
+from main_app.tests.make_fakes import make_fake_user, make_fake_source
 from main_app.tests.test_views import get_random_search_term
 
 # run with `python -Wa manage.py test users.tests`
@@ -62,17 +62,15 @@ class IndexerListViewTest(TestCase):
         indexer_with_no_source = make_fake_user()
 
         # generate published/unpublished sources and assign indexers to them
-        unpublished_source = Source.objects.create(
+        unpublished_source = make_fake_source(
             title="unpublished source", published=False
         )
         unpublished_source.inventoried_by.set([indexer_with_unpublished_source])
 
-        published_source = Source.objects.create(
-            title="published source", published=True
-        )
+        published_source = make_fake_source(title="published source", published=True)
         published_source.inventoried_by.set([indexer_with_published_source])
 
-        source_with_multiple_indexers = Source.objects.create(
+        source_with_multiple_indexers = make_fake_source(
             title="unpublished source with multiple indexers",
             published=False,
         )
@@ -94,9 +92,7 @@ class IndexerListViewTest(TestCase):
         Only public indexers should appear in the results
         """
         indexer_with_published_source = make_fake_user()
-        published_source = Source.objects.create(
-            title="published source", published=True
-        )
+        published_source = make_fake_source(title="published source", published=True)
         published_source.inventoried_by.set([indexer_with_published_source])
 
         # search with a random slice of first name
@@ -108,9 +104,7 @@ class IndexerListViewTest(TestCase):
 
     def test_search_country(self):
         indexer_with_published_source = make_fake_user()
-        published_source = Source.objects.create(
-            title="published source", published=True
-        )
+        published_source = make_fake_source(title="published source", published=True)
         published_source.inventoried_by.set([indexer_with_published_source])
 
         target = indexer_with_published_source.country
@@ -121,9 +115,7 @@ class IndexerListViewTest(TestCase):
 
     def test_search_city(self):
         indexer_with_published_source = make_fake_user()
-        published_source = Source.objects.create(
-            title="published source", published=True
-        )
+        published_source = make_fake_source(title="published source", published=True)
         published_source.inventoried_by.set([indexer_with_published_source])
 
         target = indexer_with_published_source.city
@@ -134,9 +126,7 @@ class IndexerListViewTest(TestCase):
 
     def test_search_institution(self):
         indexer_with_published_source = make_fake_user()
-        published_source = Source.objects.create(
-            title="published source", published=True
-        )
+        published_source = make_fake_source(title="published source", published=True)
         published_source.inventoried_by.set([indexer_with_published_source])
 
         target = indexer_with_published_source.institution


### PR DESCRIPTION
It seems the users app hasn't been run in a while, and errors now occur when we try to create fake sources within this test suite (sources' `siglum` field is now required, but the tests for users hadn't been updated to reflect this). This PR substitutes `make_fake_source` for `Source.objects.create`, which resolves the issue.