### PR TITLE
Add functionality to pagination

### DIFF
--- a/django/cantusdb_project/main_app/templates/pagination.html
+++ b/django/cantusdb_project/main_app/templates/pagination.html
@@ -7,12 +7,12 @@
             <a href="?{% url_add_get_params page=page_obj.previous_page_number %}">previous</a>
         {% endif %}
 
-        {% if page_obj.number > 5 %}
+        {% if page_obj.number > 6 %}
             <span class="ellipsis">...</span>
         {% endif %}
 
         {% for num in page_obj.paginator.page_range %}
-            {% if num > page_obj.number|add:'-5' and num < page_obj.number|add:'5' %}
+            {% if num > page_obj.number|add:'-6' and num < page_obj.number|add:'6' %}
                 {% if num == page_obj.number %}
                     <b>{{ num }}</b>
                 {% else %}
@@ -21,7 +21,7 @@
             {% endif %}
         {% endfor %}
 
-        {% if page_obj.number < page_obj.paginator.num_pages|add:'-5' %}
+        {% if page_obj.number < page_obj.paginator.num_pages|add:'-6' %}
             <span class="ellipsis">...</span>
         {% endif %}
 

--- a/django/cantusdb_project/main_app/templates/pagination.html
+++ b/django/cantusdb_project/main_app/templates/pagination.html
@@ -4,7 +4,6 @@
     <span class="step-links">
         {% if page_obj.has_previous %}
             <a href="?{% url_add_get_params page=1 %}">&laquo; first</a>
-            <a href="?{% url_add_get_params page=page_obj.previous_page_number %}">previous</a>
         {% endif %}
 
         {% if page_obj.number > 6 %}
@@ -26,7 +25,6 @@
         {% endif %}
 
         {% if page_obj.has_next %}
-            <a href="?{% url_add_get_params page=page_obj.next_page_number %}">next</a>
             <a href="?{% url_add_get_params page=page_obj.paginator.num_pages %}">last &raquo;</a>
         {% endif %}
     </span>

--- a/django/cantusdb_project/main_app/templates/pagination.html
+++ b/django/cantusdb_project/main_app/templates/pagination.html
@@ -3,18 +3,32 @@
 <div class="pagination">
     <span class="step-links">
         {% if page_obj.has_previous %}
-        <a href="?{% url_add_get_params page=1%}">&laquo;
-            first</a>
-        <a href="?{% url_add_get_params page=page_obj.previous_page_number %}">previous</a>
+            <a href="?{% url_add_get_params page=1 %}">&laquo; first</a>
+            <a href="?{% url_add_get_params page=page_obj.previous_page_number %}">previous</a>
         {% endif %}
-        <span class="current">
-            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-        </span>
+
+        {% if page_obj.number > 5 %}
+            <span class="ellipsis">...</span>
+        {% endif %}
+
+        {% for num in page_obj.paginator.page_range %}
+            {% if num > page_obj.number|add:'-5' and num < page_obj.number|add:'5' %}
+                {% if num == page_obj.number %}
+                    <b>{{ num }}</b>
+                {% else %}
+                    <a href="?{% url_add_get_params page=num %}">{{ num }}</a>
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+        {% if page_obj.number < page_obj.paginator.num_pages|add:'-5' %}
+            <span class="ellipsis">...</span>
+        {% endif %}
 
         {% if page_obj.has_next %}
-        <a href="?{% url_add_get_params page=page_obj.next_page_number %}">next</a>
-        <a href="?{% url_add_get_params page=page_obj.paginator.num_pages %}">last
-            &raquo;</a>
+            <a href="?{% url_add_get_params page=page_obj.next_page_number %}">next</a>
+            <a href="?{% url_add_get_params page=page_obj.paginator.num_pages %}">last &raquo;</a>
         {% endif %}
     </span>
 </div>
+<span class="current">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>


### PR DESCRIPTION
Currently the pagination only displays the current page and options to skip to the next/previous page or the first/last page. Now, we display links to the next and previous 5 pages (we can change this number). This will allow the user to jump to a section further in the pagination instead of having to click through each next page.

Fixes #917 as long as the number of pages displayed on left and right seems reasonable, we still need to implement #936