### PR TITLE
Ensure Source Search page unaccents source fields it's matching against

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.flatpages",
     "django.contrib.humanize",
+    "django.contrib.postgres",
     "extra_views",
     "main_app",
     "articles",

--- a/django/cantusdb_project/main_app/migrations/0002_unaccent.py
+++ b/django/cantusdb_project/main_app/migrations/0002_unaccent.py
@@ -1,0 +1,12 @@
+from django.contrib.postgres.operations import UnaccentExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("main_app", "0001_initial"),
+    ]
+
+    operations = [
+        UnaccentExtension(),
+    ]

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -43,6 +43,36 @@ def make_random_string(
     return "".join(characters[random.randrange(len(characters))] for _ in range(length))
 
 
+def add_accents_to_string(s: str) -> str:
+    """Replace some letters in a string
+    with their accented versions.
+
+    Args:
+        s (str): A string
+
+    Returns:
+        str: The same string, but with vowels, c's and n's
+            replaced with accented versions of the same letter
+    """
+    accented_string = (
+        s.replace("a", "à")
+        .replace("e", "é")
+        .replace("i", "ï")
+        .replace("o", "ô")
+        .replace("u", "ū")
+        .replace("c", "ç")
+        .replace("n", "ñ")
+        .replace("A", "À")
+        .replace("E", "É")
+        .replace("I", "Ï")
+        .replace("O", "Ô")
+        .replace("U", "Ū")
+        .replace("C", "Ç")
+        .replace("N", "Ñ")
+    )
+    return accented_string
+
+
 def make_fake_volpiano(
     words: int = 5,
     syllables_per_word: int = 2,

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -29,6 +29,7 @@ from .make_fakes import (
     make_fake_source,
     make_fake_volpiano,
     make_random_string,
+    add_accents_to_string,
 )
 
 from main_app.models import Century
@@ -4198,6 +4199,14 @@ class SourceListViewTest(TestCase):
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
+        # Test that postgres searches unaccented version of title
+        unaccented_title = source.title
+        accented_title = add_accents_to_string(unaccented_title)
+        source.title = accented_title
+        source.save()
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
     def test_search_by_siglum(self):
         source = make_fake_source(
             siglum=make_random_string(6),
@@ -4205,6 +4214,14 @@ class SourceListViewTest(TestCase):
             title="title",
         )
         search_term = get_random_search_term(source.siglum)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Test that postgres searches unaccented version of siglum
+        unaccented_siglum = source.siglum
+        accented_siglum = add_accents_to_string(unaccented_siglum)
+        source.siglum = accented_siglum
+        source.save()
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
@@ -4219,6 +4236,14 @@ class SourceListViewTest(TestCase):
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
+        # Test that postgres searches unaccented version of RISM siglum name
+        unaccented_name = rism_siglum.name
+        accented_name = add_accents_to_string(unaccented_name)
+        rism_siglum.name = accented_name
+        rism_siglum.save()
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
     def test_search_by_rism_siglum_description(self):
         rism_siglum = make_fake_rism_siglum()
         source = make_fake_source(
@@ -4227,6 +4252,14 @@ class SourceListViewTest(TestCase):
             title="title",
         )
         search_term = get_random_search_term(source.rism_siglum.description)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Test that postgres searches unaccented version of RISM siglum description
+        unaccented_description = rism_siglum.description
+        accented_description = add_accents_to_string(unaccented_description)
+        rism_siglum.description = accented_description
+        rism_siglum.save()
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
@@ -4240,6 +4273,14 @@ class SourceListViewTest(TestCase):
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
+        # Test that postgres searches unaccented version of description
+        unaccented_description = source.description
+        accented_description = add_accents_to_string(unaccented_description)
+        source.title = accented_description
+        source.save()
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
     def test_search_by_summary(self):
         source = make_fake_source(
             summary=faker.sentence(),
@@ -4247,6 +4288,14 @@ class SourceListViewTest(TestCase):
             title="title",
         )
         search_term = get_random_search_term(source.summary)
+        response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Test that postgres searches unaccented version of summary
+        unaccented_summary = source.summary
+        accented_summary = add_accents_to_string(unaccented_summary)
+        source.title = accented_summary
+        source.save()
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
@@ -4259,6 +4308,14 @@ class SourceListViewTest(TestCase):
         )
         search_term = get_random_search_term(source.indexing_notes)
         response = self.client.get(reverse("source-list"), {"indexing": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Test that postgres searches unaccented version of indexing_notes
+        unaccented_indexing_notes = source.indexing_notes
+        accented_indexing_notes = add_accents_to_string(unaccented_indexing_notes)
+        source.title = accented_indexing_notes
+        source.save()
+        response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
 

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -122,13 +122,13 @@ class SourceListView(ListView):
             # field, allowing for a more flexible search, and a field needs
             # to match only one of the terms
             for term in general_search_terms:
-                title_q |= Q(title__icontains=term)
-                siglum_q |= Q(siglum__icontains=term)
-                rism_siglum_q |= Q(rism_siglum__name__icontains=term) | Q(
-                    rism_siglum__description__icontains=term
+                title_q |= Q(title__unaccent__icontains=term)
+                siglum_q |= Q(siglum__unaccent__icontains=term)
+                rism_siglum_q |= Q(rism_siglum__name__unaccent__icontains=term) | Q(
+                    rism_siglum__description__unaccent__icontains=term
                 )
-                description_q |= Q(description__icontains=term)
-                summary_q |= Q(summary__icontains=term)
+                description_q |= Q(description__unaccent__icontains=term)
+                summary_q |= Q(summary__unaccent__icontains=term)
                 # provenance_q |= Q(provenance__name__icontains=term)
             # All the Q objects are put together with OR.
             # The end result is that at least one term has to match in at least one


### PR DESCRIPTION
This PR fixes #935, ensuring that when a person searches for sources relating to "krakow", sources that have "kraków" in their title/description/etc. will appear.

This fix involved adding an extension to Postgres; it seems that one of the preferred ways to do this is by writing a custom migration. Now that we keep migrations in the repo, we can install it this way!

The PR also includes updates to the Source Search tests (aside: my custom `add_accents_to_string` is a proper hoot when used in combination with our lorem ipsum generator).