### PR TITLE
Redirect user to Source Detail page after they create a source

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -6,6 +6,14 @@
 <div class="container">
     <div class="row">
         <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+            <!--Display "submit success" message -->
+            {% if messages %}
+                <div class="alert alert-success alert-dismissible">
+                    {% for message in messages %}
+                        {{ message }}
+                    {% endfor %}
+                </div>
+            {% endif %}
             <h3>{{ source.title }}</h3>
 
             {% if user.is_authenticated %}

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1118,9 +1118,9 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
         return user_can_edit_chants_in_source(user, source)
 
-    # will direct to chant detail page
+    # if success_url and get_success_url not specified, will direct to chant detail page
     def get_success_url(self):
-        return reverse("chant-detail", args=[self.object.id])
+        return reverse("chant-create", args=[self.source.id])
 
     def get_initial(self):
         """Get intial data from the latest chant in source.

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1118,9 +1118,9 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
         return user_can_edit_chants_in_source(user, source)
 
-    # if success_url and get_success_url not specified, will direct to chant detail page
+    # will direct to chant detail page
     def get_success_url(self):
-        return reverse("chant-create", args=[self.source.id])
+        return reverse("chant-detail", args=[self.object.id])
 
     def get_initial(self):
         """Get intial data from the latest chant in source.

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -190,8 +190,8 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         else:
             return False
 
-    def get_success_url(self):
-        return reverse("source-create")
+    def get_success_url(self, source):
+        return reverse("source-detail", args=[source.id])
 
     def form_valid(self, form):
         form.instance.created_by = self.request.user
@@ -208,7 +208,7 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             "Source created successfully!",
         )
 
-        return HttpResponseRedirect(self.get_success_url())
+        return HttpResponseRedirect(self.get_success_url(source))
 
 
 class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -190,25 +190,26 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         else:
             return False
 
-    def get_success_url(self, source):
-        return reverse("source-detail", args=[source.id])
+    def get_success_url(self):
+        return reverse("source-detail", args=[self.object.id])
 
     def form_valid(self, form):
-        form.instance.created_by = self.request.user
-        source = form.save()
+        if form.is_valid():
+            form.instance.created_by = self.request.user
+            self.object = form.save()
 
-        # assign this source to the "current_editors"
-        current_editors = source.current_editors.all()
+            # assign this source to the "current_editors"
+            current_editors = self.object.current_editors.all()
 
-        for editor in current_editors:
-            editor.sources_user_can_edit.add(source)
+            for editor in current_editors:
+                editor.sources_user_can_edit.add(self.object)
 
-        messages.success(
-            self.request,
-            "Source created successfully!",
-        )
-
-        return HttpResponseRedirect(self.get_success_url(source))
+            messages.success(
+                self.request,
+                "Source created successfully!",
+            )
+            return HttpResponseRedirect(self.get_success_url())
+        return super().form_valid(form)
 
 
 class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -194,23 +194,21 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         return reverse("source-detail", args=[self.object.id])
 
     def form_valid(self, form):
-        if form.is_valid():
-            form.instance.created_by = self.request.user
-            self.object = form.save()
+        form.instance.created_by = self.request.user
+        self.object = form.save()
 
-            # assign this source to the "current_editors"
-            current_editors = self.object.current_editors.all()
-            self.request.user.sources_user_can_edit.add(self.object)
+        # assign this source to the "current_editors"
+        current_editors = self.object.current_editors.all()
+        self.request.user.sources_user_can_edit.add(self.object)
 
-            for editor in current_editors:
-                editor.sources_user_can_edit.add(self.object)
+        for editor in current_editors:
+            editor.sources_user_can_edit.add(self.object)
 
-            messages.success(
-                self.request,
-                "Source created successfully!",
-            )
-            return HttpResponseRedirect(self.get_success_url())
-        return super().form_valid(form)
+        messages.success(
+            self.request,
+            "Source created successfully!",
+        )
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class SourceEditView(


### PR DESCRIPTION
Previously, if the user creates a source, the success message will be displayed on an empty create form. This is confusing because it looks like none of their data was saved to the source. Now, if they create a source they will be redirected to the source detail page.

Also removing the inheritance to SourceDetailView in the SourceEditView to avoid any unwanted behaviour. Reworking the logic inside of get_context_data outside of both of these views seemed to me like it would be more convoluted rather than helpful, especially since much of the logic is dependent on the object instance. Instead, SourceEditView now has it's own get_context_data that behaves similarly to that of SourceDetailView.

Fixes #814, but we may still need to consider whether we should do the same for the chant create page.