### PR TITLE
update widgets for indexer fields in source admin area

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -863,15 +863,43 @@ class AdminSourceForm(forms.ModelForm):
             | Q(groups__name="editor")
             | Q(groups__name="contributor")
         )
-        .order_by("last_name"),
+        .order_by("full_name"),
         required=False,
-        widget=FilteredSelectMultiple(verbose_name="Century", is_stacked=False),
+        widget=FilteredSelectMultiple(verbose_name="current editors", is_stacked=False),
+    )
+
+    inventoried_by = forms.ModelMultipleChoiceField(
+        queryset=get_user_model().objects.all().order_by("full_name"),
+        required=False,
+        widget=FilteredSelectMultiple(verbose_name="inventoried by", is_stacked=False),
+    )
+
+    full_text_entered_by = forms.ModelMultipleChoiceField(
+        queryset=get_user_model().objects.all().order_by("full_name"),
+        required=False,
+        widget=FilteredSelectMultiple(
+            verbose_name="full text entered by", is_stacked=False
+        ),
     )
 
     melodies_entered_by = forms.ModelMultipleChoiceField(
         queryset=get_user_model().objects.all().order_by("full_name"),
         required=False,
-        widget=FilteredSelectMultiple(verbose_name="Century", is_stacked=False),
+        widget=FilteredSelectMultiple(
+            verbose_name="melodies entered by", is_stacked=False
+        ),
+    )
+
+    proofreaders = forms.ModelMultipleChoiceField(
+        queryset=get_user_model().objects.all().order_by("full_name"),
+        required=False,
+        widget=FilteredSelectMultiple(verbose_name="proofreaders", is_stacked=False),
+    )
+
+    other_editors = forms.ModelMultipleChoiceField(
+        queryset=get_user_model().objects.all().order_by("full_name"),
+        required=False,
+        widget=FilteredSelectMultiple(verbose_name="other editors", is_stacked=False),
     )
 
     TRUE_FALSE_CHOICES_INVEN = ((True, "Complete"), (False, "Incomplete"))


### PR DESCRIPTION
Fixes #918. The correct headers are now displayed for the FilteredSelectMultiple widgets on the admin source detail pages. The list of available user names are now sorted alphabetically by full_name.