### PR TITLE
Fix bug in provenance_detail.html

### DIFF
--- a/django/cantusdb_project/main_app/templates/provenance_detail.html
+++ b/django/cantusdb_project/main_app/templates/provenance_detail.html
@@ -7,7 +7,7 @@
     </object>
     <h3>{{ provenance.name }}</h3>
     <ul>
-        {% for source in provenance.sources.all|dictsort:"title" %}
+        {% for source in sources|dictsort:"title" %}
             <li>
                 <a href="{% url 'source-detail' source.id %}" title="{{ source.siglum }}">
                     {{ source.title }}

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -648,7 +648,7 @@ def redirect_node_url(request, pk: int) -> HttpResponse:
     # we will manually create (unpublished) dummy objects in the database to ensure that all subqequent objects created will have IDs above this number.
     if pk >= 1_000_000:
         raise Http404("Invalid ID for /node/ path.")
-    
+
     # chant, source, sequence, article
     possible_types = [
         (Chant, "chant-detail"),
@@ -668,7 +668,6 @@ def redirect_node_url(request, pk: int) -> HttpResponse:
 
     # if it reaches the end of the types with finding an existing object, a 404 will be returned
     raise Http404("No record found matching the /node/ query.")
-
 
 
 # used to determine whether record of specific type (chant, source, sequence, article) exists for a given pk
@@ -707,6 +706,6 @@ def redirect_indexer(request, pk: int) -> HttpResponse:
     """
     user_id = get_user_id_from_old_indexer_id(pk)
     if get_user_id_from_old_indexer_id(pk) is not None:
-        return redirect('user-detail', user_id)
-    
+        return redirect("user-detail", user_id)
+
     raise Http404("No indexer found matching the query.")


### PR DESCRIPTION
When I fixed #724, I made a mistake. When I opened my PR to fix that, I changed `context["sources"]` to properly filter, and in our tests we tested that the right sources were included among `context["sources"]`, but in our template, we were displaying not `context["sources"]` but `provenance.sources.all`.

This PR corrects this bug.

Along the way, Black decided more files needed formatting.