### PR TITLE
On homepage, in My Sources card, use source.siglum instead of .rism_siglum

### DIFF
--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -45,7 +45,7 @@ def my_sources(user):
 
     def make_source_detail_link_with_siglum(source):
         id = source.id
-        siglum = source.rism_siglum
+        siglum = source.siglum
         url = reverse("source-detail", args=[id])
         link = '<a href="{}">{}</a>'.format(url, siglum)
         return link


### PR DESCRIPTION
goes part of the way toward fi\xing #438