### PR TITLE
my-sources: fix bug in user created sources side panel

### DIFF
--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -52,7 +52,7 @@
                 <div class="card-body">
                     <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
                     <ul>
-                        {% for my_source in page_obj %}
+                        {% for my_source in user_created_sources_page_obj %}
                             <li>
                                 <a href="{% url "source-detail" my_source.pk %}">
                                     <b> {{ my_source.siglum }}</b>

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -104,7 +104,7 @@ class UserSourceListView(LoginRequiredMixin, ListView):
             .order_by("-date_created")
             .distinct()
         )
-        paginator = Paginator(user_created_sources, 10)
+        paginator = Paginator(user_created_sources, 6)
         page_number = self.request.GET.get("page2")
         page_obj = paginator.get_page(page_number)
 


### PR DESCRIPTION
Fixes #844. The wrong pagination object was being used on the my-sources page which was causing the user-created sources to look the exact same as the my-sources table. Sources on the sidebar are set to six sources per page. 