### PR TITLE
Melody Search Page: prevent "null" from being displayed

### DIFF
--- a/django/cantusdb_project/static/js/melody_search.js
+++ b/django/cantusdb_project/static/js/melody_search.js
@@ -221,8 +221,8 @@ function melodySearch() {
                                             <br>
                                             fol. <b>${chant.folio}</b>
                                             <br>
-                                            <b>${chant.genre__name}</b> | Mode: <b>${chant.mode}</b>
-                                    </td>`;
+                                            <b>${chant.genre__name != null ? chant.genre__name : ""}</b> | Mode: <b>${chant.mode != null ? chant.mode : ""}</b>
+                                    </td>`; // ternary operator for chant.genre__name and .mode ensures "null" and "undefined" are never displayed
                 // pb-2 = bottom padding, so that the lower notes in volpiano do not get cut off
                 newRow.innerHTML += `<td style="width:80%">
                                             <a href="${chant.chant_link}" target="_blank"><b>${chant.incipit}</b></a>


### PR DESCRIPTION
fixes #482

previously:
![Screen Shot 2022-12-16 at 1 42 41 PM](https://user-images.githubusercontent.com/58090591/208167453-425ee7fd-bba3-408b-9ffc-80da28331fc0.png)

with these changes:
![Screenshot 2023-06-22 at 2 12 14 PM](https://github.com/DDMAL/CantusDB/assets/58090591/d034c12f-702c-453b-a693-f01f4a540376)

Will require a `collectstatic` to come into effect once merged