### PR TITLE
Add user to last_updated_by when creating a source/chant

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -338,7 +338,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -441,7 +441,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 200)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -481,7 +481,7 @@ class PermissionsTest(TestCase):
         # SourceDeleteView
         response = self.client.get(f"/source/{source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -482,7 +482,6 @@ class PermissionsTest(TestCase):
         response = self.client.get(f"/source/{source.id}/delete")
         self.assertEqual(response.status_code, 403)
 
-
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1283,6 +1283,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
         if form.is_valid():
             form.instance.created_by = self.request.user
+            form.instance.last_updated_by = self.request.user
             messages.success(
                 self.request,
                 "Chant '" + form.instance.incipit + "' created successfully!",

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -208,6 +208,7 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
     def form_valid(self, form):
         form.instance.created_by = self.request.user
+        form.instance.last_updated_by = self.request.user
         self.object = form.save()
 
         # assign this source to the "current_editors"


### PR DESCRIPTION
This PR fixes a problem in the content overview page where the last_updated_by column would display None for objects that have just been created. The solution adds the created_by user to the last_updated_by field when the object is created.