### PR TITLE
Fix 404 error on edit-chants page for sources with no chants and deleting last chant in source

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -251,36 +251,40 @@
                     <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
                 </div>
                 <div class="card-body">
-                    <small>
-                        <!--a small selector of all folios of this source-->
-                        <select id="folioSelect" class="w-30">
-                            <option value="">Select a folio:</option>
-                            {% for folio in folios %}
-                                {% if folio == initial_GET_folio %}
-                                    <option value="{{ folio }}" selected>{{ folio }}</option>
-                                {% else %}
-                                    <option value="{{ folio }}">{{ folio }}</option>
-                                {% endif %}
-                            {% endfor %}
-                        </select>             
-                        
-                        {% if previous_folio %}
-                            <a href="{% url "source-edit-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
-                        {% endif %}
-                        {% if next_folio %}
-                            &nbsp;<a href="{% url "source-edit-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
-                        {% endif %}             
+                    {% if source.chant_set.exists %}
+                        <small>
+                            <!--a small selector of all folios of this source-->
+                            <select id="folioSelect" class="w-30">
+                                <option value="">Select a folio:</option>
+                                {% for folio in folios %}
+                                    {% if folio == initial_GET_folio %}
+                                        <option value="{{ folio }}" selected>{{ folio }}</option>
+                                    {% else %}
+                                        <option value="{{ folio }}">{{ folio }}</option>
+                                    {% endif %}
+                                {% endfor %}
+                            </select>             
+                            
+                            {% if previous_folio %}
+                                <a href="{% url "source-edit-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
+                            {% endif %}
+                            {% if next_folio %}
+                                &nbsp;<a href="{% url "source-edit-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
+                            {% endif %}             
 
-                        <br>
+                            <br>
 
-                        <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
-                            <option value="">Select a feast:</option>
-                            {% for folio, feast in feasts_with_folios %}
-                                <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
-                            {% endfor %}
-                        </select>
-                        <br>
-                    </small>
+                            <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                                <option value="">Select a feast:</option>
+                                {% for folio, feast in feasts_with_folios %}
+                                    <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
+                                {% endfor %}
+                            </select>
+                            <br>
+                        </small>
+                    {% else %}
+                        <small>Source contains no chants – <a href="{% url "chant-create" source.pk %}">Add new chant</a></small>
+                    {% endif %}
                     {% comment %} render if the user has selected a specific folio {% endcomment %}
                     {% if feasts_current_folio %}
                         {% for feast, chants in feasts_current_folio %}

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2020,7 +2020,7 @@ class SourceEditChantsViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertTemplateUsed(response, "404.html")
 
-        # trying to access chant-edit with a source that has no chant should return 404
+        # trying to access chant-edit with a source that has no chant should return 200
         source2 = make_fake_source()
 
         response = self.client.get(reverse("source-edit-chants", args=[source2.id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2024,8 +2024,8 @@ class SourceEditChantsViewTest(TestCase):
         source2 = make_fake_source()
 
         response = self.client.get(reverse("source-edit-chants", args=[source2.id]))
-        self.assertEqual(response.status_code, 404)
-        self.assertTemplateUsed(response, "404.html")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "chant_edit.html")
 
     def test_update_chant(self):
         source = make_fake_source()

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1525,7 +1525,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
         # the following code block is sort of obsolete because if there is no Chant
         # in the Source, a 404 will be raised
-        if chants_in_source.count() == 0:
+        if not chants_in_source.exists():
             # these are needed in the selectors and hyperlinks on the right side of the page
             # if there's no chant in the source, there should be no options in those selectors
             context["folios"] = None

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1544,20 +1544,25 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         # the options for the feast selector on the right, same as the source detail page
         context["feasts_with_folios"] = get_feast_selector_options(source, folios)
 
-        # the user has selected a folio, or,
-        # they have just navigated to the edit-chant page (where the first folio gets
-        # selected by default)
-        if self.request.GET.get("folio") or (
-            not self.request.GET.get("folio") and not self.request.GET.get("feast")
-        ):
-            # if browsing chants on a specific folio
+        if self.request.GET.get("feast"):
+            # if there is a "feast" query parameter, it means the user has chosen a specific feast
+            # need to render a list of chants, grouped and ordered by folio and within each group,
+            # ordered by c_sequence
+            context["folios_current_feast"] = get_chants_with_folios(self.queryset)
+        else:
+            # the user has selected a folio, or,
+            # they have just navigated to the edit-chant page (where the first folio gets
+            # selected by default)
             if self.request.GET.get("folio"):
+                # if browsing chants on a specific folio
                 folio = self.request.GET.get("folio")
             else:
                 folio = folios[0]
                 # will be used in the template to pre-select the first folio in the drop-down
                 context["initial_GET_folio"] = folio
+            print("line 1560")
             index = list(folios).index(folio)
+            print("line 1561")
             # get the previous and next folio, if available
             context["previous_folio"] = folios[index - 1] if index != 0 else None
             context["next_folio"] = (
@@ -1566,12 +1571,6 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             # if there is a "folio" query parameter, it means the user has chosen a specific folio
             # need to render a list of chants, ordered by c_sequence and grouped by feast
             context["feasts_current_folio"] = get_chants_with_feasts(self.queryset)
-
-        elif self.request.GET.get("feast"):
-            # if there is a "feast" query parameter, it means the user has chosen a specific feast
-            # need to render a list of chants, grouped and ordered by folio and within each group,
-            # ordered by c_sequence
-            context["folios_current_feast"] = get_chants_with_folios(self.queryset)
 
         # this boolean lets us decide whether to show the user the instructions or the editing form
         # if the pk hasn't been specified, a user hasn't selected a specific chant they want to edit

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1597,16 +1597,16 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
                 json_response = None
             if json_response:
                 context["suggested_fulltext"] = json_response[0]["fulltext"]
-        if source.chant_set.exists():
-            chant = self.get_object()
-            if chant.volpiano:
-                has_syl_text = bool(chant.manuscript_syllabized_full_text)
-                text_and_mel = syllabize_text_and_melody(
-                    chant.get_best_text_for_syllabizing(),
-                    pre_syllabized=has_syl_text,
-                    melody=chant.volpiano,
-                )
-                context["syllabized_text_with_melody"] = text_and_mel
+
+        chant = self.get_object()
+        if chant.volpiano:
+            has_syl_text = bool(chant.manuscript_syllabized_full_text)
+            text_and_mel = syllabize_text_and_melody(
+                chant.get_best_text_for_syllabizing(),
+                pre_syllabized=has_syl_text,
+                melody=chant.volpiano,
+            )
+            context["syllabized_text_with_melody"] = text_and_mel
 
         return context
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1560,9 +1560,10 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
                 folio = folios[0]
                 # will be used in the template to pre-select the first folio in the drop-down
                 context["initial_GET_folio"] = folio
-            print("line 1560")
-            index = list(folios).index(folio)
-            print("line 1561")
+            try:
+                index = list(folios).index(folio)
+            except ValueError:
+                raise Http404("No chants within source match the specified folio")
             # get the previous and next folio, if available
             context["previous_folio"] = folios[index - 1] if index != 0 else None
             context["next_folio"] = (


### PR DESCRIPTION
This PR addresses several issues related to accessing pages with a source that contains no chants. Specifically, a 404 error that occurs when trying to access the edit-chants page for a source without any chants, as well as when deleting the last chant in a source. This solution allows the edit-chants page to load even when there are no chants in the source. The test views have been updated to reflect the implemented changes.

The previous approach involved hiding links to the edit-chants page if there were no chants and instead displaying an option to add new chants. We should now consider whether we want to display these links again, since this is what OldCantus does.

Fixes #711, Fixes #710, Fixes #489