### PR TITLE
Create redirects for old document paths

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -338,7 +338,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -441,7 +441,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 200)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -481,7 +481,7 @@ class PermissionsTest(TestCase):
         # SourceDeleteView
         response = self.client.get(f"/source/{source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
 
@@ -5251,6 +5251,34 @@ class IndexerRedirectTest(TestCase):
             reverse("redirect-indexer", args=[example_bad_indexer_id])
         )
         self.assertEqual(response_1.status_code, 404)
+
+
+class DocumentRedirectTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_document_redirects(self):
+        old_document_paths = (
+            "/sites/default/files/documents/1. Quick Guide to Liturgy.pdf",
+            "/sites/default/files/documents/2. Volpiano Protocols.pdf",
+            "/sites/default/files/documents/3. Volpiano Neumes for Review.docx",
+            "/sites/default/files/documents/4. Volpiano Neume Protocols.pdf",
+            "/sites/default/files/documents/5. Volpiano Editing Guidelines.pdf",
+            "/sites/default/files/documents/7. Guide to Graduals.pdf",
+            "/sites/default/files/HOW TO - manuscript descriptions-Nov6-20.pdf",
+        )
+        for path in old_document_paths:
+            # each path should redirect to the new path
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 302)
+            # In Aug 2023, Jacob struggled to get the following lines to work -
+            # I was getting 404s when I expected 200s. This final step would be nice
+            # to test properly - if a future developer who is cleverer than me can
+            # get this working, that would be excellent!
+
+            # redirect_url = response.url
+            # followed_response = self.client.get(redirect_url)
+            # self.assertEqual(followed_response.status_code, 200)
 
 
 class ContentOverviewTest(TestCase):

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -383,6 +383,42 @@ urlpatterns = [
         views.redirect_indexer,
         name="redirect-indexer",
     ),
+    # redirects for static files present on OldCantus
+    path(
+        "sites/default/files/documents/1. Quick Guide to Liturgy.pdf",
+        views.redirect_documents,
+        name="redirect-quick-guide-to-liturgy",
+    ),
+    path(
+        "sites/default/files/documents/2. Volpiano Protocols.pdf",
+        views.redirect_documents,
+        name="redirect-volpiano-protocols",
+    ),
+    path(
+        "sites/default/files/documents/3. Volpiano Neumes for Review.docx",
+        views.redirect_documents,
+        name="redirect-volpiano-neumes-for-review",
+    ),
+    path(
+        "sites/default/files/documents/4. Volpiano Neume Protocols.pdf",
+        views.redirect_documents,
+        name="redirect-volpiano-neume-protocols",
+    ),
+    path(
+        "sites/default/files/documents/5. Volpiano Editing Guidelines.pdf",
+        views.redirect_documents,
+        name="redirect-volpiano-editing-guidelines",
+    ),
+    path(
+        "sites/default/files/documents/7. Guide to Graduals.pdf",
+        views.redirect_documents,
+        name="redirect-guide-to-graduals",
+    ),
+    path(
+        "sites/default/files/HOW TO - manuscript descriptions-Nov6-20.pdf",
+        views.redirect_documents,
+        name="redirect-how-to-manuscript-descriptions",
+    ),
 ]
 
 handler404 = "main_app.views.views.handle404"

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -29,6 +29,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from typing import List
 from django.core.paginator import Paginator
+from django.templatetags.static import static
 
 
 @login_required
@@ -842,3 +843,47 @@ def redirect_indexer(request, pk: int) -> HttpResponse:
         return redirect("user-detail", user_id)
 
     raise Http404("No indexer found matching the query.")
+
+
+def redirect_documents(request) -> HttpResponse:
+    """Handle requests to old paths for various
+    documents on OldCantus, returning an HTTP Response
+    redirecting the user to the updated path
+
+    Args:
+        request: the request to the old path
+
+    Returns:
+        HttpResponse: response redirecting to the new path
+    """
+    mapping = {
+        "/sites/default/files/documents/1. Quick Guide to Liturgy.pdf": static(
+            "documents/1. Quick Guide to Liturgy.pdf"
+        ),
+        "/sites/default/files/documents/2. Volpiano Protocols.pdf": static(
+            "documents/2. Volpiano Protocols.pdf"
+        ),
+        "/sites/default/files/documents/3. Volpiano Neumes for Review.docx": static(
+            "documents/3. Volpiano Neumes for Review.docx"
+        ),
+        "/sites/default/files/documents/4. Volpiano Neume Protocols.pdf": static(
+            "documents/4. Volpiano Neume Protocols.pdf"
+        ),
+        "/sites/default/files/documents/5. Volpiano Editing Guidelines.pdf": static(
+            "documents/5. Volpiano Editing Guidelines.pdf"
+        ),
+        "/sites/default/files/documents/7. Guide to Graduals.pdf": static(
+            "documents/7. Guide to Graduals.pdf"
+        ),
+        "/sites/default/files/HOW TO - manuscript descriptions-Nov6-20.pdf": static(
+            "documents/HOW TO - manuscript descriptions-Nov6-20.pdf"
+        ),
+    }
+    old_path = request.path
+    try:
+        new_path = mapping[old_path]
+    except KeyError:
+        print("key error!")
+        print(old_path)
+        raise Http404
+    return redirect(new_path)


### PR DESCRIPTION
This PR creates a function-based view to redirect old document paths (most of them are of the form `/sites/default/files/documents/the-documents-filename.pdf`) to their new locations in NewCantus (mostly in the form `/static/documents/the-documents-filename.pdf`). It fixes #960.

I also wrote a test for the view. I spent a while trying to make the test fully rigorous but was getting different results than I expected; I figured I was spending more time on it than it was worth, so I left a comment in the code describing the difficulty I encountered and inviting improvements from future developers.