### PR TITLE
Improve formatting of Chant Search page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -233,9 +233,9 @@
                                     {% else %}
                                         <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
                                     {% endif %}
-                                    <p>
+                                    <div>
                                         {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
-                                    </p>           
+                                    </div>
                                 </td>
                                 <td class="text-wrap" style="text-align:center">
                                     {% if chant.feast__id %}

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -96,8 +96,8 @@
         }
 
         a:hover {
-            color: #CC3333;
-            text-decoration: none;
+            color: #922;
+            text-decoration: underline;
         }
 
         .footer h5 {


### PR DESCRIPTION
This PR fixes a couple of formatting-related things:
- It removes the unnecessary space at the bottom of certain cells on the Chant Search page - previously, they'd been wrapped in `<p>` tags, which was adding an extra space beneath (fixes #852)
- It changes the formatting of links: now, when you hover over them with your cursor, they become underlined rather than changing colour very slightly (as they'd previously done). This is an important accessibility fix that has been bothering me for a while.