### PR TITLE
Create APIs to list all articles, flat pages

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -338,7 +338,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -441,7 +441,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 200)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -481,7 +481,7 @@ class PermissionsTest(TestCase):
         # SourceDeleteView
         response = self.client.get(f"/source/{source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
 

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -388,6 +388,11 @@ urlpatterns = [
         views.articles_list_export,
         name="articles-list-export",
     ),
+    path(
+        "flatpages-list/",
+        views.flatpages_list_export,
+        name="flatpages-list-export",
+    ),
 ]
 
 handler404 = "main_app.views.views.handle404"

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -383,6 +383,11 @@ urlpatterns = [
         views.redirect_indexer,
         name="redirect-indexer",
     ),
+    path(
+        "articles-list/",
+        views.articles_list_export,
+        name="articles-list-export",
+    ),
 ]
 
 handler404 = "main_app.views.views.handle404"

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -29,6 +29,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from typing import List
 from django.core.paginator import Paginator
+from django.contrib.flatpages.models import FlatPage
 
 
 @login_required
@@ -748,6 +749,24 @@ def articles_list_export(request) -> HttpResponse:
         for article in articles
     ]
     return HttpResponse(" ".join(article_urls))
+
+
+def flatpages_list_export(request) -> HttpResponse:
+    """Returns a list of URLs of all articles on the site
+
+    Args:
+        request: the incoming request
+
+    Returns:
+        HttpResponse: A list of URLs, separated by newline characters
+    """
+
+    flatpages = FlatPage.objects.all()
+    flatpage_urls = [
+        request.build_absolute_uri(flatpage.get_absolute_url())
+        for flatpage in flatpages
+    ]
+    return HttpResponse(" ".join(flatpage_urls))
 
 
 def redirect_node_url(request, pk: int) -> HttpResponse:

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -742,7 +742,6 @@ def articles_list_export(request) -> HttpResponse:
     Returns:
         HttpResponse: A list of URLs, separated by newline characters
     """
-    # request.build_absolute_uri(reverse("csv-export", args=[id]))
     articles = Article.objects.all()
     article_urls = [
         request.build_absolute_uri(reverse("article-detail", args=[article.id]))

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -747,7 +747,7 @@ def articles_list_export(request) -> HttpResponse:
         request.build_absolute_uri(reverse("article-detail", args=[article.id]))
         for article in articles
     ]
-    return HttpResponse(" ".join(article_urls))
+    return HttpResponse(" ".join(article_urls), content_type="text/plain")
 
 
 def flatpages_list_export(request) -> HttpResponse:
@@ -765,7 +765,7 @@ def flatpages_list_export(request) -> HttpResponse:
         request.build_absolute_uri(flatpage.get_absolute_url())
         for flatpage in flatpages
     ]
-    return HttpResponse(" ".join(flatpage_urls))
+    return HttpResponse(" ".join(flatpage_urls), content_type="text/plain")
 
 
 def redirect_node_url(request, pk: int) -> HttpResponse:

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -732,6 +732,24 @@ def json_node_export(request, id: int) -> JsonResponse:
     return HttpResponseNotFound()
 
 
+def articles_list_export(request) -> HttpResponse:
+    """Returns a list of URLs of all articles on the site
+
+    Args:
+        request: the incoming request
+
+    Returns:
+        HttpResponse: A list of URLs, separated by newline characters
+    """
+    # request.build_absolute_uri(reverse("csv-export", args=[id]))
+    articles = Article.objects.all()
+    article_urls = [
+        request.build_absolute_uri(reverse("article-detail", args=[article.id]))
+        for article in articles
+    ]
+    return HttpResponse(" ".join(article_urls))
+
+
 def redirect_node_url(request, pk: int) -> HttpResponse:
     """
     A function that will redirect /node/ URLs from OldCantus to their corresponding page in NewCantus.


### PR DESCRIPTION
This PR creates two new APIs to list the static pages on the site. They are meant to be used by @zhannaklimanova's helpful link-checker, to ensure that all articles and flat pages contain no dead links.

Both APIs return a list of URLs, separated by spaces.