### PR TITLE
Update JSON Node Export API to raise 404 for items created in NewCantus

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3458,6 +3458,17 @@ class JsonNodeExportTest(TestCase):
         response_3 = self.client.get(reverse("json-node-export", args=["1000000000"]))
         self.assertEqual(response_3.status_code, 404)
 
+    def test_404_for_objects_created_in_newcantus(self):
+        # json_node should only work for items created in OldCantus, where objects of different
+        # types are all guaranteed to have unique IDs.
+        # objects created in NewCantus should all have ID >= 1_000_000
+        chant = make_fake_chant()
+        chant.id = 1_000_001
+        chant.save()
+
+        response_3 = self.client.get(reverse("json-node-export", args=["1000001"]))
+        self.assertEqual(response_3.status_code, 404)
+
     def test_json_node_for_chant(self):
         chant = make_fake_chant()
         id = chant.id

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -303,7 +303,7 @@ urlpatterns = [
         name="json-sources-export",
     ),
     path(
-        "json-node/<str:id>",
+        "json-node/<int:id>",
         views.json_node_export,
         name="json-node-export",
     ),


### PR DESCRIPTION
Towards #840, this PR updates the JSON Node Export API to return 404 errors for items created in NewCantus (i.e. items with IDs greater than 1 million).

Along the way, it refactors the Node Redirect view a bit, since the two views share similar logic. Comments have been added/updated, and so on.

There's also a new test in the test suite to ensure this always works.