### PR TITLE
Update data migration sync scripts

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -344,7 +344,7 @@ def make_dummy_chant() -> None:
             "Aborting attempt to create a new dummy chant."
         )
         return
-    except Source.DoesNotExist:
+    except Chant.DoesNotExist:
         pass
 
     dummy_source = Source.objects.get(id=1_000_000, published=False)
@@ -391,7 +391,6 @@ class Command(BaseCommand):
                         f"---------------- {counter} of {total} chants synced --------------"
                     )
                 counter += 1
-            make_dummy_chant()
         else:
             get_new_chant(id)
 

--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -132,7 +132,7 @@ def get_new_chant(chant_id):
 
     try:
         differentia_new = json_response["field_differentia_new"]["und"][0]["value"]
-    except (KeyError, TypeError):
+    except (KeyError, TypeError, IndexError):
         differentia_new = None
 
     try:

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -233,7 +233,7 @@ def make_dummy_sequence() -> None:
             "This unpublished dummy sequence exists in order that all newly created "
             "sequences have IDs greater than 1,000,000 (which ensures that requests "
             "made to /node/<id> URLs can be redirected to their proper "
-            "sequence/sequence/article detail page). Once a sequence with an ID greater than "
+            "chant/sequence/article detail page). Once a sequence with an ID greater than "
             "1,000,000 has been created, this dummy sequence may be safely deleted."
         ),
     )

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -226,16 +226,18 @@ def make_dummy_sequence() -> None:
         pass
 
     dummy_source = Source.objects.get(id=1_000_000, published=False)
-    dummy_sequence = Sequence.objects.create(
+    Sequence.objects.create(
+        title="DUMMY",
         source=dummy_source,
         manuscript_full_text_std_spelling=(
-            "This unpublished dummy sequence exists in order that all newly created "
-            "sequences have IDs greater than 1,000,000 (which ensures that requests "
+            "This unpublished dummy chant exists in order that all newly created "
+            "chants have IDs greater than 1,000,000 (which ensures that requests "
             "made to /node/<id> URLs can be redirected to their proper "
-            "chant/sequence/article detail page). Once a sequence with an ID greater than "
-            "1,000,000 has been created, this dummy sequence may be safely deleted."
+            "chant/sequence/article detail page). Once a chant with an ID greater than "
+            "1,000,000 has been created, this dummy chant may be safely deleted."
         ),
     )
+    dummy_sequence = Sequence.objects.filter(title="DUMMY")
     dummy_sequence.update(id=1_000_000)
     return dummy_sequence
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -260,10 +260,16 @@ class Command(BaseCommand):
         id = options["id"]
         if id == "all":
             all_seqs = get_seq_list(SEQUENCE_ID_FILE)
+            total = len(all_seqs)
+            counter = 0
             for i, seq_id in enumerate(all_seqs):
                 # print(seq_id)
                 get_new_sequence(seq_id)
-            make_dummy_sequence()
+                if counter % 500 == 0:
+                    print(
+                        f"---------------- {counter} of {total} chants synced --------------"
+                    )
+                counter += 1
         else:
             get_new_sequence(id)
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -230,11 +230,11 @@ def make_dummy_sequence() -> None:
         title="DUMMY",
         source=dummy_source,
         manuscript_full_text_std_spelling=(
-            "This unpublished dummy chant exists in order that all newly created "
-            "chants have IDs greater than 1,000,000 (which ensures that requests "
+            "This unpublished dummy sequence exists in order that all newly created "
+            "sequences have IDs greater than 1,000,000 (which ensures that requests "
             "made to /node/<id> URLs can be redirected to their proper "
-            "chant/sequence/article detail page). Once a chant with an ID greater than "
-            "1,000,000 has been created, this dummy chant may be safely deleted."
+            "sequence/sequence/article detail page). Once a sequence with an ID greater than "
+            "1,000,000 has been created, this dummy sequence may be safely deleted."
         ),
     )
     dummy_sequence = Sequence.objects.filter(title="DUMMY")

--- a/django/cantusdb_project/main_app/management/commands/sync_sources.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sources.py
@@ -343,6 +343,8 @@ def remove_extra_sources():
     print(len(our_sources))
     print(len(waterloo_sources))
     extra_sources = [id for id in our_sources if id not in waterloo_sources]
+    if 1_000_000 in extra_sources:
+        extra_sources.remove(1_000_000)
     for source in extra_sources:
         Source.objects.get(id=source).delete()
         print(f"Extra source removed: {source}")
@@ -368,7 +370,7 @@ def make_dummy_source() -> None:
         pass
 
     cantus_segment = Segment.objects.get(id=4063)
-    dummy_source = Source.objects.create(
+    Source.objects.create(
         segment=cantus_segment,
         siglum="DUMMY",
         published=False,
@@ -381,6 +383,7 @@ def make_dummy_source() -> None:
             "1,000,000 has been created, this dummy source may be safely deleted."
         ),
     )
+    dummy_source = Source.objects.filter(siglum="DUMMY")
     dummy_source.update(id=1_000_000)
     return dummy_source
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sources.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sources.py
@@ -409,7 +409,6 @@ class Command(BaseCommand):
             for source_id in all_sources:
                 print(source_id)
                 source = get_new_source(source_id)
-            make_dummy_source()
         else:
             new_source = get_new_source(id)
             print(new_source.title)


### PR DESCRIPTION
This PR includes all of the updates that were made to the synchronization scripts to migrate the data from oldcantus to newcantus. We may never have to use these scripts again since we have now completed the final migration, but this will be the most up-to-date code for this task regardless.
- Handle Index errors and ObjectDoesNotExist errors
- Remove calls to "make dummy object" functions since we have now directly altered the table to start ID's for these objects at 1000000