### PR TITLE
Use `select_related` to optimize "view full index" page of a source.

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1392,7 +1392,7 @@ class ChantIndexView(TemplateView):
             queryset = (
                 source.sequence_set.annotate(record_type=Value("sequence"))
                 .order_by("s_sequence")
-                .select_related("feast", "office", "genre")
+                .select_related("genre")
             )
         else:
             queryset = (

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1389,12 +1389,16 @@ class ChantIndexView(TemplateView):
 
         # 4064 is the id for the sequence database
         if source.segment.id == 4064:
-            queryset = source.sequence_set.annotate(
-                record_type=Value("sequence")
-            ).order_by("s_sequence")
+            queryset = (
+                source.sequence_set.annotate(record_type=Value("sequence"))
+                .order_by("s_sequence")
+                .select_related("feast", "office", "genre")
+            )
         else:
-            queryset = source.chant_set.annotate(record_type=Value("chant")).order_by(
-                "folio", "c_sequence"
+            queryset = (
+                source.chant_set.annotate(record_type=Value("chant"))
+                .order_by("folio", "c_sequence")
+                .select_related("feast", "office", "genre")
             )
 
         context["source"] = source


### PR DESCRIPTION
Previously, the "view full inventory" link on NewCantus was very slow to load (~30s). This is because the queries are fetching the office, feast, and genre descriptions for each chant. To fix this we can use select_related to fetch the related office, feast, and genre objects.

Fixes #872 