### PR TITLE
fix update_source_melody_count signal

### DIFF
--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -91,9 +91,11 @@ def update_source_melody_count(instance):
     except Source.DoesNotExist:
         source = None
     if source is not None:
-        source.number_of_melodies = source.chant_set.filter(
-            volpiano__isnull=False
-        ).count()
+        source.number_of_melodies = (
+            source.chant_set.exclude(volpiano__isnull=True)
+            .exclude(volpiano__exact="")
+            .count()
+        )
         source.save()
 
 


### PR DESCRIPTION
Fixes #838. The update_source_melody_count was not updating properly because there are two default null values for an empty TextField, NULL and the empty string "". From the django docs (https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.Field.null) it is not recommended to use null=True on Textfields for this reason. we have `volpiano = models.TextField(null=True, blank=True)` in the BaseChant model. This PR changes the update_source_melody_count signal to filter by excluding both volpiano__isnull=True and volpiano__exact=""