### PR TITLE
Merge Staging into Production, 2023-07-24 edition

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -196,6 +196,8 @@ INTERNAL_IPS = [
     "127.0.0.1",
 ]
 
+CSRF_TRUSTED_ORIGINS = ["https://cantusdatabase.org", "https://www.cantusdatabase.org"]
+
 if DEBUG:
     INSTALLED_APPS.append("debug_toolbar")
     # debug toolbar must be inserted as early in the middleware as possible

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -37,7 +37,7 @@ class ChantAdmin(BaseModelAdmin):
 
 
 class FeastAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name", "feast_code")
 
 
 class GenreAdmin(BaseModelAdmin):
@@ -53,7 +53,7 @@ class OfficeAdmin(BaseModelAdmin):
 
 
 class ProvenanceAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class RismSiglumAdmin(BaseModelAdmin):
@@ -65,7 +65,10 @@ class SegmentAdmin(BaseModelAdmin):
 
 
 class SequenceAdmin(BaseModelAdmin):
+    search_fields = ("title", "incipit", "cantus_id",)
     exclude = EXCLUDE + ("c_sequence", "next_chant", "is_last_chant_in_feast")
+    list_display = ("incipit", "siglum", "genre")
+    list_filter = ("genre",)
 
 
 class SourceAdmin(BaseModelAdmin):

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -23,7 +23,7 @@ class CenturyAdmin(BaseModelAdmin):
 
 
 class ChantAdmin(BaseModelAdmin):
-    list_display = ("incipit", "siglum", "genre")
+    list_display = ("incipit", "get_source_siglum", "genre")
     search_fields = ("title", "incipit", "cantus_id")
     list_filter = ("genre",)
     exclude = EXCLUDE + (
@@ -34,6 +34,9 @@ class ChantAdmin(BaseModelAdmin):
         "s_sequence",
         "is_last_chant_in_feast",
     )
+
+    def get_source_siglum(self, obj):
+        return obj.source.siglum
 
 
 class FeastAdmin(BaseModelAdmin):
@@ -65,10 +68,17 @@ class SegmentAdmin(BaseModelAdmin):
 
 
 class SequenceAdmin(BaseModelAdmin):
-    search_fields = ("title", "incipit", "cantus_id",)
+    search_fields = (
+        "title",
+        "incipit",
+        "cantus_id",
+    )
     exclude = EXCLUDE + ("c_sequence", "next_chant", "is_last_chant_in_feast")
-    list_display = ("incipit", "siglum", "genre")
+    list_display = ("incipit", "get_source_siglum", "genre")
     list_filter = ("genre",)
+
+    def get_source_siglum(self, obj):
+        return obj.source.siglum
 
 
 class SourceAdmin(BaseModelAdmin):

--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -344,7 +344,7 @@ def make_dummy_chant() -> None:
             "Aborting attempt to create a new dummy chant."
         )
         return
-    except Source.DoesNotExist:
+    except Chant.DoesNotExist:
         pass
 
     dummy_source = Source.objects.get(id=1_000_000, published=False)
@@ -391,7 +391,6 @@ class Command(BaseCommand):
                         f"---------------- {counter} of {total} chants synced --------------"
                     )
                 counter += 1
-            make_dummy_chant()
         else:
             get_new_chant(id)
 

--- a/django/cantusdb_project/main_app/management/commands/sync_chants.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_chants.py
@@ -132,7 +132,7 @@ def get_new_chant(chant_id):
 
     try:
         differentia_new = json_response["field_differentia_new"]["und"][0]["value"]
-    except (KeyError, TypeError):
+    except (KeyError, TypeError, IndexError):
         differentia_new = None
 
     try:

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -233,7 +233,7 @@ def make_dummy_sequence() -> None:
             "This unpublished dummy sequence exists in order that all newly created "
             "sequences have IDs greater than 1,000,000 (which ensures that requests "
             "made to /node/<id> URLs can be redirected to their proper "
-            "sequence/sequence/article detail page). Once a sequence with an ID greater than "
+            "chant/sequence/article detail page). Once a sequence with an ID greater than "
             "1,000,000 has been created, this dummy sequence may be safely deleted."
         ),
     )

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -226,16 +226,18 @@ def make_dummy_sequence() -> None:
         pass
 
     dummy_source = Source.objects.get(id=1_000_000, published=False)
-    dummy_sequence = Sequence.objects.create(
+    Sequence.objects.create(
+        title="DUMMY",
         source=dummy_source,
         manuscript_full_text_std_spelling=(
-            "This unpublished dummy sequence exists in order that all newly created "
-            "sequences have IDs greater than 1,000,000 (which ensures that requests "
+            "This unpublished dummy chant exists in order that all newly created "
+            "chants have IDs greater than 1,000,000 (which ensures that requests "
             "made to /node/<id> URLs can be redirected to their proper "
-            "chant/sequence/article detail page). Once a sequence with an ID greater than "
-            "1,000,000 has been created, this dummy sequence may be safely deleted."
+            "chant/sequence/article detail page). Once a chant with an ID greater than "
+            "1,000,000 has been created, this dummy chant may be safely deleted."
         ),
     )
+    dummy_sequence = Sequence.objects.filter(title="DUMMY")
     dummy_sequence.update(id=1_000_000)
     return dummy_sequence
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -260,10 +260,16 @@ class Command(BaseCommand):
         id = options["id"]
         if id == "all":
             all_seqs = get_seq_list(SEQUENCE_ID_FILE)
+            total = len(all_seqs)
+            counter = 0
             for i, seq_id in enumerate(all_seqs):
                 # print(seq_id)
                 get_new_sequence(seq_id)
-            make_dummy_sequence()
+                if counter % 500 == 0:
+                    print(
+                        f"---------------- {counter} of {total} chants synced --------------"
+                    )
+                counter += 1
         else:
             get_new_sequence(id)
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sequences.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sequences.py
@@ -230,11 +230,11 @@ def make_dummy_sequence() -> None:
         title="DUMMY",
         source=dummy_source,
         manuscript_full_text_std_spelling=(
-            "This unpublished dummy chant exists in order that all newly created "
-            "chants have IDs greater than 1,000,000 (which ensures that requests "
+            "This unpublished dummy sequence exists in order that all newly created "
+            "sequences have IDs greater than 1,000,000 (which ensures that requests "
             "made to /node/<id> URLs can be redirected to their proper "
-            "chant/sequence/article detail page). Once a chant with an ID greater than "
-            "1,000,000 has been created, this dummy chant may be safely deleted."
+            "sequence/sequence/article detail page). Once a sequence with an ID greater than "
+            "1,000,000 has been created, this dummy sequence may be safely deleted."
         ),
     )
     dummy_sequence = Sequence.objects.filter(title="DUMMY")

--- a/django/cantusdb_project/main_app/management/commands/sync_sources.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sources.py
@@ -343,6 +343,8 @@ def remove_extra_sources():
     print(len(our_sources))
     print(len(waterloo_sources))
     extra_sources = [id for id in our_sources if id not in waterloo_sources]
+    if 1_000_000 in extra_sources:
+        extra_sources.remove(1_000_000)
     for source in extra_sources:
         Source.objects.get(id=source).delete()
         print(f"Extra source removed: {source}")
@@ -368,7 +370,7 @@ def make_dummy_source() -> None:
         pass
 
     cantus_segment = Segment.objects.get(id=4063)
-    dummy_source = Source.objects.create(
+    Source.objects.create(
         segment=cantus_segment,
         siglum="DUMMY",
         published=False,
@@ -381,6 +383,7 @@ def make_dummy_source() -> None:
             "1,000,000 has been created, this dummy source may be safely deleted."
         ),
     )
+    dummy_source = Source.objects.filter(siglum="DUMMY")
     dummy_source.update(id=1_000_000)
     return dummy_source
 

--- a/django/cantusdb_project/main_app/management/commands/sync_sources.py
+++ b/django/cantusdb_project/main_app/management/commands/sync_sources.py
@@ -409,7 +409,6 @@ class Command(BaseCommand):
             for source_id in all_sources:
                 print(source_id)
                 source = get_new_source(source_id)
-            make_dummy_source()
         else:
             new_source = get_new_source(id)
             print(new_source.title)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1392,7 +1392,7 @@ class ChantIndexView(TemplateView):
             queryset = (
                 source.sequence_set.annotate(record_type=Value("sequence"))
                 .order_by("s_sequence")
-                .select_related("feast", "office", "genre")
+                .select_related("genre")
             )
         else:
             queryset = (

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1389,12 +1389,16 @@ class ChantIndexView(TemplateView):
 
         # 4064 is the id for the sequence database
         if source.segment.id == 4064:
-            queryset = source.sequence_set.annotate(
-                record_type=Value("sequence")
-            ).order_by("s_sequence")
+            queryset = (
+                source.sequence_set.annotate(record_type=Value("sequence"))
+                .order_by("s_sequence")
+                .select_related("feast", "office", "genre")
+            )
         else:
-            queryset = source.chant_set.annotate(record_type=Value("chant")).order_by(
-                "folio", "c_sequence"
+            queryset = (
+                source.chant_set.annotate(record_type=Value("chant"))
+                .order_by("folio", "c_sequence")
+                .select_related("feast", "office", "genre")
             )
 
         context["source"] = source

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -334,13 +334,15 @@
                                 </a>
                             </div>
                         </div>
-                        <img
-                            class="img-fluid p-2"
-                            style="max-width: 100%;"
-                            src="{% static "sshrc-logo.jpg" %}"
-                            alt="Social Sciences and Humanities Research Council Logo"
-                            title="Social Sciences and Humanities Research Council of Canada"
-                            loading="lazy">
+                        <a href="https://www.sshrc-crsh.gc.ca" target="_blank">
+                            <img
+                                class="img-fluid p-2"
+                                style="max-width: 100%;"
+                                src="{% static "sshrc-logo.jpg" %}"
+                                alt="Social Sciences and Humanities Research Council Logo"
+                                title="Social Sciences and Humanities Research Council of Canada"
+                                loading="lazy">
+                        </a>
                         <a href="https://alliancecan.ca/" target="_blank">
                             <img
                                 class="img-fluid p-2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - 3000:3000
     depends_on:
       - postgres
+    restart: always
 
   nginx:
     image: nginx:alpine
@@ -22,6 +23,7 @@ services:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
       - media_volume:/resources/media
+    restart: always
     depends_on:
       - django
 
@@ -30,6 +32,7 @@ services:
     env_file: ./config/envs/dev_env
     volumes:
       - postgres_data:/var/lib/postgresql/data/
+    restart: always
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Pages/views that have been modified:

- admin area
  - [x] feast list: a search box has been added to the top of the page, allowing filtering by `name` and `feast_code`
  - [x] provenance list: a search box has been added to the top of the page, allowing filtering by `name`
  - [x] sequence list: a search box has been added to the top of the page, allowing filtering by `incipit`, `title` and `cantus_id`
- [x] Full Index page
  - has been optimized. Other than loading faster, there should be no changes to how it looks/behaves
- [x] all pages
  - SSHRC logo is now clickable, and takes you to the SSHRC website (previously, it wasn't a link)

Other changes:
- a restart policy has been added to `docker-compose.yml`. This means that if one of our servers goes down for some reason (as appears to have happened on staging over the weekend), it will start back up right away.
- the sync scripts have been updated to the version we used while doing the final sync. We shouldn't need to run these again, but in the future we may want to know what they did, so now they're up-to-date
- The project's CSRF settings have been updated, meaning users will be able to log in on Production (this change had already been applied as a hotfix last Friday)