### PR TITLE
Configure site to use certbot to work with https

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -1,6 +1,23 @@
 server {
-
     listen 80;
+
+    server_tokens off;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+
+    listen 443 default_server http2 ssl;
+	
+    ssl_certificate /etc/nginx/ssl/live/cantusdatabase.org/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/cantusdatabase.org/privkey.pem;
 
     location / {
         proxy_pass http://django:8000;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,20 +13,27 @@ services:
       - 3000:3000
     depends_on:
       - postgres
-    restart: always
 
   nginx:
     build:
       context: ./nginx
     ports:
       - 80:80
+      - 443:443
     volumes:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
       - media_volume:/resources/media
-    restart: always
+      - certbot_data:/var/www/certbot/:ro
+      - certificates:/etc/nginx/ssl/:ro
     depends_on:
       - django
+
+  certbot:
+    image: certbot/certbot:latest
+    volumes:
+      - certbot_data:/var/www/certbot/:rw
+      - certificates:/etc/letsencrypt/:rw
 
   postgres:
     build:
@@ -34,9 +41,10 @@ services:
     env_file: ./config/envs/dev_env
     volumes:
       - postgres_data:/var/lib/postgresql/data/
-    restart: always
 
 volumes:
   postgres_data:
   static_volume:
   media_volume:
+  certbot_data:
+  certificates:


### PR DESCRIPTION
@kqct and I made a couple of changes to some configuration files to get https working properly on Production last week. I updated the documentation, but the instructions ended up being quite long and fiddly. Hoping that by adding these changes to the repo, we can simplify the instructions.

@kqct, can you look this over to ensure we're not doing anything foolish here?