### PR TITLE
Fix header "about" section

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -170,7 +170,7 @@
                                 <a class="dropdown-item" href="/about/acknowledgements/">Acknowledgements</a>
                                 <a class="dropdown-item" href="/about/faq/">FAQ</a>
                                 <a class="dropdown-item" href="https://www.youtube.com/watch?v=iMmGrUxhPj4">Short Video
-                                    Introduction(YouTube)</a>
+                                    Introduction (YouTube)</a>
                                 <a class="dropdown-item" href="{% url 'items-count' %}">Items Count</a>
                             </div>
                         </li>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -171,7 +171,9 @@
                                 <a class="dropdown-item" href="/about/faq/">FAQ</a>
                                 <a class="dropdown-item" href="https://www.youtube.com/watch?v=iMmGrUxhPj4">Short Video
                                     Introduction (YouTube)</a>
-                                <a class="dropdown-item" href="{% url 'items-count' %}">Items Count</a>
+                                {% if request.user.is_authenticated %}
+                                    <a class="dropdown-item" href="{% url 'items-count' %}">Items Count</a>
+                                {% endif %}
                             </div>
                         </li>
 


### PR DESCRIPTION
This PR fixes #882.

It adds a space before "(YouTube)", and hides the Items Count list from non-authenticated users.