### PR TITLE
Search Bar: ensure chantsDiv is not displayed when user backspaces to empty search bar

### DIFF
--- a/django/cantusdb_project/static/js/search_bar.js
+++ b/django/cantusdb_project/static/js/search_bar.js
@@ -14,14 +14,14 @@ function globalSearch() {
     var lastXhttp = new XMLHttpRequest();
 
     function loadChants() {
+        // whenever a new search begins, abort the previous one, so that it does not update the result table with wrong data
+        lastXhttp.abort()
         const searchTerm = searchBar.value;
         // if the search bar is empty, clear the target area and don't proceed to search
         if (searchTerm == "") {
             chantsDiv.innerHTML = "";
             return;
         }
-        // whenever a new search begins, abort the previous one, so that it does not update the result table with wrong data
-        lastXhttp.abort()
 
         const xhttp = new XMLHttpRequest();
         // construct the ajax url with the search term


### PR DESCRIPTION
fixes #790.

Previously, whenever the text in the search bar would change, we would abort the previous xhttp request, _except_ when the search bar was empty, in which case we would set the div where the search results are displayed to be an empty string and then return before aborting. The result, when using the search bar over a slow-ish internet connection, often meant the second last request finished running after the last request finished, creating a search bar that couldn't be gotten rid of.

This PR fixes this bug by moving the abort command to the top of the function. Thanks, @jackyyzhang03, for the help debugging this!