### PR TITLE
Add permissions for editors to proofread their created sources

### DIFF
--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -22,11 +22,13 @@
                                         Full text &amp; volpiano editor
                                     </a>
                                 </td>
-                                <td class="h-25" style="width: 30%; text-align:center">
-                                    <a href="{% url "chant-proofread" source.pk %}">
-                                        Proofreading form
-                                    </a>
-                                </td>
+                                {% if request.user|has_group:"project manager" or request.user|has_group:"editor" %}
+                                    <td class="h-25" style="width: 30%; text-align:center">
+                                        <a href="{% url "chant-proofread" source.pk %}">
+                                            Proofreading form
+                                        </a>
+                                    </td>
+                                {% endif %}
                             {% else %}
                             <td class="h-25" style="width: 30%; text-align:center" colspan="2">
                                 Source contains no chants –

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -199,6 +199,7 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
         # assign this source to the "current_editors"
         current_editors = source.current_editors.all()
+        self.request.user.sources_user_can_edit.add(source)
 
         for editor in current_editors:
             editor.sources_user_can_edit.add(source)


### PR DESCRIPTION
This PR is related to changing the permissions system to allow editors to proofread the sources they create. Previously, editors did not automatically have proofreading permission for the sources they created unless explicitly added as editors. This solution addresses this issue by automatically adding the source to the `sources_user_can_edit` field of the user when an editor creates a new source. Additionally, contributors should not have access to the proofreading form. In the "My Sources" page, the "Proofreading form" link is hidden for contributors, as it should only be available to the editor and project manager groups. 

I believe all of the permissions are correct here, but do check the permissions spreadsheet to make sure before approving.

resolves #491, fixes #736 