### PR TITLE
Source Edit: fix source navigation links and feast/folio dropdown selector

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <title>{{ source.title }} | Cantus Manuscript Database</title>
+<script src="/static/js/source_detail.js"></script>
 
 <div class="container">
     <div class="row">
@@ -193,30 +194,33 @@
                 <div class="card-body">
                     <small>
                         <!--a small selector of all folios of this source-->
-                        <select id="folioSelect" class="w-30">
+                        <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
                             <option value="">Select a folio:</option>
                             {% for folio in folios %}
                                 <option value="{{ folio }}">{{ folio }}</option>
                             {% endfor %}
-                        </select>             
-                        
-                        {% if previous_folio %}
-                            <a href="{% url "source-edit-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
-                        {% endif %}
-                        {% if next_folio %}
-                            &nbsp;<a href="{% url "source-edit-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
-                        {% endif %}             
+                        </select>                              
 
-                        <br>
-
-                        <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                        <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
                             {% for folio, feast in feasts_with_folios %}
                                 <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
                             {% endfor %}
-                        </select>
+                        </select>          
 
                         <br>
+                        {% if source.segment.id == 4063 %}
+                            {# only display this link for sources in the CANTUS segment #}
+                            <a href="{% url "chant-list" %}?source={{ source.id }}" class="guillemet" target="_blank">View all chants</a>
+                        {% endif %}
+                        <a href="{% url "chant-index" %}?source={{ source.id }}" class="guillemet" target="_blank">View full inventory</a>
+                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
+                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
+                        {% if source.image_link %}
+                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>
+                        {% endif %}
+                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
+                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
 
                     </small>
                     {% if chants.all %}

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -211,7 +211,9 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         return HttpResponseRedirect(self.get_success_url())
 
 
-class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+class SourceEditView(
+    LoginRequiredMixin, UserPassesTestMixin, UpdateView, SourceDetailView
+):
     template_name = "source_edit.html"
     model = Source
     form_class = SourceEditForm


### PR DESCRIPTION
Previously, the feast and folio drop-down options were functioning correctly on the source detail page but not on the source edit page. Additionally, the source navigation links available on the source detail page were missing from the source edit page. To resolve these issues, the same logic from the source detail page was implemented to ensure consistent functionality on the source edit page as well.

![Screenshot 2023-07-06 at 3 37 59 PM](https://github.com/DDMAL/CantusDB/assets/71031342/86956a79-ab5b-4197-8851-b178c74f1948)


Fixes #483, Fixes #781 