### PR TITLE
Re-add "restart: always" to docker-compose.yml

### DIFF
--- a/django/cantusdb_project/main_app/widgets.py
+++ b/django/cantusdb_project/main_app/widgets.py
@@ -1,6 +1,7 @@
 from django.forms.widgets import TextInput, Select, Textarea, CheckboxInput
 from django.utils.safestring import mark_safe
 
+
 class TextInputWidget(TextInput):
     def __init__(self):
         self.attrs = {"class": "form-control form-control-sm"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     env_file: ./config/envs/dev_env
     ports:
       - 3000:3000
+    restart: always
     depends_on:
       - postgres
 
@@ -26,6 +27,7 @@ services:
       - media_volume:/resources/media
       - certbot_data:/var/www/certbot/:ro
       - certificates:/etc/nginx/ssl/:ro
+    restart: always
     depends_on:
       - django
 
@@ -34,6 +36,7 @@ services:
     volumes:
       - certbot_data:/var/www/certbot/:rw
       - certificates:/etc/letsencrypt/:rw
+    restart: always
 
   postgres:
     build:
@@ -41,6 +44,7 @@ services:
     env_file: ./config/envs/dev_env
     volumes:
       - postgres_data:/var/lib/postgresql/data/
+    restart: always
 
 volumes:
   postgres_data:


### PR DESCRIPTION
This PR fixes #899, adding `restart: always` to each container in `docker-compose.yml`.

It basically replicates the changes made in #854. I tested the changes locally, and upon killing the django container, the container restarts right away and the app continues to work even after the tiny disruption.

Also, Black wanted to make some changes to formatting in one of the files, so that change also came along for the ride.