### PR TITLE
Remove `<meta content="noindex">` from templates

### DIFF
--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -2,8 +2,6 @@
 <html>
 
 <head>
-    <!-- prevent search engines from indexing the staging website, remove for production -->
-    <meta name="robots" content="noindex">
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
         integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -5,7 +5,6 @@
 
 <head>
     <!-- Required meta tags -->
-    <meta name="robots" content="noindex">
     <meta name="google-site-verification" content="EwxpNpZ_ZOQnetVVLELGn5-aD_beT3EQqUuI6glkArI" />
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, 


### PR DESCRIPTION
Fixes #466. This is a good thing, because we are currently instructing Google/etc. not to crawl NewCantus Production.