### PR TITLE
Write Tests for Chant Search View

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/add_prefix.py
+++ b/django/cantusdb_project/main_app/management/commands/add_prefix.py
@@ -1,6 +1,5 @@
 from django.core.management.base import BaseCommand
 
-# from pprint import pprint
 from main_app.models import Feast
 
 

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -113,6 +113,7 @@ def make_fake_chant(
     c_sequence=None,
     cantus_id=None,
     feast=None,
+    mode=None,
     manuscript_full_text_std_spelling=None,
     incipit=None,
     manuscript_full_text_std_proofread=None,
@@ -142,6 +143,8 @@ def make_fake_chant(
         cantus_id = make_random_string(6, "0123456789")
     if feast is None:
         feast = make_fake_feast()
+    if mode is None:
+        mode = make_random_string(1, "0123456789*?")
     if manuscript_full_text_std_spelling is None:
         manuscript_full_text_std_spelling = faker.sentence()
     if incipit is None:
@@ -167,7 +170,7 @@ def make_fake_chant(
         position=position,
         cantus_id=cantus_id,
         feast=feast,
-        mode=make_random_string(1, "0123456789*?"),
+        mode=mode,
         differentia=differentia,
         finalis=make_random_string(1, "abcdefg"),
         extra=make_random_string(3, "0123456789"),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -112,6 +112,7 @@ def make_fake_chant(
     position=None,
     c_sequence=None,
     cantus_id=None,
+    image_link=None,
     feast=None,
     mode=None,
     manuscript_full_text_std_spelling=None,
@@ -141,6 +142,8 @@ def make_fake_chant(
         c_sequence = random.randint(1, MAX_SEQUENCE_NUMBER)
     if cantus_id is None:
         cantus_id = make_random_string(6, "0123456789")
+    if image_link is None:
+        image_link = faker.image_url()
     if feast is None:
         feast = make_fake_feast()
     if mode is None:
@@ -187,7 +190,7 @@ def make_fake_chant(
         manuscript_full_text_proofread=faker.boolean(),
         volpiano=volpiano,
         volpiano_proofread=faker.boolean(),
-        image_link=faker.image_url(),
+        image_link=image_link,
         cao_concordances=make_random_string(12, "ABCDEFGHIJKLMNOPQRSTUVWXYZ  "),
         melody_id="m" + make_random_string(8, "0123456789."),
         manuscript_syllabized_full_text=manuscript_syllabized_full_text,

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -904,10 +904,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_incipit(self):
         source = make_fake_source(published=True)
@@ -941,10 +941,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_office(self):
         # currently, office sort works by ID rather than by name
@@ -981,10 +981,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_genre(self):
         # currently, genre sort works by ID rather than by name
@@ -1021,10 +1021,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_cantus_id(self):
         chant_1 = make_fake_chant(incipit="isaac", cantus_id="121393")
@@ -1057,10 +1057,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_mode(self):
         chant_1 = make_fake_chant(
@@ -1099,10 +1099,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_ms_fulltext(self):
         chant_1 = make_fake_chant(
@@ -1142,10 +1142,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_volpiano(self):
         chant_1 = make_fake_chant(
@@ -1185,10 +1185,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_image_link(self):
         chant_1 = make_fake_chant(
@@ -1228,10 +1228,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         descending_results = response_descending.context["chants"]
-        first_result_incipit = descending_results[1]["incipit"]
-        self.assertEqual(first_result_incipit, chant_1.incipit)
-        last_result_incipit = descending_results[0]["incipit"]
-        self.assertEqual(last_result_incipit, chant_2.incipit)
+        first_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_2.incipit)
+        last_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_column_header_links(self):
         # these are the 9 column headers users can order by:

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1063,7 +1063,47 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_mode(self):
-        pass
+        chant_1 = make_fake_chant(
+            incipit="For first he looks upon his forepaws to see if they are clean",
+            mode="1",
+        )
+        chant_2 = make_fake_chant(
+            incipit="For secondly he kicks up behind to clear away there",
+            mode="2",
+        )
+
+        search_term = "for"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "cantus_id",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        print(ascending_results[0]["incipit"], ascending_results[0]["mode"])
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "cantus_id",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_ms_fulltext(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1085,7 +1085,6 @@ class ChantSearchViewTest(TestCase):
         )
         ascending_results = response_ascending.context["chants"]
         first_result_incipit = ascending_results[0]["incipit"]
-        print(ascending_results[0]["incipit"], ascending_results[0]["mode"])
         self.assertEqual(first_result_incipit, chant_1.incipit)
         last_result_incipit = ascending_results[1]["incipit"]
         self.assertEqual(last_result_incipit, chant_2.incipit)
@@ -1106,7 +1105,47 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_ms_fulltext(self):
-        pass
+        chant_1 = make_fake_chant(
+            incipit="this is a chant with a MS spelling fulltext",
+            manuscript_full_text="this is a chant with a MS spelling fylltexte",
+        )
+        chant_2 = make_fake_chant(
+            incipit="this is a chant without",
+        )
+        chant_2.manuscript_full_text = None
+        chant_2.save()
+
+        search_term = "s is a ch"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "has_fulltext",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "has_fulltext",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_volpiano(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1223,7 +1223,7 @@ class ChantSearchViewTest(TestCase):
             {
                 "keyword": search_term,
                 "op": "contains",
-                "order": "has_fulltext",
+                "order": "has_image",
                 "sort": "desc",
             },
         )

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1148,7 +1148,47 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_volpiano(self):
-        pass
+        chant_1 = make_fake_chant(
+            incipit="this is a chant with volpiano",
+            volpiano="1---d---d---a--a---a---e--f--e---d---4",
+        )
+        chant_2 = make_fake_chant(
+            incipit="this is a chant about parsley",
+        )
+        chant_2.volpiano = None
+        chant_2.save()
+
+        search_term = "s is a ch"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "has_melody",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "has_fulltext",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_image_link(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3694,7 +3694,11 @@ class SourceCreateViewTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse("source-create"))
+        created_source = Source.objects.get(siglum="test-siglum")
+        self.assertRedirects(
+            response,
+            reverse("source-detail", args=[created_source.id]),
+        )
 
         source = Source.objects.first()
         self.assertEqual(source.title, "test")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1079,7 +1079,7 @@ class ChantSearchViewTest(TestCase):
             {
                 "keyword": search_term,
                 "op": "contains",
-                "order": "cantus_id",
+                "order": "mode",
                 "sort": "asc",
             },
         )
@@ -1094,7 +1094,7 @@ class ChantSearchViewTest(TestCase):
             {
                 "keyword": search_term,
                 "op": "contains",
-                "order": "cantus_id",
+                "order": "mode",
                 "sort": "desc",
             },
         )
@@ -1180,7 +1180,7 @@ class ChantSearchViewTest(TestCase):
             {
                 "keyword": search_term,
                 "op": "contains",
-                "order": "has_fulltext",
+                "order": "has_melody",
                 "sort": "desc",
             },
         )

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -987,7 +987,44 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_genre(self):
-        pass
+        # currently, genre sort works by ID rather than by name
+        genre_1 = make_fake_genre()
+        genre_2 = make_fake_genre()
+        assert genre_1.id < genre_2.id
+        chant_1 = make_fake_chant(genre=genre_1, incipit="hocus")
+        chant_2 = make_fake_chant(genre=genre_2, incipit="pocus")
+
+        search_term = "ocu"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "genre",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "genre",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_cantus_id(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1027,7 +1027,40 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_cantus_id(self):
-        pass
+        chant_1 = make_fake_chant(incipit="isaac", cantus_id="121393")
+        chant_2 = make_fake_chant(incipit="baal", cantus_id="196418")
+
+        search_term = "aa"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "cantus_id",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "cantus_id",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_mode(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -910,7 +910,41 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_incipit(self):
-        pass
+        source = make_fake_source(published=True)
+        chant_1 = make_fake_chant(source=source, incipit="higgledy")
+        chant_2 = make_fake_chant(source=source, incipit="piggledy")
+
+        search_term = "iggl"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "incipit",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "incipit",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_office(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -947,7 +947,44 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_office(self):
-        pass
+        # currently, office sort works by ID rather than by name
+        office_1 = make_fake_office()
+        office_2 = make_fake_office()
+        assert office_1.id < office_2.id
+        chant_1 = make_fake_chant(office=office_1, incipit="hocus")
+        chant_2 = make_fake_chant(office=office_2, incipit="pocus")
+
+        search_term = "ocu"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "office",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "office",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_genre(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -872,7 +872,42 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(chant.id, context_chant_id)
 
     def test_order_by_siglum(self):
-        pass
+        source_1 = make_fake_source(published=True, siglum="sigl-1")
+        chant_1 = make_fake_chant(incipit="thing 1", source=source_1)
+        source_2 = make_fake_source(published=True, siglum="sigl-2")
+        chant_2 = make_fake_chant(incipit="thing 2", source=source_2)
+
+        search_term = "thing"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "siglum",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "siglum",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_incipit(self):
         pass

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4372,11 +4372,6 @@ class JsonCidTest(TestCase):
         )
         json_for_one_chant_2 = response_2.json()["chants"][0]["chant"]
         for item in json_for_one_chant_2.items():
-            try:
-                assert isinstance(item[1], str)
-            except AssertionError:
-                print(item)
-
             self.assertIsInstance(item[1], str)  # we shouldn't see any Nones or nulls
 
         chant.manuscript_full_text = "nahn-staendrd spillynge"

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -871,6 +871,36 @@ class ChantSearchViewTest(TestCase):
         context_chant_id = response.context["chants"][0]["id"]
         self.assertEqual(chant.id, context_chant_id)
 
+    def test_order_by_siglum(self):
+        pass
+
+    def test_order_by_incipit(self):
+        pass
+
+    def test_order_by_office(self):
+        pass
+
+    def test_order_by_genre(self):
+        pass
+
+    def test_order_by_cantus_id(self):
+        pass
+
+    def test_order_by_mode(self):
+        pass
+
+    def test_order_by_ms_fulltext(self):
+        pass
+
+    def test_order_by_volpiano(self):
+        pass
+
+    def test_order_by_image_link(self):
+        pass
+
+    def test_column_header_links(self):
+        pass
+
     def test_source_link_column(self):
         siglum = "Sigl-01"
         source = make_fake_source(published=True, siglum=siglum)

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1191,7 +1191,47 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_order_by_image_link(self):
-        pass
+        chant_1 = make_fake_chant(
+            incipit="this is a chant with a link",
+            image_link="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+        chant_2 = make_fake_chant(
+            incipit="this is a chant without",
+        )
+        chant_2.image_link = None
+        chant_2.save()
+
+        search_term = "a chant with"
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "has_image",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_incipit = ascending_results[0]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = ascending_results[1]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "keyword": search_term,
+                "op": "contains",
+                "order": "has_fulltext",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_incipit = descending_results[1]["incipit"]
+        self.assertEqual(first_result_incipit, chant_1.incipit)
+        last_result_incipit = descending_results[0]["incipit"]
+        self.assertEqual(last_result_incipit, chant_2.incipit)
 
     def test_column_header_links(self):
         pass


### PR DESCRIPTION
This PR adds a bunch of tests for our Chant Search view. It already had some tests, but none to test the click-on-the-column-headers-to-reorder-results feature. So, now we have a thorough suite of tests to ensure this feature doesn't break when we refactor this view and the Chant Search MS View.

A task for early next week: I need to do the same thing for the ChantSearchMSViewTest. I think this will mostly be copy-pasting, so shouldn't take nearly as long.

Also in this PR, I stumbled across a commented-out import statement in a management command, and found some print statement / debugging apparatus that had accidentally been left in one of the tests. I got rid of them. Finally, the Chant Create view redirect behavior is meant to be different now, so that test is updated too.