### PR TITLE
Add contributor information to source and chant detail sidebars

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -534,7 +534,9 @@
 
                                 {{ source.indexing_notes|default_if_none:"" }}
                                 <br>
-                                Contributor: <a href="#" onclick="return false;"></a>
+                                {% if source.created_by %}
+                                    Contributor: <a href={% url 'user-detail' source.created_by.id %}><b>{{ source.created_by.full_name }}</b></a>
+                                {% endif %}
                             </small>
                         </div>
                     </div>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -263,7 +263,9 @@
                         {% endif %}
                         {{ source.indexing_notes|default_if_none:"" }}
                         <br>
-                        Contributor: <a href=""></a>
+                        {% if source.created_by %}
+                            Contributor: <a href={% url 'user-detail' source.created_by.id %}><b>{{ source.created_by.full_name }}</b></a>
+                        {% endif %}
                     </small>
                 </div>
             </div>


### PR DESCRIPTION
Resolves #737. We have recently discovered that the `created_by` information from OldCantus comes from the "uid" field from the json-node information. We have now completed syncing this information in #825 so we can access this information to display in the source and chant detail page sidebars.

Separating some of the discussion from #737 into #931