### PR TITLE
Add autocomplete widget for Rism Siglum

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -223,6 +223,7 @@ class SourceCreateForm(forms.ModelForm):
             "fragmentarium_id": TextInputWidget(),
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
+            "rism_siglum": autocomplete.ModelSelect2(url="rismsiglum-autocomplete"),
             "current_editors": autocomplete.ModelSelect2Multiple(
                 url="current-editors-autocomplete"
             ),
@@ -243,13 +244,6 @@ class SourceCreateForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
         }
-
-    rism_siglum = forms.ModelChoiceField(
-        queryset=RismSiglum.objects.all().order_by("name"), required=False
-    )
-    rism_siglum.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
 
     provenance = forms.ModelChoiceField(
         queryset=Provenance.objects.all().order_by("name"), required=False
@@ -515,7 +509,7 @@ class SourceEditForm(forms.ModelForm):
         ]
         widgets = {
             "title": TextInputWidget(),
-            "rism_siglum": TextInputWidget(),
+            "rism_siglum": autocomplete.ModelSelect2(url="rismsiglum-autocomplete"),
             "siglum": TextInputWidget(),
             "provenance_notes": TextInputWidget(),
             "date": TextInputWidget(),

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -541,13 +541,6 @@ class SourceEditForm(forms.ModelForm):
             ),
         }
 
-    rism_siglum = forms.ModelChoiceField(
-        queryset=RismSiglum.objects.all().order_by("name"), required=False
-    )
-    rism_siglum.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
-
     provenance = forms.ModelChoiceField(
         queryset=Provenance.objects.all().order_by("name"), required=False
     )

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -44,14 +44,17 @@
                 </div>
 
                 <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-4">
+                    <div class="form-group m-1 col-3">
                         <label for="{{ form.rism_siglum.id_for_label }}">
                             RISM:
                         </label>
                         {{ form.rism_siglum }}
                         <small><a href="https://www.rism.info/sigla.html" target="_blank">Browse RISM sigla</a> (opens in new tab)</small>
                     </div>
-                    <div class="form-group m-1 col-lg-7">
+                </div>
+
+                <div class="form-row mb-3">
+                    <div class="form-group m-1 col-lg-9">
                         <label for="{{ form.siglum.id_for_label }}">
                             Siglum:<span class="text-danger" title="This field is required">*</span>
                         </label>

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -67,6 +67,7 @@ from main_app.views.views import (
     CurrentEditorsAutocomplete,
     AllUsersAutocomplete,
     CenturyAutocomplete,
+    RismSiglumAutocomplete,
 )
 
 urlpatterns = [
@@ -459,6 +460,11 @@ urlpatterns = [
         "century-autocomplete/",
         CenturyAutocomplete.as_view(),
         name="century-autocomplete",
+    ),
+    path(
+        "rismsiglum-autocomplete/",
+        RismSiglumAutocomplete.as_view(),
+        name="rismsiglum-autocomplete",
     ),
 ]
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -993,3 +993,13 @@ class CenturyAutocomplete(autocomplete.Select2QuerySetView):
         if self.q:
             qs = qs.filter(name__istartswith=self.q)
         return qs
+
+
+class RismSiglumAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return RismSiglum.objects.none()
+        qs = RismSiglum.objects.all().order_by("name")
+        if self.q:
+            qs = qs.filter(name__istartswith=self.q)
+        return qs


### PR DESCRIPTION
Sorry for being just a little bit late! 
This PR uses an autocomplete widget for the source rism siglum field on the source create and edit pages.

<img width="759" alt="image" src="https://github.com/DDMAL/CantusDB/assets/71031342/a96c34ce-babb-4c8b-809f-c4ef05c8410c">

Fixes #973 
