### PR TITLE
Improve search bar experience

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -792,7 +792,7 @@ class ChantSearchView(ListView):
             else:
                 # if search bar is doing Cantus ID search
                 cantus_id = self.request.GET.get("search_bar")
-                q_obj_filter &= Q(cantus_id=cantus_id)
+                q_obj_filter &= Q(cantus_id__icontains=cantus_id)
                 chant_set = chant_set.filter(q_obj_filter).values(
                     *CHANT_SEARCH_TEMPLATE_VALUES
                 )

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -404,12 +404,12 @@ def ajax_search_bar(request, search_term):
     # load only the first seven chants
     CHANT_CNT = 7
 
-    if any(char.isdigit() for char in search_term):
+    if not search_term.replace(" ", "").isalpha():
         # if the search term contains at least one digit, assume user is searching by Cantus ID
         chants = Chant.objects.filter(cantus_id__istartswith=search_term).order_by("id")
     else:
         # if the search term does not contain any digits, assume user is searching by incipit
-        chants = Chant.objects.filter(incipit__icontains=search_term).order_by("id")
+        chants = Chant.objects.filter(incipit__istartswith=search_term).order_by("id")
 
     display_unpublished = request.user.is_authenticated
     if not display_unpublished:

--- a/django/cantusdb_project/static/js/chant_search.js
+++ b/django/cantusdb_project/static/js/chant_search.js
@@ -1,10 +1,15 @@
+function containsOnlyLettersAndSpaces(str) {
+    return /^[A-Za-z\s]*$/.test(str);
+  }
+
 window.addEventListener("load", function () {
     // Make sure the select components keep their values across multiple GET requests
     // so the user can "drill down" on what they want
     const opFilter = document.getElementById("opFilter");
     const genreFilter = document.getElementById("genreFilter");
     const melodiesFilter = document.getElementById("melodiesFilter");
-    const searchBar = document.getElementById("searchBar")
+    const keywordField = document.getElementById("keywordSearch");
+    const cantusIDField = document.getElementById("cantus_id");
 
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has("op")) {
@@ -17,6 +22,15 @@ window.addEventListener("load", function () {
         melodiesFilter.value = urlParams.get("melodies");
     }
     if (urlParams.has("search_bar")) {
-        searchBar.value = urlParams.get("search_bar");
+        search_term = urlParams.get("search_bar");
+        if (containsOnlyLettersAndSpaces(search_term)) {
+            // assume user is doing an incipit search
+            opFilter.value = "starts_with"
+            keywordField.value = search_term
+        } else {
+            // if search term contains other characters, assume user
+            // is doing a Cantus ID search
+            cantusIDField.value = search_term
+        }
     }
 });


### PR DESCRIPTION
@jackyyzhang03 mentioned something that unlocked an insight for how to fix #515, which has been bothering me for a while. While implementing this, I also fixed #903.

This PR improves two main things for when users interact with the global search bar (the one at the top of each page):
- When a user is searching for an incipit, in the search preview, we now only provide results where the search term matches the start of the incipit, rather than checking whether the search term is contained in the incipit (i.e. fixes #903)
- When a user searches for an incipit, we automatically populate the "keyword" text field and set the operation to "starts_with". When a user searches for a Cantus ID, we automatically populate the "Cantus ID" text field. (i.e. fixes #515)
- When a user searches for a Cantus ID via the search bar, we now do an `icontains` search rather than an exact-match search. This behavior now matches the behavior when the user searches for a Cantus ID via the "Cantus ID" text field

It's worth noting that there's probably a more django-idiomatic way to accomplish everything in `chant_search.js` (and most of the other `_.js` files among our static files), using views' `get_initial` method. This remains a good opportunity for some refactoring in the future.