### PR TITLE
Source Detail page: add notes1-3 columns when displaying list of sequences within source

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -97,7 +97,7 @@
                 <h4>Sequences in this source</h4>
                 <small>Displaying 1 - {{ sequences.count }} of {{ sequences.count }}</small>
                 <small>
-                    <table class="table table-sm small table-bordered">
+                    <table class="table table-sm small table-bordered table-responsive">
                         <thead>
                             <tr>
                                 <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">Siglum</th>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -101,7 +101,7 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Text&nbsp;Incipit</th>
                                 <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
                                 <th scope="col" class="text-wrap" style="text-align:center">AH</th>
                                 <th scope="col" class="text-wrap" style="text-align:center">Cantus&nbsp;ID</th>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -96,41 +96,55 @@
             {% if sequences %}
                 <h4>Sequences in this source</h4>
                 <small>Displaying 1 - {{ sequences.count }} of {{ sequences.count }}</small>
-                <table class="table table-sm small table-bordered">
-                    <thead>
-                        <tr>
-                            <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                            <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
-                            <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
-                            <th scope="col" class="text-wrap" style="text-align:center">AH</th>
-                            <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for sequence in sequences %}
+                <small>
+                    <table class="table table-sm small table-bordered">
+                        <thead>
                             <tr>
-                                <td class="text-wrap" style="text-align:center">
-                                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a>
-                                    <br>
-                                    <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    <a href="{% url 'sequence-detail' sequence.id %}" >{{ sequence.incipit|default:"" }}</a>
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {{ sequence.rubrics|default:"" }}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {{ sequence.analecta_hymnica|default:"" }}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
-                                    <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
-                                </td>
+                                <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">AH</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Cantus&nbsp;ID</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Notes&nbsp;1</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Notes&nbsp;2</th>
+                                <th scope="col" class="text-wrap" style="text-align:center">Notes&nbsp;3</th>
                             </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            {% for sequence in sequences %}
+                                <tr>
+                                    <td class="text-wrap" style="text-align:center">
+                                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a>
+                                        <br>
+                                        <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        <a href="{% url 'sequence-detail' sequence.id %}" >{{ sequence.incipit|default:"" }}</a>
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        {{ sequence.rubrics|default:"" }}
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        {{ sequence.analecta_hymnica|default:"" }}
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
+                                        <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        {{ sequence.col1|default:"" }}
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        {{ sequence.col2|default:"" }}
+                                    </td>
+                                    <td class="text-wrap" style="text-align:center">
+                                        {{ sequence.col3|default:"" }}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </small>
             {% endif %}
         </div>
 

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -100,14 +100,14 @@
                     <table class="table table-sm small table-bordered">
                         <thead>
                             <tr>
-                                <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Text&nbsp;Incipit</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">AH</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Cantus&nbsp;ID</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Notes&nbsp;1</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Notes&nbsp;2</th>
-                                <th scope="col" class="text-wrap" style="text-align:center">Notes&nbsp;3</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">Siglum</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Text Incipit">Text&nbsp;Incipit</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Rubrics">Rubrics</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Analecta Hymnica">AH</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">Cantus&nbsp;ID</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Notes 1">Notes&nbsp;1</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Notes 2">Notes&nbsp;2</th>
+                                <th scope="col" class="text-wrap" style="text-align:center" title="Notes 3">Notes&nbsp;3</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Fixes #562

Also in this PR, formatting has been updated, with the entire table wrapped in `<small>` tags.

OldCantus:
![Screenshot 2023-06-21 at 3 28 20 PM](https://github.com/DDMAL/CantusDB/assets/58090591/41f3caa7-9ed5-4554-8445-e9d90a7e5465)

NewCantus, previously:
![Screenshot 2023-06-21 at 3 28 27 PM](https://github.com/DDMAL/CantusDB/assets/58090591/54b7e012-a540-42f3-8549-fee9274dbb98)

NewCantus, with these changes:
![Screenshot 2023-06-21 at 3 38 48 PM](https://github.com/DDMAL/CantusDB/assets/58090591/08ef443a-1fe1-48ba-950c-9f2078a1a93f)
