### PR TITLE
Optimize templates to use `.exists` instead of `.all` within `if` tags

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -499,14 +499,14 @@
                                     <br>
                                 {% endif %}
 
-                                {% if source.notation.all %}
+                                {% if source.notation.exists %}
                                     <b>
                                         <a href="{% url 'notation-detail' source.notation.all.first.id %}">{{ source.notation.all.first.name }}</a>
                                     </b>
                                     <br>
                                 {% endif %}
 
-                                {% if source.inventoried_by.all %}
+                                {% if source.inventoried_by.exists %}
                                     Inventoried by:
                                     <ul>
                                         {% for editor in source.inventoried_by.all %}
@@ -519,7 +519,7 @@
                                     </ul>
                                 {% endif %}
 
-                                {% if source.proofreaders.all %}
+                                {% if source.proofreaders.exists %}
                                     Proofreader{{ source.proofreaders.all|pluralize }}:
                                     <br>
                                     <ul>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -90,7 +90,7 @@
         
     </form>
 
-    {% if chants.all %}
+    {% if chants.exists %}
         <small>
             <table class="table table-responsive table-sm small table-bordered">
                 <thead>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -45,7 +45,7 @@
                     <dd>{{ source.indexing_notes|safe }}</dd>
                 {% endif %}
 
-                {% if source.other_editors.all %}
+                {% if source.other_editors.exists %}
                     <dt>Other Editors</dt>
                     <dd>
                         {% for editor in source.other_editors.all %}
@@ -54,7 +54,7 @@
                     </dd>
                 {% endif %}
 
-                {% if source.full_text_entered_by.all %}
+                {% if source.full_text_entered_by.exists %}
                     <dt>Full Text Entered by</dt>
                     <dd>
                         {% for editor in source.full_text_entered_by.all %}
@@ -63,7 +63,7 @@
                     </dd>
                 {% endif %}
 
-                {% if source.melodies_entered_by.all %}
+                {% if source.melodies_entered_by.exists %}
                     <dt>Melodies Entered by</dt>
                     <dd>
                         {% for editor in source.melodies_entered_by.all %}
@@ -225,13 +225,13 @@
                             Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
                             <br>
                         {% endif %}
-                        {% if source.notation.all %}
+                        {% if source.notation.exists %}
                             Notation: <b><a href="{% url 'notation-detail' source.notation.all.first.id %}">
                                 {{ source.notation.all.first.name }}
                             </a></b>
                             <br>
                         {% endif %}
-                        {% if source.inventoried_by.all %}
+                        {% if source.inventoried_by.exists %}
                             Inventoried by:
                             <ul>
                                 {% for editor in source.inventoried_by.all %}
@@ -242,7 +242,7 @@
                                 {% endfor %}
                             </ul>
                         {% endif %}
-                        {% if source.proofreaders.all %}
+                        {% if source.proofreaders.exists %}
                             Proofreader{{ source.proofreaders.all|pluralize }}:
                             <br>
                             <ul>
@@ -272,7 +272,7 @@
                                 <li>
                                     <a href="{% url "chant-create" source.id%}">Add new chant</a>
                                 </li>
-                                {% if source.chant_set.all %}
+                                {% if source.chant_set.exists %}
                                     <li>
                                         <a href="{% url "source-edit-chants" source.pk %}">
                                             Full text &amp; volpiano editor

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -223,7 +223,7 @@
                         <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
 
                     </small>
-                    {% if chants.all %}
+                    {% if chants.exists %}
                         <table class="table table-sm small table-bordered">
                             <tbody>
                                 {% for chant in chants %}

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -87,7 +87,7 @@
                             {{ source.summary|default:""|truncatechars_html:140 }}
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            {% if source.century.all %}
+                            {% if source.century.exists %}
                                 <b><a href="{% url 'century-detail' source.century.first.id %}">{{ source.century.first.name }}</a></b><br>
                             {% endif %}
                             {% if source.provenance %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -420,6 +420,7 @@ class ChantDetailView(DetailView):
                     f"https://gregorien.info/chant/cid/{chant.cantus_id}/en:",
                     exc,
                 )
+                gregorien_response = None
 
             if gregorien_response and gregorien_response.status_code == 200:
                 gregorien_database_dict: dict = {


### PR DESCRIPTION
This PR goes through all the templates, and substitutes `.exists` for `.all` wherever it was found in an `if` tag. It was prompted by #813, when I was looking into why the source detail page might be taking so long to load. Testing locally, the Source Detail page spends about half as long sending SQL requests with this change, compared to how it was previously.

Timing results on other pages are inconsistent: Request times are decreased significantly on certain pages, while they increase or decrease request by a handful of milliseconds on some pages that already load quickly. We know that Staging and Production have different limitations than local machines, so since there's a good theoretical reason to use `.exists` in place of `.all`, and it improves the clarity of the code in the templates, I think this change is a good one in spite of the variability observed while testing.

It also fixes a discovered bug on the Chant Detail page, where if a request to gregorien.info would fail, we'd hit a `NameError` because we forgot to set a variable.