### PR TITLE
Chant List page: ensure search_bar search behaves the same as keyword+starts_with

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -750,8 +750,12 @@ class ChantSearchView(ListView):
         display_unpublished = self.request.user.is_authenticated
         # if the search is accessed by the global search bar
         if self.request.GET.get("search_bar"):
-            chant_set = Chant.objects.filter(source__published=True)
-            sequence_set = Sequence.objects.filter(source__published=True)
+            if display_unpublished:
+                chant_set = Chant.objects.all()
+                sequence_set = Sequence.objects.all()
+            else:
+                chant_set = Chant.objects.filter(source__published=True)
+                sequence_set = Sequence.objects.filter(source__published=True)
             if self.request.GET.get("search_bar").replace(" ", "").isalpha():
                 # if search bar is doing incipit search
                 incipit = self.request.GET.get("search_bar")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -758,13 +758,21 @@ class ChantSearchView(ListView):
                 sequence_set = Sequence.objects.filter(source__published=True)
             if self.request.GET.get("search_bar").replace(" ", "").isalpha():
                 # if search bar is doing incipit search
-                incipit = self.request.GET.get("search_bar")
-                chant_set = chant_set.filter(
-                    manuscript_full_text_std_spelling__istartswith=incipit
-                ).values(*CHANT_SEARCH_TEMPLATE_VALUES)
-                sequence_set = sequence_set.filter(
-                    manuscript_full_text_std_spelling__istartswith=incipit
-                ).values(*CHANT_SEARCH_TEMPLATE_VALUES)
+                search_term = self.request.GET.get("search_bar")
+                ms_spelling_filter = Q(manuscript_full_text__istartswith=search_term)
+                std_spelling_filter = Q(
+                    manuscript_full_text_std_spelling__istartswith=search_term
+                )
+                incipit_filter = Q(incipit__istartswith=search_term)
+                search_term_filter = (
+                    ms_spelling_filter | std_spelling_filter | incipit_filter
+                )
+                chant_set = chant_set.filter(search_term_filter).values(
+                    *CHANT_SEARCH_TEMPLATE_VALUES
+                )
+                sequence_set = sequence_set.filter(search_term_filter).values(
+                    *CHANT_SEARCH_TEMPLATE_VALUES
+                )
                 queryset = chant_set.union(sequence_set, all=True)
             else:
                 # if search bar is doing Cantus ID search


### PR DESCRIPTION
fixes #516

This PR:
- fixes a bug while conducting a search_bar search, where chants from unpublished sources were not being displayed, whether or not the user is logged in (now they're displayed IFF the user is logged in)
- fixes a bug while conducting a search_bar search, where we would only search the standard_spelling fulltext field, rather than all the full text fields.

In sum, now search_bar searches work the same as keyword+starts_with searches.