### PR TITLE
Add default=timezone.now to Article model

### DIFF
--- a/django/cantusdb_project/articles/models.py
+++ b/django/cantusdb_project/articles/models.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from django.db import models
 from django.urls import reverse
 from django_quill.fields import QuillField
+from django.utils import timezone
 
 
 class Article(models.Model):
@@ -13,6 +14,7 @@ class Article(models.Model):
     )
     date_created = models.DateTimeField(
         help_text="The date this article was created",
+        default=timezone.now,
         null=True,
         blank=True,
     )


### PR DESCRIPTION
This PR adds a default to our Article model's date_created field. In doing so, it fixes #793 (now that our article pages include a list of articles in the sidebar, we would get an error since we hadn't set the article's date_created and we were trying to format it).