### PR TITLE
Create postgres backup scripts and set up cron jobs

### DIFF
--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -1,0 +1,11 @@
+######################
+# CantusDB Cron Jobs #
+######################
+
+# Note: This is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
+
+# min   hour    day     month   weekday command
+0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/daily.sh
+0       4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
+0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
+0       4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -10,4 +10,4 @@
 20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
 30      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       1       */6     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org
+50      4       1       */6     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d cantusdatabase.org

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -5,10 +5,10 @@
 # Note: This is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
 
 # min   hour    day     month   weekday command
-0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/daily.sh
-0       4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
-0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
-0       4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
-0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
-0       4       1       *       *       /usr/local/bin/docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org
+0        4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/daily.sh
+5        4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
+10       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
+15       4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
+20       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
+25       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
+30       4       1       *       *       /usr/local/bin/docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -11,4 +11,4 @@
 15       4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
 20       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
 25       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
-30       4       1       *       *       /usr/local/bin/docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org
+30       4       1       *       *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -10,4 +10,4 @@
 20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
 30      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       1       */6     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d cantusdatabase.org
+50      4       1       */2     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d cantusdatabase.org

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -6,9 +6,8 @@
 
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/daily.sh
-5       4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
-10      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
-15      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
-20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-25      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
-30      4       1       */6     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org
+10      4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
+20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
+30      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
+40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
+50      4       1       */6     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -5,10 +5,10 @@
 # Note: This is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
 
 # min   hour    day     month   weekday command
-0        4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/daily.sh
-5        4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
-10       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
-15       4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
-20       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-25       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
-30       4       1       *       *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org
+0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/daily.sh
+5       4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
+10      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
+15      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
+20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
+25      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
+30      4       1       */6     *       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -9,3 +9,6 @@
 0       4       *       *       0       bash /home/ubuntu/code/CantusDB/cron/postgres/weekly.sh
 0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
 0       4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
+0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
+0       4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields
+0       4       1       *       *       /usr/local/bin/docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ --dry-run -d cantusdatabase.org

--- a/cron/management/manage.sh
+++ b/cron/management/manage.sh
@@ -7,4 +7,4 @@
 DOCKER_COMPOSE_FILE=/home/ubuntu/code/CantusDB/docker-compose.yml   # This is the path to the docker-compose file.
 COMMAND=$1                                                          # This is the command to execute.
 
-/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec django python manage.py $COMMAND
+/usr/local/bin/docker-compose -f $DOCKER_COMPOSE_FILE exec django python manage.py $COMMAND

--- a/cron/management/manage.sh
+++ b/cron/management/manage.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script executes the manage.py script in the django docker container.
+
+# Note: This script is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
+
+DOCKER_COMPOSE_FILE=/home/ubuntu/code/CantusDB/docker-compose.yml   # This is the path to the docker-compose file.
+COMMAND=$1                                                          # This is the command to execute.
+
+/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec django python manage.py $COMMAND

--- a/cron/postgres/daily.sh
+++ b/cron/postgres/daily.sh
@@ -10,6 +10,6 @@ BACKUP_DIR=/home/ubuntu/backups/postgres/daily                      # This is th
 RETENTION_COUNT=7                                                   # This is the number of daily backups to keep.
 
 mkdir -p $BACKUP_DIR
-/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+/usr/local/bin/docker-compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
 FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
 [[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/daily.sh
+++ b/cron/postgres/daily.sh
@@ -1,0 +1,15 @@
+#!/bin.bash
+
+# This script creates a compressed SQL dump of the database in the /home/ubuntu/backups/postgres/daily directory.
+# It then deletes any daily backups so that only 7 daily backups are retained.
+
+# Note: This script is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
+
+DOCKER_COMPOSE_FILE=/home/ubuntu/code/CantusDB/docker-compose.yml   # This is the path to the docker-compose file.
+BACKUP_DIR=/home/ubuntu/backups/postgres/daily                      # This is the directory where the daily backups will be stored.
+RETENTION_COUNT=7                                                   # This is the number of daily backups to keep.
+
+mkdir -p $BACKUP_DIR
+/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
+[[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/monthly.sh
+++ b/cron/postgres/monthly.sh
@@ -10,6 +10,6 @@ BACKUP_DIR=/home/ubuntu/backups/postgres/monthly                     # This is t
 RETENTION_COUNT=12                                                  # This is the number of monthly backups to keep.
 
 mkdir -p $BACKUP_DIR
-/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+/usr/local/bin/docker-compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
 FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
 [[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/monthly.sh
+++ b/cron/postgres/monthly.sh
@@ -1,0 +1,15 @@
+#!/bin.bash
+
+# This script creates a compressed SQL dump of the database in the /home/ubuntu/backups/postgres/monthly directory.
+# It then deletes any monthly backups so that only 12 monthly backups are retained.
+
+# Note: This script is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
+
+DOCKER_COMPOSE_FILE=/home/ubuntu/code/CantusDB/docker-compose.yml   # This is the path to the docker-compose file.
+BACKUP_DIR=/home/ubuntu/backups/postgres/monthly                     # This is the directory where the monthly backups will be stored.
+RETENTION_COUNT=12                                                  # This is the number of monthly backups to keep.
+
+mkdir -p $BACKUP_DIR
+/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
+[[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/weekly.sh
+++ b/cron/postgres/weekly.sh
@@ -10,6 +10,6 @@ BACKUP_DIR=/home/ubuntu/backups/postgres/weekly                     # This is th
 RETENTION_COUNT=8                                                   # This is the number of weekly backups to keep.
 
 mkdir -p $BACKUP_DIR
-/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+/usr/local/bin/docker-compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
 FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
 [[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/weekly.sh
+++ b/cron/postgres/weekly.sh
@@ -1,0 +1,15 @@
+#!/bin.bash
+
+# This script creates a compressed SQL dump of the database in the /home/ubuntu/backups/postgres/weekly directory.
+# It then deletes any weekly backups so that only 8 weekly backups are retained.
+
+# Note: This script is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
+
+DOCKER_COMPOSE_FILE=/home/ubuntu/code/CantusDB/docker-compose.yml   # This is the path to the docker-compose file.
+BACKUP_DIR=/home/ubuntu/backups/postgres/weekly                     # This is the directory where the weekly backups will be stored.
+RETENTION_COUNT=8                                                   # This is the number of weekly backups to keep.
+
+mkdir -p $BACKUP_DIR
+/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
+[[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/yearly.sh
+++ b/cron/postgres/yearly.sh
@@ -1,0 +1,15 @@
+#!/bin.bash
+
+# This script creates a compressed SQL dump of the database in the /home/ubuntu/backups/postgres/yearly directory.
+# It then deletes any yearly backups so that only 10 yearly backups are retained.
+
+# Note: This script is set up to run on the production server. If you want to run it on your local machine, you will need to change the paths.
+
+DOCKER_COMPOSE_FILE=/home/ubuntu/code/CantusDB/docker-compose.yml   # This is the path to the docker-compose file.
+BACKUP_DIR=/home/ubuntu/backups/postgres/yearly                     # This is the directory where the yearly backups will be stored.
+RETENTION_COUNT=10                                                  # This is the number of yearly backups to keep.
+
+mkdir -p $BACKUP_DIR
+/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
+[[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE

--- a/cron/postgres/yearly.sh
+++ b/cron/postgres/yearly.sh
@@ -10,6 +10,6 @@ BACKUP_DIR=/home/ubuntu/backups/postgres/yearly                     # This is th
 RETENTION_COUNT=10                                                  # This is the number of yearly backups to keep.
 
 mkdir -p $BACKUP_DIR
-/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
+/usr/local/bin/docker-compose -f $DOCKER_COMPOSE_FILE exec postgres pg_dump cantusdb -U cantusdb | gzip > $BACKUP_DIR/$(date "+%Y-%m-%dT%H:%M:%S").sql.gz
 FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/* | tail -n +$(($RETENTION_COUNT + 1)))
 [[ ! -z "$FILES_TO_REMOVE" ]] && rm $FILES_TO_REMOVE


### PR DESCRIPTION
Resolves #395, #870, #740. 

Created database backup scripts to be run outside container through cron. The scripts are currently set up to keep 7 daily backups, 8 weekly backups, and 12 monthly backups.

Runs `populate_next_chant_fields` and `populate_is_last_chant_in_feast` management commands monthly.

Updates certificates every 6 months.