### PR TITLE
Merge Staging into Production, 2023-Aug-02 edition

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -826,7 +826,7 @@ class AdminSourceForm(forms.ModelForm):
         widget=AdminTextInputWidget,
         help_text="Full Manuscript Identification (City, Archive, Shelf-mark)",
     )
-    title.widget.attrs.update({"style": "width: 400px;"})
+    title.widget.attrs.update({"style": "width: 610px;"})
 
     siglum = forms.CharField(
         required=True,

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -826,6 +826,7 @@ class AdminSourceForm(forms.ModelForm):
         widget=AdminTextInputWidget,
         help_text="Full Manuscript Identification (City, Archive, Shelf-mark)",
     )
+    title.widget.attrs.update({"style": "width: 400px;"})
 
     siglum = forms.CharField(
         required=True,

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -233,9 +233,9 @@
                                     {% else %}
                                         <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
                                     {% endif %}
-                                    <p>
+                                    <div>
                                         {{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}
-                                    </p>           
+                                    </div>
                                 </td>
                                 <td class="text-wrap" style="text-align:center">
                                     {% if chant.feast__id %}

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -5,79 +5,98 @@
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <h3>Content Overview</h3>
-    <table class="table table-sm small table-bordered">
-        <small>Displaying the <b>50</b> most recently updated objects</small>
-        <div style="height:10px;"></div>
-        <thead>
-            <tr>
-                <th scope="col" class="text-wrap" style="text-align:center">Title / Manuscript Full Text / Name</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Type</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Creation Date</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Creator</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Last Updated Date</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Last Updated By</th>
-                <th scope="col" class="text-wrap" style="text-align:center">Operations</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for object in objects %}
+
+    <div class="row justify-content-center">
+        {% for model_name in models %}
+            <div class="col-auto">
+                {% if model_name == selected_model_name %}
+                    <b>{{ model_name|capfirst }}</b>
+                {% else %}
+                    <a href="?model={{ model_name }}">{{ model_name|capfirst }}</a>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+    <div style="height:10px;"></div>
+    {% if selected_model_name %}
+        <table class="table table-sm small table-bordered">
+            <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
+                {{ selected_model_name|capfirst }}</b></small>
+            <thead>
                 <tr>
-                    {% if object.title %}
+                    <th scope="col" class="text-wrap" style="text-align:center">Title / Manuscript Full Text / Name</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Type</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Creation Date</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Creator</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Last Updated Date</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Last Updated By</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Operations</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for object in page_obj %}
+                    <tr>
+                        {% if object.title %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
+                            </td>
+                        {% elif object.manuscript_full_text_std_spelling %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object.manuscript_full_text_std_spelling|truncatechars:30 }}</b></a>
+                            </td>
+                        {% elif object.name %}
+                            <td class="text-wrap" style="text-align:center">
+                                {% if object|classname == "Notation" or object|classname == "Segment" or object|classname == "RismSiglum" %}
+                                    <b>{{ object.name|truncatechars:30 }}
+                                {% else %}
+                                    <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                {% endif %}
+                            </td>
+                        {% elif object.full_name %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
+                            </td>
+                        {% else %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
+                            </td>
+                        {% endif %}
+                        <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
+                        <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
-                        </td>
-                    {% elif object.manuscript_full_text_std_spelling %}
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.manuscript_full_text_std_spelling|truncatechars:30 }}</b></a>
-                        </td>
-                    {% elif object.name %}
-                        <td class="text-wrap" style="text-align:center">
-                            {% if object|classname == "Notation" or object|classname == "Provenance" or object|classname == "Segment" %}
-                                <b>{{ object.name|truncatechars:30 }}
+                            {% if object.created_by is None %}
+                                {{ object.created_by }}
                             {% else %}
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                <a href="{% url 'admin:users_user_change' object.created_by.id %}">
+                                    {{ object.created_by }}
+                                </a>
                             {% endif %}
                         </td>
-                    {% elif object.full_name %}
+                        <td class="text-wrap" style="text-align:center">{{ object.date_updated|date:'Y-m-d H:i' }}</td>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
-                        </td>
-                    {% else %}
-                        <td class="text-wrap" style="text-align:center">
-                            <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
-                        </td>
-                    {% endif %}
-                    <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
-                    <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if object.created_by is None %}
-                            {{ object.created_by }}
-                        {% else %}
-                            <a href="{% url 'admin:users_user_change' object.created_by.id %}">
-                                {{ object.created_by }}
-                            </a>
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">{{ object.date_updated|date:'Y-m-d H:i' }}</td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% if object.last_updated_by is None %}
-                            {{ object.last_updated_by }}
-                        {% else %}
-                            <a href="{% url 'admin:users_user_change' object.last_updated_by.id %}">
+                            {% if object.last_updated_by is None %}
                                 {{ object.last_updated_by }}
-                            </a>
-                        {% endif %}
-                    </td>
-                    <td class="text-wrap" style="text-align:center">
-                        {% with class=object|classname %}
-                            <a href={% url class|admin_url_name:"change" object.id %}><b>Edit</b></a>
-                            |
-                            <a href={% url class|admin_url_name:"delete" object.id %}><b>Delete</b></a>
-                        {% endwith %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+                            {% else %}
+                                <a href="{% url 'admin:users_user_change' object.last_updated_by.id %}">
+                                    {{ object.last_updated_by }}
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% with class=object|classname %}
+                                <a href={% url class|admin_url_name:"change" object.id %}><b>Edit</b></a>
+                                |
+                                <a href={% url class|admin_url_name:"delete" object.id %}><b>Delete</b></a>
+                            {% endwith %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% include "pagination.html" %}
+    {% else %}
+        <div style="height:10px;"></div>
+        Please select a model from the tabs to view the most recently updated objects.
+    {% endif %}
 </div>
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/full_index.html
+++ b/django/cantusdb_project/main_app/templates/full_index.html
@@ -2,8 +2,6 @@
 <html>
 
 <head>
-    <!-- prevent search engines from indexing the staging website, remove for production -->
-    <meta name="robots" content="noindex">
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
         integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -157,7 +157,8 @@ class PermissionsTest(TestCase):
         response = self.client.get(f"/edit-source/{source.id}")
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.get("content-overview")
+        # ContentOverview
+        response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 200)
 
     def test_permissions_contributor(self):
@@ -247,6 +248,9 @@ class PermissionsTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.get(f"/edit-source/{assigned_source.id}")
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
 
     def test_permissions_editor(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -342,6 +342,9 @@ class PermissionsTest(TestCase):
         response = self.client.get(f"/edit-source/{assigned_source.id}")
         self.assertEqual(response.status_code, 200)
 
+        response = self.client.get(reverse("content-overview"))
+        self.assertEqual(response.status_code, 403)
+
     def test_permissions_default(self):
         self.client.login(email="test@test.com", password="pass")
 
@@ -372,6 +375,9 @@ class PermissionsTest(TestCase):
 
         # SourceEditView
         response = self.client.get(f"/edit-source/{source.id}")
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
 
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -21,6 +21,7 @@ from .make_fakes import (
     make_fake_genre,
     make_fake_office,
     make_fake_provenance,
+    make_fake_notation,
     make_fake_rism_siglum,
     make_fake_segment,
     make_fake_sequence,
@@ -154,6 +155,9 @@ class PermissionsTest(TestCase):
 
         # SourceEditView
         response = self.client.get(f"/edit-source/{source.id}")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get("content-overview")
         self.assertEqual(response.status_code, 200)
 
     def test_permissions_contributor(self):
@@ -5132,3 +5136,78 @@ class IndexerRedirectTest(TestCase):
             reverse("redirect-indexer", args=[example_bad_indexer_id])
         )
         self.assertEqual(response_1.status_code, 404)
+
+
+class ContentOverviewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="project manager")
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email="test@test.com")
+        self.user.set_password("pass")
+        self.user.save()
+        self.client = Client()
+
+        project_manager = Group.objects.get(name="project manager")
+        project_manager.user_set.add(self.user)
+        self.client.login(email="test@test.com", password="pass")
+
+    def test_templates_used(self):
+        response = self.client.get(reverse("content-overview"))
+        self.assertTemplateUsed(response, "base.html")
+        self.assertTemplateUsed(response, "content_overview.html")
+
+    def test_project_manager_permission(self):
+        response = self.client.get(reverse("content-overview"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_content_overview_view_with_login_required(self):
+        self.client.logout()
+        response = self.client.get(reverse("content-overview"))
+        self.assertRedirects(response, "/login/?next=/content-overview/")
+
+    def test_content_overview_view_for_non_project_manager(self):
+        user = get_user_model().objects.create(email="non_project_manager@test.com")
+        user.set_password("pass")
+        user.save()
+        self.client.login(email="non_project_manager@test.com", password="pass")
+
+        response = self.client.get(reverse("content-overview"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_content_overview_view_selected_model(self):
+        response = self.client.get(reverse("content-overview"), {"model": "sources"})
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIsNotNone(response.context["models"])
+        models = response.context["models"]
+        self.assertIsNotNone(response.context["page_obj"])
+        page_obj = response.context["page_obj"]
+        self.assertEqual(response.context["selected_model_name"], "sources")
+
+    def test_source_selected_model(self):
+        source = make_fake_source(title="Test Source")
+        chant = make_fake_chant(incipit="Test Chant")
+        response = self.client.get(reverse("content-overview"), {"model": "sources"})
+        self.assertContains(response, f"<b>Sources</b>", html=True)
+        self.assertContains(
+            response,
+            f'<a href="?model=chants">Chants</a>',
+            html=True,
+        )
+        self.assertContains(response, "Test Source", html=True)
+        self.assertNotContains(response, "Test Chant", html=True)
+
+    def test_chant_selected_model(self):
+        source = make_fake_source(title="Test Source")
+        chant = make_fake_chant(manuscript_full_text_std_spelling="Test Chant")
+        response = self.client.get(reverse("content-overview"), {"model": "chants"})
+        self.assertContains(response, f"<b>Chants</b>", html=True)
+        self.assertContains(
+            response,
+            f'<a href="?model=sources">Sources</a>',
+            html=True,
+        )
+        self.assertContains(response, "Test Chant", html=True)
+        self.assertNotContains(response, "Test Source", html=True)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1182,6 +1182,12 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         cantus_id = latest_chant.cantus_id
         if cantus_id is None:
             return None
+        if cantus_id == "909000":
+            # 909000 is the Cantus ID for "Gloria patri", the most common Cantus ID in the
+            # database by about a factor of ~10 compared to the second most common Cantus ID.
+            # It takes too long to calculate suggested chants for this Cantus ID, and the
+            # results aren't particularly useful anyways.
+            return None
 
         suggested_chants = next_chants(cantus_id, display_unpublished=True)
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -350,7 +350,7 @@ class ChantDetailView(DetailView):
                 },
                 {
                     "name": "Portuguese Early Music Database",
-                    "initialism": "MMMO",
+                    "initialism": "PEM",
                     "base_url": "https://pemdatabase.eu",
                     "results_url": f"https://pemdatabase.eu/id/{chant.cantus_id}",
                     "results_count": len(

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -14,7 +14,6 @@ from main_app.models import (
     Office,
     Provenance,
     RismSiglum,
-    Segment,
     Sequence,
     Source,
 )
@@ -30,7 +29,6 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from typing import List
 from django.core.paginator import Paginator
-from django.db.models import Q
 
 
 @login_required

--- a/django/cantusdb_project/main_app/widgets.py
+++ b/django/cantusdb_project/main_app/widgets.py
@@ -1,6 +1,7 @@
 from django.forms.widgets import TextInput, Select, Textarea, CheckboxInput
 from django.utils.safestring import mark_safe
 
+
 class TextInputWidget(TextInput):
     def __init__(self):
         self.attrs = {"class": "form-control form-control-sm"}

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -5,7 +5,6 @@
 
 <head>
     <!-- Required meta tags -->
-    <meta name="robots" content="noindex">
     <meta name="google-site-verification" content="EwxpNpZ_ZOQnetVVLELGn5-aD_beT3EQqUuI6glkArI" />
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, 

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -96,8 +96,8 @@
         }
 
         a:hover {
-            color: #CC3333;
-            text-decoration: none;
+            color: #922;
+            text-decoration: underline;
         }
 
         .footer h5 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     env_file: ./config/envs/dev_env
     ports:
       - 3000:3000
+    restart: always
     depends_on:
       - postgres
 
@@ -26,6 +27,7 @@ services:
       - media_volume:/resources/media
       - certbot_data:/var/www/certbot/:ro
       - certificates:/etc/nginx/ssl/:ro
+    restart: always
     depends_on:
       - django
 
@@ -34,6 +36,7 @@ services:
     volumes:
       - certbot_data:/var/www/certbot/:rw
       - certificates:/etc/letsencrypt/:rw
+    restart: always
 
   postgres:
     build:
@@ -41,6 +44,7 @@ services:
     env_file: ./config/envs/dev_env
     volumes:
       - postgres_data:/var/lib/postgresql/data/
+    restart: always
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Pre-testing tasks:

- [x] update the staging server so we can test the new code - done!
- [x] run tests
- [x] ensure password reset feature works - it works!

General/global Changes:
- [x] Our containers automatically restart if they go down for some reason
- [x] All of our pages used to tell crawlers not to index them, meaning we were telling Google not to include these pages in search results. This has been removed, so Google can now start crawling the website!
- [x] When you hover your cursor over a link, the link now becomes underlined while remaining the same colour. (previously, links would only change colour (very, very slightly!) when hovered over)

Pages where changes took place:
- [x] Admin Area, Source Edit page
  - [x] the "Title" field is much wider now
- [x] Chant Create
  - [x] When the most recently created chant in the source has a Cantus ID of `909000`, we don't try to generate a list of suggested chants
- [x] Chant Detail
  - [x] Concordances summary: previously, the initialism for Portuguese Early Music Database read "MMMO". It now reads "PEM"
- [x] Chant Search
  - [x] There was an extra/unnecessary space near the bottom of each cell that has been removed. This space has been removed.
- [x] Content Overview
  - [x] There are now different tabs for each kind of object in the database, allowing project managers to view all recently-changed chants separately from all recently-changed sources, etc.
  - [x] 100 results are now displayed per page (rather than 50), and results are paginated, allowing more to be loaded if necessary