### PR TITLE
Improve layout of Chant Search, Chant Search MS views

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -31,23 +31,27 @@
 
     <form method="get">
         <div class="form-row align-items-end">
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-12">
+                <label for="keywordSearch"><small>Keyword search</small></label>
+            </div>
+        </div>
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg-3 col-sm-3 col-3">
                 <select class="form-control custom-select custom-select-sm" id="opFilter" name="op">
                     <option selected value="contains">Contains</option>
                     <option value="starts_with">Starts with</option>
                 </select>
             </div>
-            <div class="form-group m-1 col-lg">
-                <label for="keywordSearch"><small>Keyword search</small></label>
+            <div class="form-group m-1 col-lg col-sm col-">
                 <input type="text" class="form-control form-control-sm" name="keyword" id="keywordSearch" value="{{ request.GET.keyword }}">
             </div>
         </div>
         <div class="form-row align-items-end">
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg-3 col-sm-6">
                 <label for="office"><small>Office/Mass</small></label>
                 <input type="text" class="form-control form-control-sm" name="office" id="office" value="{{ request.GET.office }}">
             </div>
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg-3 col-sm">
                 <label for="genreFilter"><small>Genre</small></label>
                 <select id="genreFilter" name="genre" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>
@@ -56,23 +60,23 @@
                     {% endfor %}
                 </select>
             </div>
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg-3 col-sm-6">
                 <label for="cantus_id"><small>Cantus ID</small></label>
                 <input type="text" class="form-control form-control-sm" name="cantus_id" id="cantus_id" value="{{ request.GET.cantus_id }}">
             </div>
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg col-sm">
                 <label for="mode"><small>Mode</small></label>
                 <input type="text" class="form-control form-control-sm" name="mode" id="mode" value="{{ request.GET.mode }}">
             </div>
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg-3 col-sm-6">
                 <label for="feast"><small>Feast</small></label>
                 <input type="text" class="form-control form-control-sm" name="feast" id="feast" value="{{ request.GET.feast }}">
             </div>
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg-3 col-sm">
                 <label for="position"><small>Position</small></label>
                 <input type="text" class="form-control form-control-sm" name="position" id="position" value="{{ request.GET.position }}">
             </div>
-            <div class="form-group m-1 col-lg">
+            <div class="form-group m-1 col-lg-3 col-sm-6">
                 <label for="melodiesFilter"><small>Melodies</small></label>
                 <select class="form-control custom-select custom-select-sm" id="melodiesFilter" name="melodies">
                     <option value="">- Any -</option>


### PR DESCRIPTION
This PR improves the layout of the Chant Search and Chant Search Manuscript views. It is a first step towards setting up #843 (I had started to work on implementing a "search indexing notes" field, and the page began to look quite terrible - in an attempt to make PRs that aren't enormous, this PR is a first step towards implementing the latter feature, where we can just take everything above "Office/Mass" and duplicate/adapt it below "Melodies" for the new field.)

It fixes #846.

Previously, the "Contains"/"Starts with" box was just as large as the "Keyword search" field, which was tripping up testers:

![Screenshot 2023-07-13 at 1 15 45 PM](https://github.com/DDMAL/CantusDB/assets/58090591/84bc0b30-3e7e-4361-b474-2883ffc9000d)

This PR makes the "Contains" box smaller.

The fields beneath this row have also been rearranged (bootstrap deals with 12 columns, but there were 7 items equally spaced on the lower line - without this rearrangement, nothing would align visually):

![Screenshot 2023-07-13 at 1 18 05 PM](https://github.com/DDMAL/CantusDB/assets/58090591/f0f810c6-76ad-47ef-b868-fe89f240a92e)

Also, previously, when the window became somewhat narrow, every field would go onto its own line:
![Screenshot 2023-07-13 at 1 19 04 PM](https://github.com/DDMAL/CantusDB/assets/58090591/78d2be24-f4b8-47d0-9e52-bccf0f3f8e7b)

Now, when the window becomes somewhat narrow, the fields pair up, which looks a bit neater:
![Screenshot 2023-07-13 at 1 20 47 PM](https://github.com/DDMAL/CantusDB/assets/58090591/4af88bff-a290-417a-802c-b116a4367968)

And now, the fields take up full lines only when the window becomes very narrow. When this happens, the "Contains" box stays smaller than the "Keyword" field:
![Screenshot 2023-07-13 at 1 22 07 PM](https://github.com/DDMAL/CantusDB/assets/58090591/9160b9db-8288-4b06-8030-064997b9ca77)

