### PR TITLE
Source detail: Fix user permissions for source edit options 

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+{% load helper_tags %}
 <title>{{ source.title }} | Cantus Manuscript Database</title>
 <script src="/static/js/source_detail.js"></script>
 
@@ -269,7 +270,7 @@
                     </small>
                 </div>
             </div>
-            {% if not request.user.is_anonymous %}
+            {% if user_can_edit_chants %}
                 <div class="card mb-3 w-100">
                     <div class="card-header">
                         Source edit options
@@ -289,12 +290,16 @@
                                         </a>
                                     </li>
                                 {% endif %}
-                                <li>
-                                    <a href="{% url "source-edit" source.id%}">Edit source description</a>
-                                </li>
-                                <li>
-                                    <a href={% url 'admin:main_app_source_change' source.id %}>Manage source editors</a>
-                                </li>
+                                {% if user_can_edit_source %}
+                                    <li>
+                                        <a href="{% url "source-edit" source.id%}">Edit source description</a>
+                                    </li>
+                                {% endif %}
+                                {% if request.user.is_staff or request.user|has_group:"project_manager" %}
+                                    <li>
+                                        <a href={% url 'admin:main_app_source_change' source.id %}>Manage source editors</a>
+                                    </li>
+                                {% endif %}
                             </ul>
                         </small>
                     </div>

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -9,7 +9,10 @@ from django.http import HttpResponseRedirect
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
-from main_app.views.chant import get_feast_selector_options
+from main_app.views.chant import (
+    get_feast_selector_options,
+    user_can_edit_chants_in_source,
+)
 
 
 class SourceDetailView(DetailView):
@@ -19,6 +22,7 @@ class SourceDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         source = self.get_object()
+        user = self.request.user
         display_unpublished = self.request.user.is_authenticated
         if (source.published is False) and (not display_unpublished):
             raise PermissionDenied()
@@ -43,6 +47,9 @@ class SourceDetailView(DetailView):
             context["folios"] = folios
             # the options for the feast selector on the right, only chant sources have this
             context["feasts_with_folios"] = get_feast_selector_options(source, folios)
+
+        context["user_can_edit_chants"] = user_can_edit_chants_in_source(user, source)
+        context["user_can_edit_source"] = user_can_edit_source(user, source)
         return context
 
 
@@ -246,24 +253,7 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         source_id = self.kwargs.get(self.pk_url_kwarg)
         source = get_object_or_404(Source, id=source_id)
 
-        assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
-
-        # checks if the user is a project manager
-        is_project_manager = user.groups.filter(name="project manager").exists()
-        # checks if the user is an editor
-        is_editor = user.groups.filter(name="editor").exists()
-        # checks if the user is a contributor
-        is_contributor = user.groups.filter(name="contributor").exists()
-
-        if (
-            (is_project_manager)
-            or (is_editor and assigned_to_source)
-            or (is_editor and source.created_by == user)
-            or (is_contributor and source.created_by == user)
-        ):
-            return True
-        else:
-            return False
+        return user_can_edit_source(user, source)
 
     def form_valid(self, form):
         form.instance.last_updated_by = self.request.user
@@ -284,3 +274,25 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             new_editor.sources_user_can_edit.add(source)
 
         return HttpResponseRedirect(self.get_success_url())
+
+
+def user_can_edit_source(user, source):
+    source_id = source.id
+    assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
+
+    # checks if the user is a project manager
+    is_project_manager = user.groups.filter(name="project manager").exists()
+    # checks if the user is an editor
+    is_editor = user.groups.filter(name="editor").exists()
+    # checks if the user is a contributor
+    is_contributor = user.groups.filter(name="contributor").exists()
+
+    if (
+        (is_project_manager)
+        or (is_editor and assigned_to_source)
+        or (is_editor and source.created_by == user)
+        or (is_contributor and source.created_by == user)
+    ):
+        return True
+    else:
+        return False


### PR DESCRIPTION
This PR fixes the links that display on the source detail page. We are currently displaying all of the edit option links to any user that is logged in. This beings them to a 404 page when they don't have the correct permissions to view that page. 

The solution uses the `user_can_edit_chants_in_source` and `user_can_edit_source` helper functions defined in our chant and source views. On the source detail page, if the user can edit chants of a source the  "add new chant" and "full text & volpiano editor" links are displayed. If the user also has permission to edit the source, the "edit source description" link is displayed. Finally, if the user has staff status or is a project manager the "manage source editors" link will be displayed.

Fixes #801 
