### PR TITLE
header: change link from /field-descriptions/ to /description/

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -227,7 +227,7 @@
                             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                                 <a class="dropdown-item" href="{% url 'genre-list' %}">Genre abbreviations</a>
                                 <a class="dropdown-item" href="{% url 'office-list' %}">Office/Mass abbreviations</a>
-                                <a class="dropdown-item" href="/field-descriptions/">Fields</a>
+                                <a class="dropdown-item" href="/description/">Fields</a>
                             </div>
                         </li>
 


### PR DESCRIPTION
fixes #677; see also #929.

On both staging and production, I duplicated the flatpage at /field-descriptions/ so that it can be seen at /description/ too. Once this change makes it to those servers, we can delete the old page that's at /field-descriptions/