### PR TITLE
chant_search: check for URL parameters before displaying "no chants found"

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -278,8 +278,10 @@
         </small>
 
         {% include "pagination.html" %}
-    {% else %}
-        No chants found.
+    {% else %} 
+        {% if request.GET %}
+            No chants found.
+        {% endif %}
     {% endif %}
 </div>
         


### PR DESCRIPTION
Fixes #826 