### PR TITLE
Fix comment in `views.json_cid_export`

### DIFF
--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -586,11 +586,15 @@ def json_cid_export(request, cantus_id: str) -> JsonResponse:
     Cantus ID, in the following format:
     {
         "chants": [
-            "chant": {
-                a bunch of keys, created in build_json_cid_dictionary
+            {
+                "chant": {
+                    a bunch of keys and values, created in build_json_cid_dictionary
+                },
             },
-            "chant": {
-                etc.
+            {
+                "chant": {
+                    etc.
+                },
             },
         ]
     }


### PR DESCRIPTION
The structure of the json-cid API's response is complicated! While documenting it in the wiki, I realized that I had messed up the comment in the function. This PR corrects this error.