### PR TITLE
Remove instances of "changed_initial_password"

### DIFF
--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -55,7 +55,7 @@ from main_app.views.source import (
     SourceListView,
 )
 from main_app.views.user import (
-    CustomLoginView,
+    LoginView,
     CustomLogoutView,
     IndexerListView,
     UserDetailView,
@@ -73,7 +73,7 @@ urlpatterns = [
     # login/logout/user
     path(
         "login/",
-        CustomLoginView.as_view(redirect_authenticated_user=True),
+        LoginView.as_view(redirect_authenticated_user=True),
         name="login",
     ),
     path(

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -165,14 +165,3 @@ class IndexerListView(SearchableListMixin, ListView):
             )
             # display those who have at least one published source
             return indexers.filter(source_count__gte=1)
-
-
-class CustomLoginView(LoginView):
-    def form_valid(self, form):
-        auth_login(self.request, form.get_user())
-        # if the user has not yet changed the initial password that was assigned to them,
-        # redirect them to the change-password page everytime they log in
-        # with warning messages prompting them to change their password
-        if form.get_user().changed_initial_password == False:
-            return HttpResponseRedirect(reverse("change-password"))
-        return HttpResponseRedirect(self.get_success_url())

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -568,23 +568,11 @@ def change_password(request):
     if request.method == "POST":
         form = PasswordChangeForm(request.user, request.POST)
         if form.is_valid():
-            # if the user is trying to change their password for the first time (the password that was given to them),
-            # update the user's changed_initial_password boolean field to True
-            if request.user.changed_initial_password == False:
-                form.user.changed_initial_password = True
             user = form.save()
             update_session_auth_hash(request, user)
             messages.success(request, "Your password was successfully updated!")
     else:
         form = PasswordChangeForm(request.user)
-        if request.user.changed_initial_password == False:
-            messages.warning(
-                request,
-                (
-                    "The current password was assigned to you by default and is unsecure. "
-                    "Please make sure to change it for security purposes."
-                ),
-            )
     return render(request, "registration/change_password.html", {"form": form})
 
 

--- a/django/cantusdb_project/users/models.py
+++ b/django/cantusdb_project/users/models.py
@@ -14,8 +14,6 @@ class User(AbstractUser):
     # i.e. users will log in with their emails
     username = None
     email = models.EmailField(unique=True)
-    # will be used to check if the user has changed the password assigned to them
-    changed_initial_password = models.BooleanField(default=False)
     # whether the user has an associated indexer object on old Cantus
     # if True, list the user in indexer-list page
     is_indexer = models.BooleanField(default=False)


### PR DESCRIPTION
This PR focuses on enhancing our password management system by implementing a more secure and user-friendly password reset mechanism. Previously, we utilized a "changed_initial_password" flag to prompt users to reset their passwords if they hadn't done so already. However, with the introduction of password reset via email, it is more appropriate to remove this field and all associated references from the codebase. Resetting the password through the password reset email provides a safer and more reliable approach.

Note that we need to make migrations again after removing this field from the Users model.

Resolves #745 