### PR TITLE
ensure Admin Navigation section in footer is only shown to admins

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -448,11 +448,11 @@
                             |
                             <a href="{% url 'change-password' %}">Change Password</a>
                             |
-                            <a href="{% url 'logout' %}">Logout</a>
+                            <a href="{% url 'logout' %}">Log out</a>
                         {% else %}
                             <h5>Login for Contributors</h5>
                             <a href="{% url 'login' %}?next={{ request.path }}">
-                                <button type="button" class="btn btn-dark">Login</button>
+                                <button type="button" class="btn btn-dark">Log in</button>
                             </a>                        
                         {% endif %}
                     </div>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -412,37 +412,37 @@
                     </div>
                     <div class="col-md-3" id="login">
                         {% if not request.user.is_anonymous %}
-                            <h5>Admin Navigation</h5>
-                            <ul class="list-group list-group-flush">
-                                {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
+                            {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
+                                <h5>Admin Navigation</h5>
+                                <ul class="list-group list-group-flush">
                                     <li class="list-group-item p-0">
                                         <a href="{% url 'my-sources' %}">My Sources</a>
                                     </li>
                                     <li class="list-group-item p-0">
                                         <a href="{% url 'source-create' %}">Add Source</a>
                                     </li>
-                                {% endif %}
-                                {% if request.user|has_group:"project manager" %}
-                                    <li class="list-group-item p-0">
-                                        <a href="{% url 'admin:articles_article_add' %}">Add News</a>
-                                    </li>
-                                    <li class="list-group-item p-0">
-                                        <a href="{% url 'admin:main_app_feast_add' %}">Add Feast</a>
-                                    </li>
-                                    <li class="list-group-item p-0">
-                                        <a href="{% url 'indexer-list' %}">List of Indexers</a>
-                                    </li>
-                                    <li class="list-group-item p-0">
-                                        <a href="{% url 'admin:users_user_changelist' %}">Administer Users</a>
-                                    </li>
-                                    <li class="list-group-item p-0">
-                                        <a href="{% url 'admin:index' %}">Taxonomy Manager</a>
-                                    </li>
-                                    <li class="list-group-item p-0">
-                                        <a href="{% url 'content-overview' %}">Content Overview</a>
-                                    </li>
-                                {% endif %}
-                            </ul>
+                                    {% if request.user|has_group:"project manager" %}
+                                        <li class="list-group-item p-0">
+                                            <a href="{% url 'admin:articles_article_add' %}">Add News</a>
+                                        </li>
+                                        <li class="list-group-item p-0">
+                                            <a href="{% url 'admin:main_app_feast_add' %}">Add Feast</a>
+                                        </li>
+                                        <li class="list-group-item p-0">
+                                            <a href="{% url 'indexer-list' %}">List of Indexers</a>
+                                        </li>
+                                        <li class="list-group-item p-0">
+                                            <a href="{% url 'admin:users_user_changelist' %}">Administer Users</a>
+                                        </li>
+                                        <li class="list-group-item p-0">
+                                            <a href="{% url 'admin:index' %}">Taxonomy Manager</a>
+                                        </li>
+                                        <li class="list-group-item p-0">
+                                            <a href="{% url 'content-overview' %}">Content Overview</a>
+                                        </li>
+                                    {% endif %}
+                                </ul>
+                            {% endif %}
                             <h5>User Profile</h5>
                             <a href="{% url 'user-detail' request.user.id %}">{{ request.user }}</a>
                             |


### PR DESCRIPTION
fixes #686 - whereas some items would be shown to all users under "Admin Navigation", that entire section is now shown only to contributors, editors and project managers.

Also, buttons/links to log in or log out now read "log in" or "log out" rather than "login" and "logout" (not included in screenshots below). 

How the bottom right now appears to:
- me, with all the permissions/groups
 ![Screenshot 2023-06-16 at 1 18 25 PM](https://github.com/DDMAL/CantusDB/assets/58090591/367c30e4-a16f-4b79-9900-e3a28bc6bb66)
- a user with no permissions/groups
 ![Screenshot 2023-06-16 at 1 19 22 PM](https://github.com/DDMAL/CantusDB/assets/58090591/8ca97959-d279-46c1-9124-473445e0fbec)
- a logged-out, anonymous user
 ![Screenshot 2023-06-16 at 1 19 36 PM](https://github.com/DDMAL/CantusDB/assets/58090591/0d1880b3-3319-4cfe-aab4-739e280b03e9)

