### PR TITLE
Add autocomplete fields for source create/edit pages

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -498,8 +498,6 @@ class SourceEditForm(forms.ModelForm):
             "date",
             "century",
             "cursus",
-            "current_editors",
-            "melodies_entered_by",
             "complete_inventory",
             "summary",
             "description",
@@ -508,6 +506,12 @@ class SourceEditForm(forms.ModelForm):
             "fragmentarium_id",
             "dact_id",
             "indexing_notes",
+            "current_editors",
+            "melodies_entered_by",
+            "inventoried_by",
+            "full_text_entered_by",
+            "proofreaders",
+            "other_editors",
         ]
         widgets = {
             "title": TextInputWidget(),
@@ -522,6 +526,25 @@ class SourceEditForm(forms.ModelForm):
             "fragmentarium_id": TextInputWidget(),
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
+            "current_editors": autocomplete.ModelSelect2Multiple(
+                url="current-editors-autocomplete"
+            ),
+            "melodies_entered_by": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "century": autocomplete.ModelSelect2Multiple(url="century-autocomplete"),
+            "inventoried_by": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "full_text_entered_by": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "proofreaders": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "other_editors": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
         }
 
     provenance = forms.ModelChoiceField(
@@ -530,13 +553,6 @@ class SourceEditForm(forms.ModelForm):
     provenance.widget.attrs.update(
         {"class": "form-control custom-select custom-select-sm"}
     )  # adds styling
-
-    century = forms.ModelMultipleChoiceField(
-        queryset=Century.objects.all().order_by("name"), required=False
-    )
-    century.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
 
     CHOICES_FULL_SOURCE = (
         (None, "None"),
@@ -555,27 +571,6 @@ class SourceEditForm(forms.ModelForm):
     )
     cursus = forms.ChoiceField(choices=CHOICES_CURSUS, required=False)
     cursus.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    current_editors = forms.ModelMultipleChoiceField(
-        queryset=get_user_model()
-        .objects.filter(
-            Q(groups__name="project manager")
-            | Q(groups__name="editor")
-            | Q(groups__name="contributor")
-        )
-        .order_by("last_name"),
-        required=False,
-    )
-    current_editors.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
-
-    melodies_entered_by = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"), required=False
-    )
-    melodies_entered_by.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
 
     CHOICES_COMPLETE_INV = (
         (True, "complete inventory"),

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -197,6 +197,10 @@ class SourceCreateForm(forms.ModelForm):
             "cursus",
             "current_editors",
             "melodies_entered_by",
+            "inventoried_by",
+            "full_text_entered_by",
+            "proofreaders",
+            "other_editors",
             "complete_inventory",
             "summary",
             "description",
@@ -226,6 +230,18 @@ class SourceCreateForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
             "century": autocomplete.ModelSelect2Multiple(url="century-autocomplete"),
+            "inventoried_by": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "full_text_entered_by": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "proofreaders": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "other_editors": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
         }
 
     rism_siglum = forms.ModelChoiceField(

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -28,6 +28,7 @@ from django.db.models import Q
 from django.contrib.admin.widgets import (
     FilteredSelectMultiple,
 )
+from dal import autocomplete
 
 # ModelForm allows to build a form directly from a model
 # see https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/
@@ -218,6 +219,13 @@ class SourceCreateForm(forms.ModelForm):
             "fragmentarium_id": TextInputWidget(),
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
+            "current_editors": autocomplete.ModelSelect2Multiple(
+                url="current-editors-autocomplete"
+            ),
+            "melodies_entered_by": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "century": autocomplete.ModelSelect2Multiple(url="century-autocomplete"),
         }
 
     rism_siglum = forms.ModelChoiceField(
@@ -243,35 +251,6 @@ class SourceCreateForm(forms.ModelForm):
     full_source.widget.attrs.update(
         {"class": "form-control custom-select custom-select-sm"}
     )
-
-    century = forms.ModelMultipleChoiceField(
-        queryset=Century.objects.all().order_by("name"), required=False
-    )
-    century.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
-
-    current_editors = forms.ModelMultipleChoiceField(
-        queryset=get_user_model()
-        .objects.filter(
-            Q(groups__name="project manager")
-            | Q(groups__name="editor")
-            | Q(groups__name="contributor")
-        )
-        .order_by("last_name"),
-        required=False,
-    )
-    current_editors.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
-
-    melodies_entered_by = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"), required=False
-    )
-    melodies_entered_by.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
-
     TRUE_FALSE_CHOICES_INVEN = ((True, "Complete"), (False, "Incomplete"))
 
     complete_inventory = forms.ChoiceField(

--- a/django/cantusdb_project/main_app/templates/source_create_form.html
+++ b/django/cantusdb_project/main_app/templates/source_create_form.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
+{% load static %}
 {% block content %}
+<script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+{{ form.media }}
 <title>Create Source | Cantus Manuscript Database</title>
 <div class="container">
     <div class="row">
@@ -88,16 +91,18 @@
                     </div>
                 </div>
 
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
+                        <small>{{ form.century.label_tag }}</small>
+                        {{ form.century }}
+                    </div>
+                </div>
 
                 <div class="form-row">
                     <div class="form-group m-1 col-lg-3">
                         <small>{{ form.date.label_tag }}</small>
                         {{ form.date }}
                         <p class=text-muted><small>{{ form.date.help_text }}</small></p>
-                    </div>
-                    <div class="form-group m-1 col-lg-3">
-                        <small>{{ form.century.label_tag }}</small>
-                        {{ form.century }}
                     </div>
                     <div class="form-group m-1 col-lg-1">
                         <small>{{ form.cursus.label_tag }}</small>
@@ -106,14 +111,16 @@
                 </div>
 
                 <div class="form-row">
-                    <div class="form-group m-1 col-lg-5">
+                    <div class="form-group m-1 col-lg-3">
                         <small>{{ form.current_editors.label_tag }}</small>
                         {{ form.current_editors }}
-                    </div> 
-                    <div class="form-group m-1 col-lg-5">
+                    </div>
+                </div> 
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
                         <small>{{ form.melodies_entered_by.label_tag }}</small>
                         {{ form.melodies_entered_by }}
-                    </div> 
+                    </div>
                 </div>
 
                 <div class="form-row">

--- a/django/cantusdb_project/main_app/templates/source_create_form.html
+++ b/django/cantusdb_project/main_app/templates/source_create_form.html
@@ -109,7 +109,6 @@
                         {{ form.cursus }}
                     </div>
                 </div>
-
                 <div class="form-row">
                     <div class="form-group m-1 col-lg-3">
                         <small>{{ form.current_editors.label_tag }}</small>
@@ -120,6 +119,30 @@
                     <div class="form-group m-1 col-lg-3">
                         <small>{{ form.melodies_entered_by.label_tag }}</small>
                         {{ form.melodies_entered_by }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
+                        <small>{{ form.inventoried_by.label_tag }}</small>
+                        {{ form.inventoried_by }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
+                        <small>{{ form.full_text_entered_by.label_tag }}</small>
+                        {{ form.full_text_entered_by }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
+                        <small>{{ form.proofreaders.label_tag }}</small>
+                        {{ form.proofreaders }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
+                        <small>{{ form.other_editors.label_tag }}</small>
+                        {{ form.other_editors }}
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
+{% load static %}
 {% block content %}
 <title>{{ source.title }} | Cantus Manuscript Database</title>
 <script src="/static/js/source_detail.js"></script>
+<script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+{{ form.media }}
 
 <div class="container">
     <div class="row">
@@ -82,14 +85,17 @@
                 </div>
 
                 <div class="form-row mb-3">
+                    <div class="form-group m-1 col-lg-3">
+                        {{ form.century.label_tag }}
+                        {{ form.century }}
+                    </div>
+                </div>
+
+                <div class="form-row mb-3">
                     <div class="form-group m-1 col-lg-7">
                         {{ form.date.label_tag }}
                         {{ form.date }}
                         <small>Date of the manuscript (e.g. "1200s", "1300-1350", etc.)</small>
-                    </div>
-                    <div class="form-group m-1 col-lg-4">
-                        {{ form.century.label_tag }}
-                        {{ form.century }}
                     </div>
                 </div>
 
@@ -101,16 +107,39 @@
                 </div>
 
                 <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
+                    <div class="form-group m-1 col-lg-3">
                         {{ form.current_editors.label_tag }}
                         {{ form.current_editors }}
                     </div>
-                </div>
-
+                </div> 
                 <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
+                    <div class="form-group m-1 col-lg-3">
                         {{ form.melodies_entered_by.label_tag }}
                         {{ form.melodies_entered_by }}
+                    </div>
+                </div>
+                <div class="form-row mb-3">
+                    <div class="form-group m-1 col-lg-3">
+                        {{ form.inventoried_by.label_tag }}
+                        {{ form.inventoried_by }}
+                    </div>
+                </div>
+                <div class="form-row mb-3">
+                    <div class="form-group m-1 col-lg-3">
+                        {{ form.full_text_entered_by.label_tag }}
+                        {{ form.full_text_entered_by }}
+                    </div>
+                </div>
+                <div class="form-row mb-3">
+                    <div class="form-group m-1 col-lg-3">
+                        {{ form.proofreaders.label_tag }}
+                        {{ form.proofreaders }}
+                    </div>
+                </div>
+                <div class="form-row mb-3">
+                    <div class="form-group m-1 col-lg-3">
+                        {{ form.other_editors.label_tag }}
+                        {{ form.other_editors }}
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -338,7 +338,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -441,7 +441,7 @@ class PermissionsTest(TestCase):
 
         response = self.client.get(f"/source/{assigned_source.id}/delete")
         self.assertEqual(response.status_code, 200)
-        
+
         # Content Overview
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
@@ -481,7 +481,7 @@ class PermissionsTest(TestCase):
         # SourceDeleteView
         response = self.client.get(f"/source/{source.id}/delete")
         self.assertEqual(response.status_code, 403)
-        
+
         response = self.client.get(reverse("content-overview"))
         self.assertEqual(response.status_code, 403)
 
@@ -5326,3 +5326,64 @@ class ContentOverviewTest(TestCase):
         )
         self.assertContains(response, "Test Chant", html=True)
         self.assertNotContains(response, "Test Source", html=True)
+
+
+class AutocompleteViewsTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create(email="test@test.com")
+        self.user.set_password("pass")
+        self.user.save()
+        self.client = Client()
+        self.client.login(email="test@test.com", password="pass")
+
+    @classmethod
+    def setUpTestData(cls):
+        Group.objects.create(name="editor")
+        u1 = get_user_model().objects.create(email="hello@test.com")
+        u2 = get_user_model().objects.create(full_name="Lucas")
+        editor = Group.objects.get(name="editor")
+        editor.user_set.add(u1)
+
+        for i in range(10):
+            make_fake_century()
+
+    def test_current_editors_autocomplete(self):
+        response = self.client.get(reverse("current-editors-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+
+    def test_all_users_autocomplete(self):
+        response = self.client.get(reverse("all-users-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 3)
+
+        response2 = self.client.get(reverse("all-users-autocomplete"), {"q": "L"})
+        self.assertEqual(response2.status_code, 200)
+        data = response2.json()
+        self.assertEqual(len(data["results"]), 1)
+
+    def test_century_autocomplete(self):
+        response = self.client.get(reverse("century-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 10)
+
+    def test_non_authenticated_user(self):
+        self.client.logout()
+        response = self.client.get(reverse("current-editors-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 0)
+
+        response = self.client.get(reverse("all-users-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 0)
+
+        response = self.client.get(reverse("century-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 0)

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -388,18 +388,18 @@ urlpatterns = [
         views.redirect_indexer,
         name="redirect-indexer",
     ),
-    re_path(
-        r"^current-editors-autocomplete/$",
+    path(
+        "current-editors-autocomplete/",
         CurrentEditorsAutocomplete.as_view(),
         name="current-editors-autocomplete",
     ),
-    re_path(
-        r"^all-users-autocomplete/$",
+    path(
+        "all-users-autocomplete/",
         AllUsersAutocomplete.as_view(),
         name="all-users-autocomplete",
     ),
-    re_path(
-        r"^century-autocomplete/$",
+    path(
+        "century-autocomplete/",
         CenturyAutocomplete.as_view(),
         name="century-autocomplete",
     ),

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path, reverse
+from django.urls import include, path, reverse, re_path
 from django.contrib.auth.views import (
     PasswordResetView,
     PasswordResetDoneView,
@@ -62,6 +62,11 @@ from main_app.views.user import (
     UserDetailView,
     UserListView,
     UserSourceListView,
+)
+from main_app.views.views import (
+    CurrentEditorsAutocomplete,
+    AllUsersAutocomplete,
+    CenturyAutocomplete,
 )
 
 urlpatterns = [
@@ -382,6 +387,21 @@ urlpatterns = [
         "indexer/<int:pk>",
         views.redirect_indexer,
         name="redirect-indexer",
+    ),
+    re_path(
+        r"^current-editors-autocomplete/$",
+        CurrentEditorsAutocomplete.as_view(),
+        name="current-editors-autocomplete",
+    ),
+    re_path(
+        r"^all-users-autocomplete/$",
+        AllUsersAutocomplete.as_view(),
+        name="all-users-autocomplete",
+    ),
+    re_path(
+        r"^century-autocomplete/$",
+        CenturyAutocomplete.as_view(),
+        name="century-autocomplete",
     ),
 ]
 

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path, reverse, re_path
+from django.urls import include, path, reverse
 from django.contrib.auth.views import (
     PasswordResetView,
     PasswordResetDoneView,

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -849,7 +849,7 @@ def redirect_indexer(request, pk: int) -> HttpResponse:
 class CurrentEditorsAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         if not self.request.user.is_authenticated:
-            return Century().objects.none()
+            return get_user_model().objects.none()
         qs = (
             get_user_model()
             .objects.filter(
@@ -881,7 +881,7 @@ class AllUsersAutocomplete(autocomplete.Select2QuerySetView):
 class CenturyAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         if not self.request.user.is_authenticated:
-            return get_user_model().objects.none()
+            return Century.objects.none()
         qs = Century.objects.all().order_by("name")
         if self.q:
             qs = qs.filter(name__istartswith=self.q)

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -848,6 +848,8 @@ def redirect_indexer(request, pk: int) -> HttpResponse:
 
 class CurrentEditorsAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Century().objects.none()
         qs = (
             get_user_model()
             .objects.filter(
@@ -866,6 +868,8 @@ class CurrentEditorsAutocomplete(autocomplete.Select2QuerySetView):
 
 class AllUsersAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return get_user_model().objects.none()
         qs = get_user_model().objects.all().order_by("full_name")
         if self.q:
             qs = qs.filter(
@@ -876,6 +880,8 @@ class AllUsersAutocomplete(autocomplete.Select2QuerySetView):
 
 class CenturyAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return get_user_model().objects.none()
         qs = Century.objects.all().order_by("name")
         if self.q:
             qs = qs.filter(name__istartswith=self.q)

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -10,7 +10,7 @@ charset-normalizer==2.0.12
 click==7.1.2
 coverage==5.3.1
 Django==4.2.3
-django-autocomplete-light==3.5.1
+django-autocomplete-light==3.9.4
 django-extra-views==0.13.0
 django-quill-editor==0.1.40
 django_debug_toolbar==3.8.1


### PR DESCRIPTION
This PR utilizes the django-autocomplete-light (DAL) package to add autocomplete widgets on the source create page and source edit page. Previously, it was difficult to select users from the "current editors" and "melodies entered by" widgets because it wasn't searchable or sorted in any useful way. The source create and source edit pages were also missing the following fields belonging to indexer contributions, so now these fields can be edited from the main site instead of the admin area.
- "inventoried_by"
- "full_text_entered_by"
- "proofreaders"
- "other_editors"

From the DAL docs, for better understanding of the implementation:
Autocompletes are based on 3 moving parts:
- widget compatible with the model field, does the initial rendering,
- javascript widget initialization code, to trigger the autocomplete,
- and a view used by the widget script to get results from.

Fixes #450 

Source Create page:
<img width="980" alt="image" src="https://github.com/DDMAL/CantusDB/assets/71031342/6b091a10-df93-4a7d-b907-b898bd987e6e">


Source Edit page:
![image](https://github.com/DDMAL/CantusDB/assets/71031342/d7107c71-f275-4fd0-ae30-2dccbf48a6cd)
