### PR TITLE
Fix IndexError when aligning pre-syllabified text with volpiano

### DIFF
--- a/django/cantusdb_project/align_text_mel.py
+++ b/django/cantusdb_project/align_text_mel.py
@@ -358,4 +358,8 @@ def syllabize_text_to_string(text, pre_syllabized):
     """
     syls_text = syllabize_text(text, pre_syllabized)
     human_readable_text = " ".join(["".join(word) for word in syls_text])
+    # in another step, we add a space at the beginning to account for the initial clef.
+    # When we perform the .join above, this means we get two leading spaces.
+    # The following line is necessary to remove these leading spaces
+    human_readable_text = human_readable_text.strip()
     return human_readable_text

--- a/django/cantusdb_project/align_text_mel.py
+++ b/django/cantusdb_project/align_text_mel.py
@@ -73,6 +73,8 @@ def syllabize_text(text, pre_syllabized=False):
             if word:
                 syls = [syl + "-" for syl in word.split("-")]
                 syls[-1] = syls[-1][:-1]
+                # remove empty syllables
+                syls = [syl for syl in syls if syl]
                 syls_text.append(syls)
     else:
         for word in words_text:


### PR DESCRIPTION
This PR solves #977, filtering to remove empty syllables created when we try to split a pre-syllabified text into syllables.

(if a word in the pre-syllabified text ended with a `-`, an empty syllable would be created when we split the word on `-`. Later, when we checked for a particular character at `word[-1][-1]`, an IndexError was being raised, leading to the 500 response noted in #977.)

In discussion on #977, it was noted that the suggested syllabification on the Edit Syllabification includes unnecessary leading spaces. This PR fixes that too.

(When syllabifying a text, we currently add an empty word at the beginning, to correspond to the clef. But in our `syllabize_text_to_string` function, we would attach all syllables to each other, adding spaces between these syllables. This led to two unnecessary leading spaces in our suggested syllabification)