### PR TITLE
content overview: add tabs for models and display all objects ordered by date created

### DIFF
--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -5,79 +5,98 @@
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <h3>Content Overview</h3>
-    <table class="table table-sm small table-bordered">
-        <small>Displaying the <b>50</b> most recently updated objects</small>
-        <div style="height:10px;"></div>
-        <thead>
-            <tr>
-                <th scope="col" class="text-wrap" style="text-align:center">Title / Manuscript Full Text / Name</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Type</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Creation Date</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Creator</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Last Updated Date</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Last Updated By</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Operations</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for object in objects %}
+
+    <div class="row justify-content-center">
+        {% for model_name in models %}
+            <div class="col-auto">
+                {% if model_name == selected_model_name %}
+                    <b>{{ model_name|capfirst }}</b>
+                {% else %}
+                    <a href="?model={{ model_name }}">{{ model_name|capfirst }}</a>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+    <div style="height:10px;"></div>
+    {% if selected_model_name %}
+        <table class="table table-sm small table-bordered">
+            <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
+                {{ selected_model_name|capfirst }}</b></small>
+            <thead>
                 <tr>
-                    {% if object.title %}
+                    <th scope="col" class="text-wrap" style="text-align:center">Title / Manuscript Full Text / Name</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Type</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Creation Date</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Creator</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Last Updated Date</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Last Updated By</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Operations</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for object in page_obj %}
+                    <tr>
+                        {% if object.title %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
+                            </td>
+                        {% elif object.manuscript_full_text_std_spelling %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object.manuscript_full_text_std_spelling|truncatechars:30 }}</b></a>
+                            </td>
+                        {% elif object.name %}
+                            <td class="text-wrap" style="text-align:center">
+                                {% if object|classname == "Notation" or object|classname == "Segment" or object|classname == "RismSiglum" %}
+                                    <b>{{ object.name|truncatechars:30 }}
+                                {% else %}
+                                    <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                {% endif %}
+                            </td>
+                        {% elif object.full_name %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
+                            </td>
+                        {% else %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
+                            </td>
+                        {% endif %}
+                        <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
+                        <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
-                        </td>
-                    {% elif object.manuscript_full_text_std_spelling %}
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.manuscript_full_text_std_spelling|truncatechars:30 }}</b></a>
-                        </td>
-                    {% elif object.name %}
-                        <td class="text-wrap" style="text-align:center">
-                            {% if object|classname == "Notation" or object|classname == "Provenance" or object|classname == "Segment" %}
-                                <b>{{ object.name|truncatechars:30 }}
+                            {% if object.created_by is None %}
+                                {{ object.created_by }}
                             {% else %}
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                <a href="{% url 'admin:users_user_change' object.created_by.id %}">
+                                    {{ object.created_by }}
+                                </a>
                             {% endif %}
                         </td>
-                    {% elif object.full_name %}
+                        <td class="text-wrap" style="text-align:center">{{ object.date_updated|date:'Y-m-d H:i' }}</td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
-                        </td>
-                    {% else %}
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
-                        </td>
-                    {% endif %}
-                    <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
-                    <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if object.created_by is None %}
-                            {{ object.created_by }}
-                        {% else %}
-                            <a href="{% url 'admin:users_user_change' object.created_by.id %}">
-                                {{ object.created_by }}
-                            </a>
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">{{ object.date_updated|date:'Y-m-d H:i' }}</td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if object.last_updated_by is None %}
-                            {{ object.last_updated_by }}
-                        {% else %}
-                            <a href="{% url 'admin:users_user_change' object.last_updated_by.id %}">
+                            {% if object.last_updated_by is None %}
                                 {{ object.last_updated_by }}
-                            </a>
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% with class=object|classname %}
-                            <a href={% url class|admin_url_name:"change" object.id %}><b>Edit</b></a>
-                            |
-                            <a href={% url class|admin_url_name:"delete" object.id %}><b>Delete</b></a>
-                        {% endwith %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+                            {% else %}
+                                <a href="{% url 'admin:users_user_change' object.last_updated_by.id %}">
+                                    {{ object.last_updated_by }}
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% with class=object|classname %}
+                                <a href={% url class|admin_url_name:"change" object.id %}><b>Edit</b></a>
+                                |
+                                <a href={% url class|admin_url_name:"delete" object.id %}><b>Delete</b></a>
+                            {% endwith %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% include "pagination.html" %}
+    {% else %}
+        <div style="height:10px;"></div>
+        Please select a model from the tabs to view the most recently updated objects.
+    {% endif %}
 </div>
 {% endblock %}

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -21,6 +21,7 @@ from .make_fakes import (
     make_fake_genre,
     make_fake_office,
     make_fake_provenance,
+    make_fake_notation,
     make_fake_rism_siglum,
     make_fake_segment,
     make_fake_sequence,
@@ -154,6 +155,9 @@ class PermissionsTest(TestCase):
 
         # SourceEditView
         response = self.client.get(f"/edit-source/{source.id}")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get("content-overview")
         self.assertEqual(response.status_code, 200)
 
     def test_permissions_contributor(self):
@@ -5132,3 +5136,78 @@ class IndexerRedirectTest(TestCase):
             reverse("redirect-indexer", args=[example_bad_indexer_id])
         )
         self.assertEqual(response_1.status_code, 404)
+
+
+class ContentOverviewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email="test@test.com")
+        self.user.set_password("pass")
+        self.user.save()
+        self.client = Client()
+
+        project_manager = Group.objects.get(name="project manager")
+        project_manager.user_set.add(self.user)
+        self.client.login(email="test@test.com", password="pass")
+
+    def test_templates_used(self):
+        response = self.client.get(reverse("content-overview"))
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "content_overview.html")
+
+    def test_project_manager_permission(self):
+        response = self.client.get(reverse("content-overview"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_content_overview_view_with_login_required(self):
+        self.client.logout()
+        response = self.client.get(reverse("content-overview"))
+        self.assertRedirects(response, "/login/?next=/content-overview/")
+
+    def test_content_overview_view_for_non_project_manager(self):
+        user = get_user_model().objects.create(email="non_project_manager@test.com")
+        user.set_password("pass")
+        user.save()
+        self.client.login(email="non_project_manager@test.com", password="pass")
+
+        response = self.client.get(reverse("content-overview"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_content_overview_view_selected_model(self):
+        response = self.client.get(reverse("content-overview"), {"model": "sources"})
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIsNotNone(response.context["models"])
+        models = response.context["models"]
+        self.assertIsNotNone(response.context["page_obj"])
+        page_obj = response.context["page_obj"]
+        self.assertEqual(response.context["selected_model_name"], "sources")
+
+    def test_source_selected_model(self):
+        source = make_fake_source(title="Test Source")
+        chant = make_fake_chant(incipit="Test Chant")
+        response = self.client.get(reverse("content-overview"), {"model": "sources"})
+        self.assertContains(response, f"<b>Sources</b>", html=True)
+        self.assertContains(
+            response,
+            f'<a href="?model=chants">Chants</a>',
+            html=True,
+        )
+        self.assertContains(response, "Test Source", html=True)
+        self.assertNotContains(response, "Test Chant", html=True)
+
+    def test_chant_selected_model(self):
+        source = make_fake_source(title="Test Source")
+        chant = make_fake_chant(manuscript_full_text_std_spelling="Test Chant")
+        response = self.client.get(reverse("content-overview"), {"model": "chants"})
+        self.assertContains(response, f"<b>Chants</b>", html=True)
+        self.assertContains(
+            response,
+            f'<a href="?model=sources">Sources</a>',
+            html=True,
+        )
+        self.assertContains(response, "Test Chant", html=True)
+        self.assertNotContains(response, "Test Source", html=True)

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -14,7 +14,6 @@ from main_app.models import (
     Office,
     Provenance,
     RismSiglum,
-    Segment,
     Sequence,
     Source,
 )
@@ -30,7 +29,6 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from typing import List
 from django.core.paginator import Paginator
-from django.db.models import Q
 
 
 @login_required

--- a/django/cantusdb_project/main_app/widgets.py
+++ b/django/cantusdb_project/main_app/widgets.py
@@ -1,6 +1,7 @@
 from django.forms.widgets import TextInput, Select, Textarea, CheckboxInput
 from django.utils.safestring import mark_safe
 
+
 class TextInputWidget(TextInput):
     def __init__(self):
         self.attrs = {"class": "form-control form-control-sm"}


### PR DESCRIPTION
In this PR, modifications are made to the content-overview page. Previously, this page would only display the last 50 updated objects in our database. The way this information was fetched was inefficient, making it impossible to scale to use all the objects in our database without affecting the page loading time. The solution implements tabs at the top of the page that represent the relevant models in our database. When the user clicks on one of these tabs, we will display all of the objects corresponding to this model ordered by "-date_created". The user can now paginate through all of these objects with 100 objects per page. Fixes #896 

![image](https://github.com/DDMAL/CantusDB/assets/71031342/a0f3f9eb-aa58-47e1-a030-f9a68b760a28)
