### PR TITLE
Add context processor to distinguish between project environments in our templates

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -87,6 +87,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "main_app.context_processors.determine_project_environment",
             ],
         },
     },

--- a/django/cantusdb_project/main_app/context_processors.py
+++ b/django/cantusdb_project/main_app/context_processors.py
@@ -1,0 +1,18 @@
+import os
+
+
+def determine_project_environment(request):
+    project_environment = os.getenv("PROJECT_ENVIRONMENT", None)
+    if not (
+        project_environment == "DEVELOPMENT"
+        or project_environment == "STAGING"
+        or project_environment == "PRODUCTION"
+    ):
+        raise ValueError(
+            "The PROJECT_ENVIRONMENT environment variable must be either "
+            "DEVELOPMENT, STAGING, or PRODUCTION. "
+            f"Its current value is {project_environment}."
+        )
+    return {
+        "PROJECT_ENVIRONMENT": project_environment,
+    }

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -4,6 +4,17 @@
 <html lang="en">
 
 <head>
+    {% if PROJECT_ENVIRONMENT == "PRODUCTION" %}
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-YSGM9EQBGL"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            
+            gtag('config', 'G-YSGM9EQBGL');
+        </script>
+    {% endif %}
     <!-- Required meta tags -->
     <meta name="google-site-verification" content="EwxpNpZ_ZOQnetVVLELGn5-aD_beT3EQqUuI6glkArI" />
     <meta charset="utf-8">

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -5,6 +5,7 @@
 
 <head>
     {% if PROJECT_ENVIRONMENT == "PRODUCTION" %}
+        {# To ensure site is tracked in Google Analytics #}
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-YSGM9EQBGL"></script>
         <script>
@@ -14,6 +15,10 @@
             
             gtag('config', 'G-YSGM9EQBGL');
         </script>
+    {% endif %}
+    {% if not PROJECT_ENVIRONMENT == "PRODUCTION" %}
+        {# to ensure Google/etc. only indexes the main production site, and not staging #}
+        <meta name="robots" content="noindex">
     {% endif %}
     <!-- Required meta tags -->
     <meta name="google-site-verification" content="EwxpNpZ_ZOQnetVVLELGn5-aD_beT3EQqUuI6glkArI" />

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -463,6 +463,12 @@
             </div>
         </div>
         <div class="col-12" style="background-color: #CC3333;">
+            {% if PROJECT_ENVIRONMENT == "DEVELOPMENT" %}
+                <span title="Project Environment: Development">DEVELOPMENT</span>
+            {% endif %}
+            {% if PROJECT_ENVIRONMENT == "STAGING" %}
+                <span title="Project Environment: Staging">STAGING</span>
+            {% endif %}
             <a href="https://www.facebook.com/CantusDatabase">
                 <img src="{% static "facebookIcon.png" %}" alt="Facebook link" loading="lazy">
             </a>


### PR DESCRIPTION
This PR adds a custom context processor, allowing us to distinguish between different project environments (i.e. development vs. staging vs. production) in our templates.

The project environment context variable can be changed by updating the value of the `PROJECT_ENVIRONMENT` variable in the `dev_env` configuration file.

With this in place, this PR makes three additional changes:
- in the production environment, a gtag.js script is added so that traffic on the site is automatically reported to Google Analytics
- in non-production environments, `<meta name="robots" content="noindex">` is added, to prevent Google or other search engines from crawling the site and indexing pages on the staging server (fixes #937)
- in non-production environments, a small "STAGING" or "DEVELOPMENT" will appear at the very bottom of the footer, for easy verification of what `PROJECT_ENVIRONMENT` is set to.