### PR TITLE
Add cantusdatabase.org to CSRF_TRUSTED_ORIGINS

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -196,6 +196,8 @@ INTERNAL_IPS = [
     "127.0.0.1",
 ]
 
+CSRF_TRUSTED_ORIGINS = ["https://cantusdatabase.org", "https://www.cantusdatabase.org"]
+
 if DEBUG:
     INSTALLED_APPS.append("debug_toolbar")
     # debug toolbar must be inserted as early in the middleware as possible


### PR DESCRIPTION
This PR adds a line to `settings.py`, adding cantusdatabase.org to CSRF_TRUSTED_ORIGINS. Without this line, users cannot log in on production.

Testing locally, this does not prevent me from logging in, so I assume it won't break things on staging.