### PR TITLE
fix bug in sources user can edit helper function

### DIFF
--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -277,6 +277,8 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
 
 def user_can_edit_source(user, source):
+    if user.is_anonymous:
+        return False
     source_id = source.id
     assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
 


### PR DESCRIPTION
This fixes a bug in the source detail view where users that were not logged in would lead to an error. The helper function for user_can_edit_source now returns False if the user is not logged in.

Fixes #947 