### PR TITLE
Improve the user admin area

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -15,7 +15,11 @@ from main_app.forms import (
 )
 
 # these fields should not be editable by all classes
-EXCLUDE = ("created_by", "last_updated_by", "json_info")
+EXCLUDE = (
+    "created_by",
+    "last_updated_by",
+    "json_info",
+)
 
 
 class BaseModelAdmin(admin.ModelAdmin):
@@ -74,8 +78,16 @@ class ChantAdmin(BaseModelAdmin):
 
 
 class FeastAdmin(BaseModelAdmin):
-    search_fields = ("name", "feast_code")
-    list_display = ("name", "month", "day", "feast_code")
+    search_fields = (
+        "name",
+        "feast_code",
+    )
+    list_display = (
+        "name",
+        "month",
+        "day",
+        "feast_code",
+    )
     form = AdminFeastForm
 
 
@@ -143,6 +155,7 @@ class SourceAdmin(BaseModelAdmin):
     search_fields = (
         "siglum",
         "title",
+        "id",
     )
     # from the Django docs:
     # Adding a ManyToManyField to this list will instead use a nifty unobtrusive JavaScript “filter” interface
@@ -161,6 +174,7 @@ class SourceAdmin(BaseModelAdmin):
     list_display = (
         "title",
         "siglum",
+        "id",
     )
 
     list_filter = (

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -878,3 +878,21 @@ class AdminSourceForm(forms.ModelForm):
     complete_inventory = forms.ChoiceField(
         choices=TRUE_FALSE_CHOICES_INVEN, required=False
     )
+
+
+class AdminUserForm(forms.ModelForm):
+    class Meta:
+        model = get_user_model()
+        fields = "__all__"
+
+    first_name = forms.CharField(
+        required=False,
+        help_text="We have full name, first name, and last name defined in our User model which can be seen "
+        "in the admin area, but we are only using full name to represent users.",
+    )
+
+    last_name = forms.CharField(
+        required=False,
+        help_text="We have full name, first name, and last name defined in our User model which can be seen "
+        "in the admin area, but we are only using full name to represent users.",
+    )

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -893,4 +893,10 @@ class AdminUserChangeForm(forms.ModelForm):
     )
     email.widget.attrs.update({"style": "width: 300px;"})
 
-    password = ReadOnlyPasswordHashField()
+    password = ReadOnlyPasswordHashField(
+        help_text=(
+            "Raw passwords are not stored, so there is no way to see "
+            "this user's password, but you can change the password "
+            'using <a href="../password/">this form</a>.'
+        )
+    )

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.forms import ReadOnlyPasswordHashField
 from .models import (
     Chant,
     Office,
@@ -881,19 +882,15 @@ class AdminSourceForm(forms.ModelForm):
     )
 
 
-class AdminUserForm(forms.ModelForm):
+class AdminUserChangeForm(forms.ModelForm):
     class Meta:
         model = get_user_model()
         fields = "__all__"
 
-    first_name = forms.CharField(
-        required=False,
-        help_text="We have full name, first name, and last name defined in our User model which can be seen "
-        "in the admin area, but we are only using full name to represent users.",
+    email = forms.CharField(
+        required=True,
+        widget=AdminTextInputWidget,
     )
+    email.widget.attrs.update({"style": "width: 300px;"})
 
-    last_name = forms.CharField(
-        required=False,
-        help_text="We have full name, first name, and last name defined in our User model which can be seen "
-        "in the admin area, but we are only using full name to represent users.",
-    )
+    password = ReadOnlyPasswordHashField()

--- a/django/cantusdb_project/main_app/widgets.py
+++ b/django/cantusdb_project/main_app/widgets.py
@@ -1,6 +1,7 @@
 from django.forms.widgets import TextInput, Select, Textarea, CheckboxInput
 from django.utils.safestring import mark_safe
 
+
 class TextInputWidget(TextInput):
     def __init__(self):
         self.attrs = {"class": "form-control form-control-sm"}

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from .models import *
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from main_app.models import Source
+from main_app.forms import AdminUserForm
 
 # Register your models here.
 
@@ -10,6 +11,7 @@ from main_app.models import Source
 class SourceInline(admin.TabularInline):
     model = Source.current_editors.through
     raw_id_fields = ["source"]
+    ordering = ("source__siglum",)
     verbose_name_plural = "Sources assigned to User"
 
 
@@ -17,10 +19,12 @@ class UserAdmin(BaseUserAdmin):
     readonly_fields = (
         "date_joined",
         "last_login",
+        "is_superuser",
     )
     # fields that are displayed on the user list page of the admin
     list_display = (
         "email",
+        "full_name",
         "first_name",
         "last_name",
         "institution",
@@ -54,9 +58,9 @@ class UserAdmin(BaseUserAdmin):
             "Permissions",
             {
                 "fields": (
-                    "is_staff",
                     "is_superuser",
                     "groups",
+                    "is_staff",
                 )
             },
         ),
@@ -96,15 +100,16 @@ class UserAdmin(BaseUserAdmin):
     )
     search_fields = (
         "email",
+        "full_name",
         "first_name",
         "last_name",
         "institution",
     )
-    # order the list of users by email
-    ordering = ("email",)
+    ordering = ("full_name",)
     filter_horizontal = ("groups",)
     exclude = ("current_editors",)
     inlines = [SourceInline]
+    form = AdminUserForm
 
 
 admin.site.register(User, UserAdmin)

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from .models import *
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from main_app.models import Source
-from main_app.forms import AdminUserForm
+from main_app.forms import AdminUserChangeForm
 
 # Register your models here.
 
@@ -19,7 +19,6 @@ class UserAdmin(BaseUserAdmin):
     readonly_fields = (
         "date_joined",
         "last_login",
-        "is_superuser",
     )
     # fields that are displayed on the user list page of the admin
     list_display = (
@@ -30,7 +29,12 @@ class UserAdmin(BaseUserAdmin):
         "institution",
     )
     # creates a filter on the right side of the page to filter users by group
-    list_filter = ("groups",)
+    list_filter = (
+        "groups",
+        "is_indexer",
+        "is_superuser",
+        "is_staff",
+    )
     fieldsets = (
         (
             "Account info",
@@ -51,7 +55,9 @@ class UserAdmin(BaseUserAdmin):
                     "institution",
                     ("city", "country"),
                     "website",
-                )
+                ),
+                "description": "We have full name, first name, and last name defined in our User model which can be seen "
+                "in the admin area, but we are only using full name to represent users.",
             },
         ),
         (
@@ -61,6 +67,7 @@ class UserAdmin(BaseUserAdmin):
                     "is_superuser",
                     "groups",
                     "is_staff",
+                    "is_indexer",
                 )
             },
         ),
@@ -91,9 +98,10 @@ class UserAdmin(BaseUserAdmin):
             "Permissions",
             {
                 "fields": (
-                    "is_staff",
                     "is_superuser",
                     "groups",
+                    "is_staff",
+                    "is_indexer",
                 )
             },
         ),
@@ -109,7 +117,7 @@ class UserAdmin(BaseUserAdmin):
     filter_horizontal = ("groups",)
     exclude = ("current_editors",)
     inlines = [SourceInline]
-    form = AdminUserForm
+    form = AdminUserChangeForm
 
 
 admin.site.register(User, UserAdmin)

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -56,8 +56,9 @@ class UserAdmin(BaseUserAdmin):
                     ("city", "country"),
                     "website",
                 ),
-                "description": "We have full name, first name, and last name defined in our User model which can be seen "
-                "in the admin area, but we are only using full name to represent users.",
+                "description": "You can enter a user's first and last name, but these are "
+                "only ever displayed in the Admin area - on the main site, users' "
+                "full names are always used rather than their first and last name.",
             },
         ),
         (


### PR DESCRIPTION
This PR makes some changes to the user admin area:
- ad "id" field to search and list display (source admin)
- add custom change user form to display email required widget
- order sources assigned to user alphabetically by siglum
- add "is_indexer", "is_superuser", "is_staff" to list filter
- add indexer to user edit and user add form
- order users in list page by full name

Towards #800, #879 