### PR TITLE
Add search options for source-user relationship in admin area

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -69,6 +69,7 @@ class SequenceAdmin(BaseModelAdmin):
 
 
 class SourceAdmin(BaseModelAdmin):
+    search_fields = ("siglum", "title")
     # from the Django docs:
     # Adding a ManyToManyField to this list will instead use a nifty unobtrusive JavaScript “filter” interface
     # that allows searching within the options. The unselected and selected options appear in two boxes side by side.

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -69,7 +69,11 @@ class SequenceAdmin(BaseModelAdmin):
 
 
 class SourceAdmin(BaseModelAdmin):
-    search_fields = ("siglum", "title")
+    # These search fields are also available on the user-source inline relationship in the user admin page
+    search_fields = (
+        "siglum",
+        "title",
+    )
     # from the Django docs:
     # Adding a ManyToManyField to this list will instead use a nifty unobtrusive JavaScript “filter” interface
     # that allows searching within the options. The unselected and selected options appear in two boxes side by side.

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -9,6 +9,7 @@ from main_app.models import Source
 # this will allow us to assign sources to users in the User admin page
 class SourceInline(admin.TabularInline):
     model = Source.current_editors.through
+    raw_id_fields = ["source"]
 
 
 class UserAdmin(BaseUserAdmin):


### PR DESCRIPTION
This PR focuses on improving the admin area by introducing enhanced search options for sources. Within the source admin area, a search bar is added, enabling users to search for sources based on siglum and title. Previously, in the user admin area, a dropdown menu was used to assign sources to users. This modification changes the functionality to allow source assignment by ID. Additionally, a search icon opens a window for searching sources in the database based on siglum and title.

Fixes #762 