### PR TITLE
chant create: set up "copy full text below" button

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <title>Create Chant | Cantus Manuscript Database</title>
+<script src="/static/js/chant_create.js"></script>
 <div class="container">
     <div class="row">
         <div class="mr-3 p-3 col-md-8 bg-white rounded">
@@ -169,6 +170,12 @@
                                 For more information, consult <a href="/field-descriptions/#Fulltext" target="_blank">Fields and Content Descriptions</a>.
                             </small>
                         </p>
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-4">
+                        <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
                     </div>
                 </div>
 

--- a/django/cantusdb_project/static/js/chant_create.js
+++ b/django/cantusdb_project/static/js/chant_create.js
@@ -1,0 +1,10 @@
+window.addEventListener("load", function () {
+    const copyTextButton = document.getElementById("copyFullTextBelow");
+    if (copyTextButton) {
+        copyTextButton.addEventListener("click", copyText);
+    }
+    function copyText() {
+        const standardText = document.getElementById('id_manuscript_full_text_std_spelling').value;
+        document.getElementById('id_manuscript_full_text').value = standardText;
+    }
+})


### PR DESCRIPTION
Fixes #914 by using the same code in chant_edit.html and chant_edit.js and creating a new chant_create.js to handle this event.