### PR TITLE
Update sync scripts to automatically create dummy objects

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -321,6 +321,40 @@ def remove_extra():
         print(f"Extra item removed: {id}")
 
 
+def make_dummy_chant() -> None:
+    """
+    creates a dummy chant with an ID of 1_000_000. This ensures that all new chants
+    created in NewCantus have IDs greater than 1_000_000. This, in turn, ensures that
+    requests to /node/<id> URLS can be redirected to their proper chant/source/article
+    detail page (all objects originally created in OldCantus have unique IDs, so there
+    is no ambiguity as to which page a /node/ URL should lead.)
+    """
+    try:
+        Chant.objects.get(id=1_000_000)
+        print(
+            "Tried to create a dummy chant with id=1000000. "
+            "A chant with id=1000000 already exists. "
+            "Aborting attempt to create a new dummy chant."
+        )
+        return
+    except Source.DoesNotExist:
+        pass
+
+    dummy_source = Source.objects.get(id=1_000_000, published=False)
+    dummy_chant = Chant.objects.create(
+        source=dummy_source,
+        manuscript_full_text_std_spelling=(
+            "This unpublished dummy chant exists in order that all newly created "
+            "chants have IDs greater than 1,000,000 (which ensures that requests "
+            "made to /node/<id> URLs can be redirected to their proper "
+            "chant/sequence/article detail page). Once a chant with an ID greater than "
+            "1,000,000 has been created, this dummy chant may be safely deleted."
+        ),
+    )
+    dummy_chant.update(id=1_000_000)
+    return dummy_chant
+
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
@@ -341,6 +375,7 @@ class Command(BaseCommand):
             all_chants = get_chant_list(CHANT_ID_FILE)
             for chant_id in all_chants:
                 get_new_chant(chant_id)
+            make_dummy_chant()
         else:
             get_new_chant(id)
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -198,6 +198,40 @@ def remove_extra():
         print(f"Extra item removed: {id}")
 
 
+def make_dummy_sequence() -> None:
+    """
+    creates a dummy seqence with an ID of 1_000_000. This ensures that all new sequences
+    created in NewCantus have IDs greater than 1_000_000. This, in turn, ensures that
+    requests to /node/<id> URLS can be redirected to their proper chant/source/article
+    detail page (all objects originally created in OldCantus have unique IDs, so there
+    is no ambiguity as to which page a /node/ URL should lead.)
+    """
+    try:
+        Sequence.objects.get(id=1_000_000)
+        print(
+            "Tried to create a dummy sequence with id=1000000. "
+            "A sequence with id=1000000 already exists. "
+            "Aborting attempt to create a new dummy sequence."
+        )
+        return
+    except Source.DoesNotExist:
+        pass
+
+    dummy_source = Source.objects.get(id=1_000_000, published=False)
+    dummy_sequence = Sequence.objects.create(
+        source=dummy_source,
+        manuscript_full_text_std_spelling=(
+            "This unpublished dummy sequence exists in order that all newly created "
+            "sequences have IDs greater than 1,000,000 (which ensures that requests "
+            "made to /node/<id> URLs can be redirected to their proper "
+            "chant/sequence/article detail page). Once a sequence with an ID greater than "
+            "1,000,000 has been created, this dummy sequence may be safely deleted."
+        ),
+    )
+    dummy_sequence.update(id=1_000_000)
+    return dummy_sequence
+
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
@@ -219,6 +253,7 @@ class Command(BaseCommand):
             for i, seq_id in enumerate(all_seqs):
                 # print(seq_id)
                 get_new_sequence(seq_id)
+            make_dummy_sequence()
         else:
             get_new_sequence(id)
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sources.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sources.py
@@ -341,6 +341,43 @@ def remove_extra_sources():
         print(f"Extra source removed: {source}")
 
 
+def make_dummy_source() -> None:
+    """
+    creates a dummy source with an ID of 1_000_000. This ensures that all new sources
+    created in NewCantus have IDs greater than 1_000_000. This, in turn, ensures that
+    requests to /node/<id> URLS can be redirected to their proper chant/source/article
+    detail page (all objects originally created in OldCantus have unique IDs, so there
+    is no ambiguity as to which page a /node/ URL should lead.)
+    """
+    try:
+        Source.objects.get(id=1_000_000)
+        print(
+            "Tried to create a dummy source with id=1000000. "
+            "A source with id=1000000 already exists. "
+            "Aborting attempt to create a new dummy source."
+        )
+        return
+    except Source.DoesNotExist:
+        pass
+
+    cantus_segment = Segment.objects.get(id=4063)
+    dummy_source = Source.objects.create(
+        segment=cantus_segment,
+        siglum="DUMMY",
+        published=False,
+        title="Unpublished Dummy Source",
+        description=(
+            "This unpublished dummy source exists in order that all newly created "
+            "sources have IDs greater than 1,000,000 (which ensures that requests "
+            "made to /node/<id> URLs can be redirected to their proper "
+            "chant/source/article detail page). Once a source with an ID greater than "
+            "1,000,000 has been created, this dummy source may be safely deleted."
+        ),
+    )
+    dummy_source.update(id=1_000_000)
+    return dummy_source
+
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
@@ -362,6 +399,7 @@ class Command(BaseCommand):
             for source_id in all_sources:
                 print(source_id)
                 source = get_new_source(source_id)
+            make_dummy_source()
         else:
             new_source = get_new_source(id)
             print(new_source.title)


### PR DESCRIPTION
This way, the dummy objects are automatically created when we run the data sync; we don't need to worry about creating them (with one exception - we'll have to renumber the first new article to 1000000).

@dchiller, you're welcome to look this over, but I've requested only Lucas's review because he's worked with these scripts recently.