### PR TITLE
Improve Admin Area

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -134,6 +134,7 @@ class SequenceAdmin(BaseModelAdmin):
         "source",
         "feast",
     )
+    ordering = ("source__siglum",)
     form = AdminSequenceForm
 
 

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -34,9 +34,14 @@ class ChantAdmin(BaseModelAdmin):
         "next_chant",
         "s_sequence",
         "is_last_chant_in_feast",
-        "visible_status"
+        "visible_status",
+        "date",
     )
     form = AdminChantForm
+    raw_id_fields = (
+        "source",
+        "feast",
+    )
 
     def get_source_siglum(self, obj):
         return obj.source.siglum
@@ -76,9 +81,18 @@ class SequenceAdmin(BaseModelAdmin):
         "incipit",
         "cantus_id",
     )
-    exclude = EXCLUDE + ("c_sequence", "next_chant", "is_last_chant_in_feast")
+    exclude = EXCLUDE + (
+        "c_sequence",
+        "next_chant",
+        "is_last_chant_in_feast",
+        "visible_status",
+    )
     list_display = ("incipit", "get_source_siglum", "genre")
     list_filter = ("genre",)
+    raw_id_fields = (
+        "source",
+        "feast",
+    )
 
     def get_source_siglum(self, obj):
         return obj.source.siglum

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -1,6 +1,18 @@
 from django.contrib import admin
 from main_app.models import *
-from main_app.forms import AdminChantForm, AdminSourceForm
+from main_app.forms import (
+    AdminCenturyForm,
+    AdminChantForm,
+    AdminFeastForm,
+    AdminGenreForm,
+    AdminNotationForm,
+    AdminOfficeForm,
+    AdminProvenanceForm,
+    AdminRismSiglumForm,
+    AdminSegmentForm,
+    AdminSequenceForm,
+    AdminSourceForm,
+)
 
 # these fields should not be editable by all classes
 EXCLUDE = ("created_by", "last_updated_by", "json_info")
@@ -21,6 +33,7 @@ class BaseModelAdmin(admin.ModelAdmin):
 
 class CenturyAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminCenturyForm
 
 
 class ChantAdmin(BaseModelAdmin):
@@ -63,30 +76,37 @@ class ChantAdmin(BaseModelAdmin):
 class FeastAdmin(BaseModelAdmin):
     search_fields = ("name", "feast_code")
     list_display = ("name", "month", "day", "feast_code")
+    form = AdminFeastForm
 
 
 class GenreAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminGenreForm
 
 
 class NotationAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminNotationForm
 
 
 class OfficeAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminOfficeForm
 
 
 class ProvenanceAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminProvenanceForm
 
 
 class RismSiglumAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminRismSiglumForm
 
 
 class SegmentAdmin(BaseModelAdmin):
     search_fields = ("name",)
+    form = AdminSegmentForm
 
 
 class SequenceAdmin(BaseModelAdmin):
@@ -114,6 +134,7 @@ class SequenceAdmin(BaseModelAdmin):
         "source",
         "feast",
     )
+    form = AdminSequenceForm
 
 
 class SourceAdmin(BaseModelAdmin):

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from main_app.models import *
+from main_app.forms import AdminChantForm
 
 # these fields should not be editable by all classes
 EXCLUDE = ("created_by", "last_updated_by", "json_info")
@@ -33,7 +34,9 @@ class ChantAdmin(BaseModelAdmin):
         "next_chant",
         "s_sequence",
         "is_last_chant_in_feast",
+        "visible_status"
     )
+    form = AdminChantForm
 
     def get_source_siglum(self, obj):
         return obj.source.siglum

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from main_app.models import *
-from main_app.forms import AdminChantForm
+from main_app.forms import AdminChantForm, AdminSourceForm
 
 # these fields should not be editable by all classes
 EXCLUDE = ("created_by", "last_updated_by", "json_info")
@@ -20,13 +20,28 @@ class BaseModelAdmin(admin.ModelAdmin):
 
 
 class CenturyAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class ChantAdmin(BaseModelAdmin):
-    list_display = ("incipit", "get_source_siglum", "genre")
-    search_fields = ("title", "incipit", "cantus_id")
-    list_filter = ("genre",)
+    @admin.display(description="Source Siglum")
+    def get_source_siglum(self, obj):
+        return obj.source.siglum
+
+    list_display = (
+        "incipit",
+        "get_source_siglum",
+        "genre",
+    )
+    search_fields = (
+        "title",
+        "incipit",
+        "cantus_id",
+    )
+    list_filter = (
+        "genre",
+        "office",
+    )
     exclude = EXCLUDE + (
         "col1",
         "col2",
@@ -42,25 +57,24 @@ class ChantAdmin(BaseModelAdmin):
         "source",
         "feast",
     )
-
-    def get_source_siglum(self, obj):
-        return obj.source.siglum
+    ordering = ("source__siglum",)
 
 
 class FeastAdmin(BaseModelAdmin):
     search_fields = ("name", "feast_code")
+    list_display = ("name", "month", "day", "feast_code")
 
 
 class GenreAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class NotationAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class OfficeAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class ProvenanceAdmin(BaseModelAdmin):
@@ -68,14 +82,18 @@ class ProvenanceAdmin(BaseModelAdmin):
 
 
 class RismSiglumAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class SegmentAdmin(BaseModelAdmin):
-    pass
+    search_fields = ("name",)
 
 
 class SequenceAdmin(BaseModelAdmin):
+    @admin.display(description="Source Siglum")
+    def get_source_siglum(self, obj):
+        return obj.source.siglum
+
     search_fields = (
         "title",
         "incipit",
@@ -88,14 +106,14 @@ class SequenceAdmin(BaseModelAdmin):
         "visible_status",
     )
     list_display = ("incipit", "get_source_siglum", "genre")
-    list_filter = ("genre",)
+    list_filter = (
+        "genre",
+        "office",
+    )
     raw_id_fields = (
         "source",
         "feast",
     )
-
-    def get_source_siglum(self, obj):
-        return obj.source.siglum
 
 
 class SourceAdmin(BaseModelAdmin):
@@ -117,6 +135,23 @@ class SourceAdmin(BaseModelAdmin):
         "proofreaders",
         "other_editors",
     )
+
+    list_display = (
+        "title",
+        "siglum",
+    )
+
+    list_filter = (
+        "full_source",
+        "segment",
+        "source_status",
+        "published",
+        "century",
+    )
+
+    ordering = ("siglum",)
+
+    form = AdminSourceForm
 
 
 admin.site.register(Century, CenturyAdmin)

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -795,29 +795,6 @@ class AdminSequenceForm(forms.ModelForm):
             "chant_range": VolpianoAreaWidget(),
         }
 
-    manuscript_full_text_std_spelling = forms.CharField(
-        required=True,
-        widget=AdminTextAreaWidget,
-        help_text="Manuscript full text with standardized spelling. Enter the words "
-        "according to the manuscript but normalize their spellings following "
-        "Classical Latin forms. Use upper-case letters for proper nouns, "
-        'the first word of each chant, and the first word after "Alleluia" for '
-        "Mass Alleluias. Punctuation is omitted.",
-    )
-
-    folio = forms.CharField(
-        required=True,
-        widget=AdminTextInputWidget,
-        help_text="Binding order",
-    )
-
-    s_sequence = forms.CharField(
-        required=True,
-        widget=AdminTextInputWidget,
-        help_text="Each folio starts with '1'.",
-        label="Sequence",
-    )
-
     # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
     # instead of [name] + description
     office = NameModelChoiceField(

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -17,6 +17,8 @@ from .widgets import (
     VolpianoAreaWidget,
     SelectWidget,
     CheckboxWidget,
+    AdminTextAreaWidget,
+    AdminTextInputWidget,
 )
 from django.contrib.auth import get_user_model
 from django.db.models import Q
@@ -649,59 +651,42 @@ class ChantEditSyllabificationForm(forms.ModelForm):
             "manuscript_syllabized_full_text": TextAreaWidget(),
         }
 
+
 class AdminChantForm(forms.ModelForm):
     class Meta:
         model = Chant
         fields = "__all__"
         widgets = {
             "volpiano": VolpianoAreaWidget(),
-            "marginalia": TextInputWidget(),
-            "position": TextInputWidget(),
-            "cantus_id": TextInputWidget(),
-            "melody_id": TextInputWidget(),
-            "mode": TextInputWidget(),
-            "finalis": TextInputWidget(),
-            "differentia": TextInputWidget(),
-            "extra": TextInputWidget(),
-            "image_link": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
             "manuscript_full_text_std_proofread": CheckboxWidget(),
             "manuscript_full_text_proofread": CheckboxWidget(),
             "volpiano_proofread": CheckboxWidget(),
-            "manuscript_syllabized_full_text": TextAreaWidget(),
             "chant_range": VolpianoAreaWidget(),
-            "siglum": TextInputWidget(),
-            "addendum": TextInputWidget(),
-            "differentia_new": TextInputWidget(),
         }
 
     manuscript_full_text_std_spelling = forms.CharField(
         required=True,
-        widget=TextAreaWidget,
+        widget=AdminTextAreaWidget,
         help_text="Manuscript full text with standardized spelling. Enter the words "
         "according to the manuscript but normalize their spellings following "
         "Classical Latin forms. Use upper-case letters for proper nouns, "
         'the first word of each chant, and the first word after "Alleluia" for '
         "Mass Alleluias. Punctuation is omitted.",
     )
-
+    
     folio = forms.CharField(
         required=True,
-        widget=TextInputWidget,
+        widget=AdminTextInputWidget,
         help_text="Binding order",
     )
 
     c_sequence = forms.CharField(
         required=True,
-        widget=TextInputWidget,
+        widget=AdminTextInputWidget,
         help_text="Each folio starts with '1'.",
+        label="Sequence",
     )
-
-    feast = forms.ModelChoiceField(
-        queryset=Feast.objects.all().order_by("name"),
-        required=False,
-    )
-    feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
     # instead of [name] + description

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -3,9 +3,11 @@ from .models import (
     Chant,
     Office,
     Genre,
+    Notation,
     Feast,
     Source,
     RismSiglum,
+    Segment,
     Provenance,
     Century,
     Sequence,
@@ -655,6 +657,14 @@ class ChantEditSyllabificationForm(forms.ModelForm):
         }
 
 
+class AdminCenturyForm(forms.ModelForm):
+    class Meta:
+        model = Century
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+
+
 class AdminChantForm(forms.ModelForm):
     class Meta:
         model = Chant
@@ -685,6 +695,123 @@ class AdminChantForm(forms.ModelForm):
     )
 
     c_sequence = forms.CharField(
+        required=True,
+        widget=AdminTextInputWidget,
+        help_text="Each folio starts with '1'.",
+        label="Sequence",
+    )
+
+    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
+    # instead of [name] + description
+    office = NameModelChoiceField(
+        queryset=Office.objects.all().order_by("name"),
+        required=False,
+    )
+    # We use NameModelChoiceField here so the dropdown list of genres displays the name
+    # instead of [name] + description
+    genre = NameModelChoiceField(
+        queryset=Genre.objects.all().order_by("name"), required=False
+    )
+
+    proofread_by = forms.ModelMultipleChoiceField(
+        queryset=get_user_model()
+        .objects.filter(Q(groups__name="project manager") | Q(groups__name="editor"))
+        .order_by("last_name"),
+        required=False,
+        widget=FilteredSelectMultiple(verbose_name="proofread by", is_stacked=False),
+    )
+
+
+class AdminFeastForm(forms.ModelForm):
+    class Meta:
+        model = Feast
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+
+
+class AdminGenreForm(forms.ModelForm):
+    class Meta:
+        model = Genre
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+    description = forms.CharField(required=True, widget=AdminTextAreaWidget)
+
+
+class AdminNotationForm(forms.ModelForm):
+    class Meta:
+        model = Notation
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+    name.widget.attrs.update({"style": "width: 400px;"})
+
+
+class AdminOfficeForm(forms.ModelForm):
+    class Meta:
+        model = Office
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+    description = forms.CharField(required=True, widget=AdminTextAreaWidget)
+
+
+class AdminProvenanceForm(forms.ModelForm):
+    class Meta:
+        model = Provenance
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+
+
+class AdminRismSiglumForm(forms.ModelForm):
+    class Meta:
+        model = RismSiglum
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+
+
+class AdminSegmentForm(forms.ModelForm):
+    class Meta:
+        model = Segment
+        fields = "__all__"
+
+    name = forms.CharField(required=True, widget=AdminTextInputWidget)
+    name.widget.attrs.update({"style": "width: 400px;"})
+
+
+class AdminSequenceForm(forms.ModelForm):
+    class Meta:
+        model = Sequence
+        fields = "__all__"
+        widgets = {
+            "volpiano": VolpianoAreaWidget(),
+            "indexing_notes": TextAreaWidget(),
+            "manuscript_full_text_std_proofread": CheckboxWidget(),
+            "manuscript_full_text_proofread": CheckboxWidget(),
+            "volpiano_proofread": CheckboxWidget(),
+            "chant_range": VolpianoAreaWidget(),
+        }
+
+    manuscript_full_text_std_spelling = forms.CharField(
+        required=True,
+        widget=AdminTextAreaWidget,
+        help_text="Manuscript full text with standardized spelling. Enter the words "
+        "according to the manuscript but normalize their spellings following "
+        "Classical Latin forms. Use upper-case letters for proper nouns, "
+        'the first word of each chant, and the first word after "Alleluia" for '
+        "Mass Alleluias. Punctuation is omitted.",
+    )
+
+    folio = forms.CharField(
+        required=True,
+        widget=AdminTextInputWidget,
+        help_text="Binding order",
+    )
+
+    s_sequence = forms.CharField(
         required=True,
         widget=AdminTextInputWidget,
         help_text="Each folio starts with '1'.",

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -648,3 +648,82 @@ class ChantEditSyllabificationForm(forms.ModelForm):
             "manuscript_full_text": TextAreaWidget(),
             "manuscript_syllabized_full_text": TextAreaWidget(),
         }
+
+class AdminChantForm(forms.ModelForm):
+    class Meta:
+        model = Chant
+        fields = "__all__"
+        widgets = {
+            "volpiano": VolpianoAreaWidget(),
+            "marginalia": TextInputWidget(),
+            "position": TextInputWidget(),
+            "cantus_id": TextInputWidget(),
+            "melody_id": TextInputWidget(),
+            "mode": TextInputWidget(),
+            "finalis": TextInputWidget(),
+            "differentia": TextInputWidget(),
+            "extra": TextInputWidget(),
+            "image_link": TextInputWidget(),
+            "indexing_notes": TextAreaWidget(),
+            "manuscript_full_text_std_proofread": CheckboxWidget(),
+            "manuscript_full_text_proofread": CheckboxWidget(),
+            "volpiano_proofread": CheckboxWidget(),
+            "manuscript_syllabized_full_text": TextAreaWidget(),
+            "chant_range": VolpianoAreaWidget(),
+            "siglum": TextInputWidget(),
+            "addendum": TextInputWidget(),
+            "differentia_new": TextInputWidget(),
+        }
+
+    manuscript_full_text_std_spelling = forms.CharField(
+        required=True,
+        widget=TextAreaWidget,
+        help_text="Manuscript full text with standardized spelling. Enter the words "
+        "according to the manuscript but normalize their spellings following "
+        "Classical Latin forms. Use upper-case letters for proper nouns, "
+        'the first word of each chant, and the first word after "Alleluia" for '
+        "Mass Alleluias. Punctuation is omitted.",
+    )
+
+    folio = forms.CharField(
+        required=True,
+        widget=TextInputWidget,
+        help_text="Binding order",
+    )
+
+    c_sequence = forms.CharField(
+        required=True,
+        widget=TextInputWidget,
+        help_text="Each folio starts with '1'.",
+    )
+
+    feast = forms.ModelChoiceField(
+        queryset=Feast.objects.all().order_by("name"),
+        required=False,
+    )
+    feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+
+    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
+    # instead of [name] + description
+    office = NameModelChoiceField(
+        queryset=Office.objects.all().order_by("name"),
+        required=False,
+    )
+    office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+
+    # We use NameModelChoiceField here so the dropdown list of genres displays the name
+    # instead of [name] + description
+    genre = NameModelChoiceField(
+        queryset=Genre.objects.all().order_by("name"), required=False
+    )
+    genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
+
+    proofread_by = forms.ModelMultipleChoiceField(
+        queryset=get_user_model()
+        .objects.filter(Q(groups__name="project manager") | Q(groups__name="editor"))
+        .order_by("last_name"),
+        required=False,
+    )
+    proofread_by.widget.attrs.update(
+        {"class": "form-control custom-select custom-select-sm"}
+    )

--- a/django/cantusdb_project/main_app/widgets.py
+++ b/django/cantusdb_project/main_app/widgets.py
@@ -1,7 +1,6 @@
 from django.forms.widgets import TextInput, Select, Textarea, CheckboxInput
 from django.utils.safestring import mark_safe
 
-
 class TextInputWidget(TextInput):
     def __init__(self):
         self.attrs = {"class": "form-control form-control-sm"}

--- a/django/cantusdb_project/main_app/widgets.py
+++ b/django/cantusdb_project/main_app/widgets.py
@@ -1,4 +1,5 @@
 from django.forms.widgets import TextInput, Select, Textarea, CheckboxInput
+from django.utils.safestring import mark_safe
 
 
 class TextInputWidget(TextInput):
@@ -42,3 +43,20 @@ class VolpianoInputWidget(TextInput):
 
 class CheckboxWidget(CheckboxInput):
     pass
+
+
+class AdminTextAreaWidget(Textarea):
+    def __init__(self):
+        self.attrs = {"class": "form-control", "rows": 10, "cols": 75}
+
+    def render(self, name, value, attrs=None, renderer=None):
+        return super().render(name, value, attrs=self.attrs) + mark_safe(
+            '<span style="color: red; font-weight: bold;"> &nbsp;* </span>'
+        )
+
+
+class AdminTextInputWidget(TextInputWidget):
+    def render(self, name, value, attrs=None, renderer=None):
+        return super().render(name, value) + mark_safe(
+            '<span style="color: red; font-weight: bold;"> &nbsp;* </span>'
+        )

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -10,6 +10,7 @@ from main_app.models import Source
 class SourceInline(admin.TabularInline):
     model = Source.current_editors.through
     raw_id_fields = ["source"]
+    verbose_name_plural = "Sources assigned to User"
 
 
 class UserAdmin(BaseUserAdmin):
@@ -102,6 +103,7 @@ class UserAdmin(BaseUserAdmin):
     # order the list of users by email
     ordering = ("email",)
     filter_horizontal = ("groups",)
+    exclude = ("current_editors",)
     inlines = [SourceInline]
 
 


### PR DESCRIPTION
This PR includes several additions/modifications to the Admin area that are mentioned in issue #800 to improve usability. 
Changes:
- have required fields marked with asterisks and bold
- display relevant columns as possible are included on the list pages for easy sorting/finding using (`list_display`)
- add search boxes for remaining models that didn't have one previously
- add filter options to chant/sequence models by office and genre (`list_filter`)
- chant and sequence page: `raw_id_fields` allow searching for source and feast
- use volpiano widgets for volpiano fields
- use checkbox widgets for booleanfields
- display Chant/Sequence source siglum as column in object list page
- order Chant and Sequence list page by source siglum
- change header name for sources user can edit inline on user admin page

Considerations:
Currently, we have many fields that are exluded from the model views ( Ex: "created_by", "last_updated_by", etc) I think some of these fields should instead be `readonly_fields` 

There is still improvement to be done on the user admin page, but this should be a good step in the right direction.