### PR TITLE
Chant Create: prevent getting suggested chants for Cantus ID of 909000

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1182,6 +1182,12 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         cantus_id = latest_chant.cantus_id
         if cantus_id is None:
             return None
+        if cantus_id == "909000":
+            # 909000 is the Cantus ID for "Gloria patri", the most common Cantus ID in the
+            # database by about a factor of ~10 compared to the second most common Cantus ID.
+            # It takes too long to calculate suggested chants for this Cantus ID, and the
+            # results aren't particularly useful anyways.
+            return None
 
         suggested_chants = next_chants(cantus_id, display_unpublished=True)
 


### PR DESCRIPTION
This PR implements a change we just added as a hotfix to the production machine (see #912). On the Chant Create page, it was taking too long to calculate the list of suggested chants if the most recently entered chant had a Cantus ID of "909000" (i.e. if the previous chant was a Gloria Patri).

This is a temporary fix and should probably be removed once we've optimized the get-suggested-chants process. (It's possible, actually, that we'll want to keep it around - "Gloria patri" is a bit of a special case, and I don't think the suggestions we generate will be particularly useful just because Gloria Patri occurs all over the place in manuscripts) But for the time being, I feel it makes sense to integrate this change into the main CI pipeline.