### PR TITLE
Sync "created_by" information from OldCantus

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -76,6 +76,12 @@ def get_new_chant(chant_id):
         return
 
     try:
+        author_id = json_response["uid"]
+        author = get_user_model().objects.get(id=author_id)
+    except (KeyError, TypeError, ObjectDoesNotExist):
+        author = None
+
+    try:
         incipit = json_response["title"]
     except KeyError:
         incipit = None
@@ -268,6 +274,7 @@ def get_new_chant(chant_id):
     chant_obj, created = Chant.objects.update_or_create(
         id=chant_id,
         defaults={
+            "created_by": author,
             "incipit": incipit,
             "visible_status": status,
             "source": source,

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import URLValidator
 import requests, json
+from django.contrib.auth import get_user_model
 
 SEQUENCE_ID_FILE = "sequence_list.txt"
 USER_AGENTS = [
@@ -48,6 +49,12 @@ def get_new_sequence(seq_id):
             error_file.write(f"sequence {seq_id} json not found")
             error_file.write("\n")
         return
+
+    try:
+        author_id = json_response["uid"]
+        author = get_user_model().objects.get(id=author_id)
+    except (KeyError, TypeError, ObjectDoesNotExist):
+        author = None
 
     try:
         title = json_response["title"]
@@ -161,6 +168,7 @@ def get_new_sequence(seq_id):
         id=seq_id,
         defaults={
             "visible_status": status,
+            "created_by": author,
             "title": title,
             "siglum": siglum,
             "incipit": incipit,

--- a/django/cantusdb_project/main_app/management/commands/sync_sources.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sources.py
@@ -51,6 +51,12 @@ def get_new_source(source_id):
     title = json_response["title"]
 
     try:
+        author_id = json_response["uid"]
+        author = get_user_model().objects.get(id=author_id)
+    except (KeyError, TypeError, ObjectDoesNotExist):
+        author = None
+
+    try:
         siglum = json_response["field_siglum"]["und"][0]["value"]
     except (KeyError, TypeError):
         siglum = None
@@ -287,6 +293,7 @@ def get_new_source(source_id):
         id=source_id,
         defaults={
             "title": title,
+            "created_by": author,
             "published": published,
             "siglum": siglum,
             "rism_siglum": rism_siglum,


### PR DESCRIPTION
The sync scripts (sync_sources, sync_chants, and sync_sequences) are updated to access the "uid" entry from the json-node API from OldCantus, which corresponds to the user who has created the specific object. Once we get an updated list of ID's for Sources, Chants, and Sequences and run the synchronization scripts, the data on NewCantus will have the "created_by" information that was previously missing.

Resolves #237 

Note #642 is directly related to #237, but we should probably leave the issue open until we decide to do the data migration from OldCantus. 