### PR TITLE
Update permissions for View/Edit toggle in source detail and sequence detail pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -14,7 +14,7 @@
         {% include "global_search_bar.html" %}
     </object>
     <h3>{{ sequence.title }}</h3>
-    {% if user.is_authenticated %}
+    {% if user_can_edit_sequence %}
         <p>
             View | <a href="{% url "sequence-edit" sequence.id %}">Edit</a>
         </p>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -17,7 +17,7 @@
             {% endif %}
             <h3>{{ source.title }}</h3>
 
-            {% if user.is_authenticated %}
+            {% if user_can_edit_source %}
                 <p>
                     View | <a href="{% url 'source-edit' source.id %}">Edit</a>
                 </p>

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -6,6 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
+from main_app.views.chant import user_can_edit_chants_in_source
 
 
 class SequenceDetailView(DetailView):
@@ -20,6 +21,8 @@ class SequenceDetailView(DetailView):
     def get_context_data(self, **kwargs):
         sequence = self.get_object()
         source = sequence.source
+        user = self.request.user
+
         # if the sequence's source isn't published,
         # only logged-in users should be able to view the sequence's detail page
         if (
@@ -35,6 +38,7 @@ class SequenceDetailView(DetailView):
             .select_related("source")
             .order_by("siglum")
         )
+        context["user_can_edit_sequence"] = user_can_edit_chants_in_source(user, source)
         return context
 
 


### PR DESCRIPTION
On the Source detail and Sequence detail pages, the View | Edit toggle is viewable to all users who are logged in. This will take them to a 404 error if they do not have the right permissions to access the edit pages. 
Based on the solution used in #941, we can update the remaining links that should be hidden or displayed to users based on their editing permissions.

Fixes #775, Fixes #448 