### PR TITLE
Source Edit: update Rism Siglum field to use ModelChoiceField

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -212,6 +212,7 @@ class SourceCreateForm(forms.ModelForm):
         ]
         widgets = {
             "title": TextInputWidget(),
+            "rism_siglum": TextInputWidget(),
             "siglum": TextInputWidget(),
             "provenance_notes": TextInputWidget(),
             "date": TextInputWidget(),
@@ -546,6 +547,13 @@ class SourceEditForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
         }
+
+    rism_siglum = forms.ModelChoiceField(
+        queryset=RismSiglum.objects.all().order_by("name"), required=False
+    )
+    rism_siglum.widget.attrs.update(
+        {"class": "form-control custom-select custom-select-sm"}
+    )
 
     provenance = forms.ModelChoiceField(
         queryset=Provenance.objects.all().order_by("name"), required=False

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -212,7 +212,6 @@ class SourceCreateForm(forms.ModelForm):
         ]
         widgets = {
             "title": TextInputWidget(),
-            "rism_siglum": TextInputWidget(),
             "siglum": TextInputWidget(),
             "provenance_notes": TextInputWidget(),
             "date": TextInputWidget(),
@@ -516,7 +515,6 @@ class SourceEditForm(forms.ModelForm):
         ]
         widgets = {
             "title": TextInputWidget(),
-            "rism_siglum": TextInputWidget(),
             "siglum": TextInputWidget(),
             "provenance_notes": TextInputWidget(),
             "date": TextInputWidget(),

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -46,10 +46,13 @@
                 <div class="form-row mb-3">
                     <div class="form-group m-1 col-lg-4">
                         <label for="{{ form.rism_siglum.id_for_label }}">
-                            RISM:
+                            <small>RISM:</small>
                         </label>
                         {{ form.rism_siglum }}
-                        <small><a href="https://www.rism.info/sigla.html" target="_blank">Browse RISM sigla</a> (opens in new tab)</small>
+                        <small>
+                            <a href="https://rism.info/community/sigla.html" target="_blank">Browse RISM sigla</a>
+                            (opens in new tab)
+                        </small>
                     </div>
                     <div class="form-group m-1 col-lg-7">
                         <label for="{{ form.siglum.id_for_label }}">


### PR DESCRIPTION
This PR changes the RISM siglum field on the Source Edit page to use a ModelChoiceField widget (previously, a user needed to know the ID of the rism siglum to assign a source to a rism siglum, which was not very useful). It was already set up properly on the Source Create page, so I copied the code from there.

Going to say this fixes #971 - it doesn't exactly solve the issue as described there currently, but this PR at least makes it useable; I'll open a new issue for making it a filterable list field, and mark it as an enhancement.

with the new changes:
![Screenshot 2023-08-11 at 1 02 50 PM](https://github.com/DDMAL/CantusDB/assets/58090591/ffc28c7a-6b48-4054-9319-e2562dfe1dfc)

previously, it was:
![Screenshot 2023-08-11 at 1 10 30 PM](https://github.com/DDMAL/CantusDB/assets/58090591/7c505c20-7171-42c3-9b9d-dd3f5cf0b9e6)

for reference, this is how the source create page looks (it works here, so I just took the code from this page):
![Screenshot 2023-08-11 at 1 11 42 PM](https://github.com/DDMAL/CantusDB/assets/58090591/52c21adb-9b33-49c4-b948-1ca53a38a93b)
