### PR TITLE
Prevent Chant List page from being accessed for sources in the Bower segment

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -175,7 +175,10 @@
                         </select>
 
                         <br>
-                        <a href="{% url "chant-list" %}?source={{ source.id }}" class="guillemet" target="_blank">View all chants</a>
+                        {% if source.segment.id == 4063 %}
+                            {# only display this link for sources in the CANTUS segment #}
+                            <a href="{% url "chant-list" %}?source={{ source.id }}" class="guillemet" target="_blank">View all chants</a>
+                        {% endif %}
                         <a href="{% url "chant-index" %}?source={{ source.id }}" class="guillemet" target="_blank">View full inventory</a>
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
                         <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -263,11 +263,14 @@ def make_fake_rism_siglum() -> RismSiglum:
     return rism_siglum
 
 
-def make_fake_segment(name=None) -> Segment:
+def make_fake_segment(name: str = None, id: int = None) -> Segment:
     """Generates a fake Segment object."""
-    if not name:
-        name = faker.sentence()
-    segment = Segment.objects.create(name=name)
+    if name is None:
+        name = faker.sentence(nb_words=2)
+    if id is None:
+        segment = Segment.objects.create(name=name)
+        return segment
+    segment = Segment.objects.create(name=name, id=id)
     return segment
 
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -435,6 +435,19 @@ class ChantListViewTest(TestCase):
         )
         self.assertEqual(response_2.status_code, 403)
 
+    def test_visibility_by_segment(self):
+        cantus_segment = make_fake_segment(id=4063)
+        cantus_source = make_fake_source(segment=cantus_segment, published=True)
+        response_1 = self.client.get(
+            reverse("chant-list"), {"source": cantus_source.id}
+        )
+        self.assertEqual(response_1.status_code, 200)
+
+        bower_segment = make_fake_segment(id=4064)
+        bower_source = make_fake_source(segment=bower_segment, published=True)
+        response_1 = self.client.get(reverse("chant-list"), {"source": bower_source.id})
+        self.assertEqual(response_1.status_code, 404)
+
     def test_filter_by_source(self):
         cantus_segment = make_fake_segment(id=4063)
         source = make_fake_source(segment=cantus_segment)

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3352,6 +3352,28 @@ class SourceDetailViewTest(TestCase):
         response_2 = self.client.get(reverse("source-detail", args=[source.id]))
         self.assertEqual(response_2.status_code, 200)
 
+    def test_chant_list_link(self):
+        chant_list_link = reverse("chant-list")
+
+        cantus_segment = make_fake_segment(id=4063)
+        cantus_source = make_fake_source(segment=cantus_segment)
+        cantus_chant_list_link = chant_list_link + f"?source={cantus_source.id}"
+
+        cantus_source_response = self.client.get(
+            reverse("source-detail", args=[cantus_source.id])
+        )
+        cantus_source_html = str(cantus_source_response.content)
+        self.assertIn(cantus_chant_list_link, cantus_source_html)
+
+        bower_segment = make_fake_segment(id=4064)
+        bower_source = make_fake_source(segment=bower_segment)
+        bower_chant_list_link = chant_list_link + f"?source={bower_source.id}"
+        bower_source_response = self.client.get(
+            reverse("source-detail", args=[bower_source.id])
+        )
+        bower_source_html = str(bower_source_response.content)
+        self.assertNotIn(bower_chant_list_link, bower_source_html)
+
 
 class JsonMelodyExportTest(TestCase):
     def test_json_melody_response(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -413,28 +413,32 @@ class CenturyDetailViewTest(TestCase):
 
 class ChantListViewTest(TestCase):
     def test_url_and_templates(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         response = self.client.get(reverse("chant-list"), {"source": source.id})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "base.html")
         self.assertTemplateUsed(response, "chant_list.html")
 
     def test_published_vs_unpublished(self):
-        published_source = make_fake_source(published=True)
+        cantus_segment = make_fake_segment(id=4063)
+
+        published_source = make_fake_source(segment=cantus_segment, published=True)
         response_1 = self.client.get(
             reverse("chant-list"), {"source": published_source.id}
         )
         self.assertEqual(response_1.status_code, 200)
 
-        unpublished_source = make_fake_source(published=False)
+        unpublished_source = make_fake_source(segment=cantus_segment, published=False)
         response_2 = self.client.get(
             reverse("chant-list"), {"source": unpublished_source.id}
         )
         self.assertEqual(response_2.status_code, 403)
 
     def test_filter_by_source(self):
-        source = make_fake_source()
-        another_source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
+        another_source = make_fake_source(segment=cantus_segment)
         chant_in_source = Chant.objects.create(source=source)
         chant_in_another_source = Chant.objects.create(source=another_source)
         response = self.client.get(reverse("chant-list"), {"source": source.id})
@@ -443,7 +447,8 @@ class ChantListViewTest(TestCase):
         self.assertNotIn(chant_in_another_source, chants)
 
     def test_filter_by_feast(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         feast = make_fake_feast()
         another_feast = make_fake_feast()
         chant_in_feast = Chant.objects.create(source=source, feast=feast)
@@ -458,7 +463,8 @@ class ChantListViewTest(TestCase):
         self.assertNotIn(chant_in_another_feast, chants)
 
     def test_filter_by_genre(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         genre = make_fake_genre()
         another_genre = make_fake_genre()
         chant_in_genre = Chant.objects.create(source=source, genre=genre)
@@ -473,7 +479,8 @@ class ChantListViewTest(TestCase):
         self.assertNotIn(chant_in_another_genre, chants)
 
     def test_filter_by_folio(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         chant_on_folio = Chant.objects.create(source=source, folio="001r")
         chant_on_another_folio = Chant.objects.create(source=source, folio="002r")
         response = self.client.get(
@@ -484,7 +491,8 @@ class ChantListViewTest(TestCase):
         self.assertNotIn(chant_on_another_folio, chants)
 
     def test_search_full_text(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         chant = Chant.objects.create(
             source=source, manuscript_full_text=faker.sentence()
         )
@@ -495,7 +503,8 @@ class ChantListViewTest(TestCase):
         self.assertIn(chant, response.context["chants"])
 
     def test_search_incipit(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         chant = Chant.objects.create(
             source=source,
             incipit=faker.sentence(),
@@ -507,7 +516,8 @@ class ChantListViewTest(TestCase):
         self.assertIn(chant, response.context["chants"])
 
     def test_search_full_text_std_spelling(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         chant = Chant.objects.create(
             source=source,
             manuscript_full_text_std_spelling=faker.sentence(),
@@ -519,28 +529,28 @@ class ChantListViewTest(TestCase):
         self.assertIn(chant, response.context["chants"])
 
     def test_context_source(self):
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         response = self.client.get(reverse("chant-list"), {"source": source.id})
         self.assertEqual(source, response.context["source"])
 
     def test_context_folios(self):
-        # create a source and several chants in it
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         Chant.objects.create(source=source, folio="001r")
         Chant.objects.create(source=source, folio="001r")
         Chant.objects.create(source=source, folio="001v")
         Chant.objects.create(source=source, folio="001v")
         Chant.objects.create(source=source, folio="002r")
         Chant.objects.create(source=source, folio="002v")
-        # request the page
         response = self.client.get(reverse("chant-list"), {"source": source.id})
         # the element in "folios" should be unique and ordered in this way
         folios = response.context["folios"]
         self.assertEqual(list(folios), ["001r", "001v", "002r", "002v"])
 
     def test_context_feasts_with_folios(self):
-        # create a source and several chants (associated with feasts) in it
-        source = make_fake_source()
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
         feast_1 = make_fake_feast()
         feast_2 = make_fake_feast()
         Chant.objects.create(source=source, folio="001r", feast=feast_1)
@@ -549,7 +559,6 @@ class ChantListViewTest(TestCase):
         Chant.objects.create(source=source, folio="001v")
         Chant.objects.create(source=source, folio="001v", feast=feast_2)
         Chant.objects.create(source=source, folio="002r", feast=feast_1)
-        # request the page
         response = self.client.get(reverse("chant-list"), {"source": source.id})
         # context "feasts_with_folios" is a list of tuples
         # it records the folios where the feast changes

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -588,13 +588,23 @@ class ChantListView(ListView):
         # these are needed in the selectors on the left side of the page
         context["feasts"] = Feast.objects.all().order_by("name")
         context["genres"] = Genre.objects.all().order_by("name")
+
         # sources in the Bower Segment contain only Sequences and no Chants,
         # so they should not appear among the list of sources
-        bower_segment = Segment.objects.get(id=4063)
-        context["sources"] = bower_segment.source_set.order_by("siglum")
+        cantus_segment = Segment.objects.get(id=4063)
+        sources = cantus_segment.source_set.order_by(
+            "siglum"
+        )  # to be displayed in the "Source" dropdown in the form
+        context["sources"] = sources
 
         source_id = self.request.GET.get("source")
         source = Source.objects.get(id=source_id)
+        if source not in sources:
+            # the chant list ("Browse Chants") page should only be visitable
+            # for sources in the CANTUS Database segment, as sources in the Bower
+            # segment contain no chants
+            raise Http404()
+
         context["source"] = source
 
         user = self.request.user

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -23,7 +23,7 @@ from main_app.forms import (
     ChantProofreadForm,
     ChantEditSyllabificationForm,
 )
-from main_app.models import Chant, Feast, Genre, Source, Sequence
+from main_app.models import Chant, Feast, Genre, Source, Sequence, Segment
 from align_text_mel import syllabize_text_and_melody, syllabize_text_to_string
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404
@@ -586,9 +586,12 @@ class ChantListView(ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # these are needed in the selectors on the left side of the page
-        context["sources"] = Source.objects.order_by("siglum")
         context["feasts"] = Feast.objects.all().order_by("name")
         context["genres"] = Genre.objects.all().order_by("name")
+        # sources in the Bower Segment contain only Sequences and no Chants,
+        # so they should not appear among the list of sources
+        bower_segment = Segment.objects.get(id=4063)
+        context["sources"] = bower_segment.source_set.order_by("siglum")
 
         source_id = self.request.GET.get("source")
         source = Source.objects.get(id=source_id)


### PR DESCRIPTION
fixes #458

This PR:
- ensures that, on the Chant List (i.e. "Browse Chants") page, only sources from the Cantus segment appear in the dropdown
- ensures that the Chant List page can only be accessed for sources in the Cantus segment (it now raises a 404 for sources not in the segment)
- hides, on the Source Detail page for sources not in the Cantus segment, the link to the Chant List page.
- updates tests that were broken by this change, ensuring all sources created during the tests belong to the right segment
- adds a test for the Chant List page to ensure it is accessible (200 http status code) for sources in the Cantus Segment and inaccessible (404) for sources in the Bower segment.
- adds a test for the Source Detail page to ensure that the link to the Chant List page is present when it should be and hidden when it shouldn't