### PR TITLE
Add "What's New" sidebar to Article pages

### DIFF
--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -1,24 +1,40 @@
 {% extends "base.html" %}
+{% load helper_tags %} {# for recent_articles #}
 {% block content %}
-<title>{{ article.title }} | Cantus Manuscript Database</title>
-<div class="mr-3 p-3 col-md-12 bg-white rounded">
-    <object align="right" class="search-bar">
-        {% include "global_search_bar.html" %}
-    </object>
-    <h3>
-        {{ article.title }}
-    </h3>
+<div class="container">
+    <title>{{ article.title }} | Cantus Manuscript Database</title>
     <div class="row">
-        <div class="col">
-            <div class="container">
-                <div class="container text-wrap">
-                    <small>Submitted by <a href="{% url 'user-detail' article.author.id %}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
-                    <div style="padding-top: 1em;">
-                        {{ article.body.html|safe }}
+        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+            <h3>
+                {{ article.title }}
+            </h3>
+            <div class="row">
+                <div class="col">
+                    <div class="container">
+                        <div class="container text-wrap">
+                            <small>Submitted by <a href="{% url 'user-detail' article.author.id %}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
+                            <div style="padding-top: 1em;">
+                                {{ article.body.html|safe }}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
+            <div class="card mt-3 w-100">
+                <div class="card-header">
+                    What's New
+                </div>
+                <div class="card-body">
+                    {% recent_articles %}
+                </div>
+            </div>
+        </div>
     </div>
+
 </div>
 {% endblock %}

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -1,27 +1,43 @@
 {% extends "base.html" %}
+{% load helper_tags %} {# for recent_articles #}
 {% block content %}
-<title>What's New | Cantus Manuscript Database</title>
-<div class="mr-3 p-3 col-md-10 mx-auto bg-white rounded">
-    <object align="right" class="search-bar">
-        {% include "global_search_bar.html" %}
-    </object>
-    <h3>What's New</h3>
-    {% for article in articles %}
+<div class="container">
+    <title>What's New | Cantus Manuscript Database</title>
     <div class="row">
-        <div class="col">
-            <small>{{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
-            <h4>
-                <a href="{% url 'article-detail' article.id %}">{{ article.title }}</a>
-            </h4>
-            <div class="container">
-                <small>
-                {{ article.body.html|safe|truncatechars_html:3000 }}
-                </small>
+        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+            <h3>What's New</h3>
+            {% for article in articles %}
+            <div class="row">
+                <div class="col">
+                    <small>{{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
+                    <h4>
+                        <a href="{% url 'article-detail' article.id %}">{{ article.title }}</a>
+                    </h4>
+                    <div class="container">
+                        <small>
+                        {{ article.body.html|safe|truncatechars_html:3000 }}
+                        </small>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+            {% include "pagination.html" %}
+            <br>
+        </div>
+        <div class="col p-0 sidebar">
+            <div class="search-bar">
+                {% include "global_search_bar.html" %}
+            </div>
+
+            <div class="card mt-3 w-100">
+                <div class="card-header">
+                    What's New
+                </div>
+                <div class="card-body">
+                    {% recent_articles %}
+                </div>
             </div>
         </div>
     </div>
-    {% endfor %}
-    {% include "pagination.html" %}
-    <br>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR fixes #444, taking the "Recent News" sidebar seen by anonymous users on the homepage and adding it to the Article Detail page (as it is on OldCantus), as well as to the Article List page (OldCantus doesn't feature it here, but it makes the page look neater imo).

While this issue is not particularly functionally important, it's the kind of thing people will probably look at and comment on when they first look at NewCantus.

As I wanted to maintain the same formatting as on the homepage, I recreated the code from the flatpages template, (including the same janky `<title>` tags within a div - we should get around to fixing this eventually).

Article Detail page - OldCantus:
![Screenshot 2023-06-26 at 10 29 05 AM](https://github.com/DDMAL/CantusDB/assets/58090591/fb716433-038c-499c-a111-d4de99a0dd6f)

Article Detail page - NewCantus, previously:
![Screenshot 2023-06-26 at 10 30 06 AM](https://github.com/DDMAL/CantusDB/assets/58090591/0a6fce9f-eab1-48f8-8401-7f8c60d7ddbf)

Article Detail page - NewCantus, updated:
![Screenshot 2023-06-26 at 10 31 21 AM](https://github.com/DDMAL/CantusDB/assets/58090591/4eb46f37-c463-45b7-9a53-c9d0a30bef45)

Article List page - NewCantus, previously:
![Screenshot 2023-06-26 at 10 31 53 AM](https://github.com/DDMAL/CantusDB/assets/58090591/b73fb20c-3884-4979-94c5-90e9b4911a14)

Article List page - NewCantus, updated:
![Screenshot 2023-06-26 at 10 32 16 AM](https://github.com/DDMAL/CantusDB/assets/58090591/f3c33776-9367-4d00-8a1c-9bb192e5df7e)