### PR TITLE
signals.py: wrap instance.source in try/except

### DIFF
--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -12,6 +12,7 @@ import re
 from main_app.models import Chant
 from main_app.models import Sequence
 from main_app.models import Feast
+from main_app.models import Source
 
 
 @receiver(post_save, sender=Chant)
@@ -68,7 +69,11 @@ def update_source_chant_count(instance):
     Called in on_chant_save(), on_chant_delete(), on_sequence_save() and on_sequence_delete()
     """
 
-    source = instance.source
+    # When a source is deleted (which in turn calls on_chant_delete() on all of its chants) instance.source does not exist
+    try:
+        source = instance.source
+    except Source.DoesNotExist:
+        source = None
     if source is not None:
         source.number_of_chants = source.chant_set.count() + source.sequence_set.count()
         source.save()
@@ -79,7 +84,12 @@ def update_source_melody_count(instance):
 
     Called in on_chant_save() and on_chant_delete()
     """
-    source = instance.source
+
+    # When a source is deleted (which in turn calls on_chant_delete() on all of its chants) instance.source does not exist
+    try:
+        source = instance.source
+    except Source.DoesNotExist:
+        source = None
     if source is not None:
         source.number_of_melodies = source.chant_set.filter(
             volpiano__isnull=False


### PR DESCRIPTION
Fixes #832 where a source could not be deleted that contains any number of chants greater than zero. This is because we have `models.CASCADE` as the `on_delete` method for the source field of a chant, meaning all chants of a source are deleted when that source is deleted. This triggers the `post_delete` signal for each chant that belongs to the source. In `signals.py`, we update the source chant count and melody count in `post_save` and `post_delete`. On `post_delete`, this will not work because we try to access `instance.source`, but the source no longer exists. 