### PR TITLE
Display source status to logged in users

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -82,6 +82,11 @@
                     <dd>{{ source.full_source|yesno:"Full Source,Fragment" }}</dd>
                 {% endif %}
 
+                {% if user.is_authenticated %}
+                    <dt>Source Status</dt>
+                    <dd>{{ source.published|yesno:"Published,Unpublished" }}</dd>
+                {% endif %}
+                
                 {% if source.fragmentarium_id is not None %}
                     <dt>Fragment ID</dt>
                     <dd>{{ source.fragmentarium_id }}</dd>


### PR DESCRIPTION
In OldCantus, the old system of indexing process/proofread pending/etc was displayed on the source detail page. In NewCantus, the publishing status has been changed to a binary variable to denote published/unpublished sources. We can display this information to logged in users on the source detail page because currently there is no distinction between these types.

Source status showed to a logged in user on an unpublished source:
![Screenshot 2023-07-06 at 2 55 16 PM](https://github.com/DDMAL/CantusDB/assets/71031342/6f7eedf9-d00d-4080-8f58-570f7214c562)

Resolves #806 
