### PR TITLE
Move user permission checks to one location in code

### DIFF
--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -69,7 +69,7 @@ def user_can_view_unpublished_chant(user: User, chant: Chant) -> bool:
     """
     source = chant.source
     user_is_authenticated: bool = user.is_authenticated
-    return (source.published) or (user_is_authenticated)
+    return (source is not None) or (source.published) or (user_is_authenticated)
 
 
 def user_can_view_unpublished_sequence(user: User, sequence: Sequence) -> bool:
@@ -79,7 +79,7 @@ def user_can_view_unpublished_sequence(user: User, sequence: Sequence) -> bool:
     """
     source = sequence.source
     user_is_authenticated: bool = user.is_authenticated
-    return (source is None) or (source.published) or (user_is_authenticated)
+    return (source is not None) or (source.published) or (user_is_authenticated)
 
 
 def user_can_edit_sequence(user: User) -> bool:

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -115,14 +115,12 @@ def user_can_edit_source(user: User, source: Source) -> bool:
     is_editor: bool = user.groups.filter(name="editor").exists()
     is_contributor: bool = user.groups.filter(name="contributor").exists()
 
-    if (
+    return (
         (is_project_manager)
         or (is_editor and assigned_to_source)
         or (is_editor and source.created_by == user)
         or (is_contributor and source.created_by == user)
-    ):
-        return True
-    return False
+    )
 
 
 def user_can_view_user_detail(viewing_user: User, user: User) -> bool:

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -1,7 +1,10 @@
 from django.db.models import Q
+from typing import Optional
+from main_app.models import Source
+from users.models import User
 
 
-def user_can_edit_chants_in_source(user, source) -> bool:
+def user_can_edit_chants_in_source(user: User, source: Optional[Source]) -> bool:
     """
     Checks if the user can edit Chants in a given Source.
     Used in ChantDetail, ChantList, ChantCreate, ChantDelete, ChantEdit,
@@ -28,7 +31,7 @@ def user_can_edit_chants_in_source(user, source) -> bool:
     )
 
 
-def user_is_proofreader(user) -> bool:
+def user_is_proofreader(user: User) -> bool:
     """
     Checks if the user is a proofreader.
     Used in UserSourceListView.
@@ -36,7 +39,7 @@ def user_is_proofreader(user) -> bool:
     return user.groups.filter(Q(name="project manager") | Q(name="editor")).exists()
 
 
-def user_can_proofread_chants_in_source(user, source_id) -> bool:
+def user_can_proofread_chants_in_source(user: User, source_id: int) -> bool:
     """
     Checks if the user can access the proofreading page of a given Source.
     Used in ChantProofreadView.
@@ -53,7 +56,7 @@ def user_can_proofread_chants_in_source(user, source_id) -> bool:
     return (user_is_project_manager) or (user_is_editor and user_is_assigned_to_source)
 
 
-def user_can_view_unpublished_source(user, source) -> bool:
+def user_can_view_unpublished_source(user: User, source: Optional[Source]) -> bool:
     """
     Checks if the user can view an unpublished Source or Chant/Sequence belonging
     to an unpublished Source on the site.
@@ -69,7 +72,7 @@ def user_can_view_unpublished_source(user, source) -> bool:
     return True
 
 
-def user_can_edit_sequence(user) -> bool:
+def user_can_edit_sequence(user: User) -> bool:
     """
     Checks if the user has permission to edit a Sequence object.
     Used in SequenceDetail and SequenceEdit views.
@@ -77,7 +80,7 @@ def user_can_edit_sequence(user) -> bool:
     return user.groups.filter(name="project manager").exists()
 
 
-def user_can_create_source(user) -> bool:
+def user_can_create_source(user: User) -> bool:
     """
     Checks if the user has permission to create a Source object.
     Used in SourceCreateView.
@@ -88,7 +91,7 @@ def user_can_create_source(user) -> bool:
     ).exists()
 
 
-def user_can_edit_source(user, source) -> bool:
+def user_can_edit_source(user: User, source: Source) -> bool:
     """
     Checks if the user has permission to edit a Source object.
     Used in SourceDetail, SourceEdit, and SourceDelete views.
@@ -112,7 +115,7 @@ def user_can_edit_source(user, source) -> bool:
     return False
 
 
-def user_can_view_user_detail(viewing_user, user) -> bool:
+def user_can_view_user_detail(viewing_user: User, user: User) -> bool:
     """
     Checks if the user can view the user detail pages of regular users in the database or just indexers.
     Used in UserDetailView.
@@ -120,7 +123,7 @@ def user_can_view_user_detail(viewing_user, user) -> bool:
     return viewing_user.is_authenticated or user.is_indexer
 
 
-def user_can_manage_source_editors(user) -> bool:
+def user_can_manage_source_editors(user: User) -> bool:
     """
     Checks if the user has permission to change the editors assigned to a Source.
     Used in SourceDetailView.

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -82,7 +82,7 @@ def user_can_view_sequence(user: User, sequence: Sequence) -> bool:
     return (source is not None) or (source.published) or (user_is_authenticated)
 
 
-def user_can_edit_sequence(user: User) -> bool:
+def user_can_edit_sequences(user: User) -> bool:
     """
     Checks if the user has permission to edit a Sequence object.
     Used in SequenceDetail and SequenceEdit views.

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -5,7 +5,7 @@ def user_can_edit_chants_in_source(user, source):
     """
     Checks if the user can edit Chants in a given Source.
     Used in ChantDetail, ChantList, ChantCreate, ChantDelete, ChantEdit,
-    ChantEditSyllabification, and SourceDetail views
+    ChantEditSyllabification, and SourceDetail views.
     """
     if user.is_anonymous or (source is None):
         return False
@@ -29,7 +29,7 @@ def user_can_edit_chants_in_source(user, source):
 def user_is_proofreader(user):
     """
     Checks if the user is a proofreader.
-    Used in UserSourceListView
+    Used in UserSourceListView.
     """
     if user.groups.filter(Q(name="project manager") | Q(name="editor")).exists():
         return True
@@ -39,7 +39,7 @@ def user_is_proofreader(user):
 def user_can_proofread_chants_in_source(user, source_id):
     """
     Checks if the user can access the proofreading page of a given Source.
-    Used in ChantProofreadView
+    Used in ChantProofreadView.
     """
     if user.is_anonymous:
         return False
@@ -57,7 +57,7 @@ def user_can_view_unpublished_source(user, source):
     """
     Checks if the user can view unpublished Sources or Chants/Sequences belonging
     to unpublished sources on the site.
-    Used in ChantDetail, SequenceDetail, SourceDetail
+    Used in ChantDetail, SequenceDetail, and SourceDetail views.
     """
     display_unpublished = user.is_authenticated
     if (
@@ -84,7 +84,7 @@ def user_can_edit_sequence(user):
 def user_can_create_source(user):
     """
     Checks if the user has permission to create a Source object.
-    Used in SourceCreateView
+    Used in SourceCreateView.
     """
 
     is_authorized = user.groups.filter(

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -35,14 +35,6 @@ def user_can_edit_chants_in_source(user: User, source: Optional[Source]) -> bool
     )
 
 
-def user_is_proofreader(user: User) -> bool:
-    """
-    Checks if the user is a proofreader.
-    Used in UserSourceListView.
-    """
-    return user.groups.filter(Q(name="project manager") | Q(name="editor")).exists()
-
-
 def user_can_proofread_chants_in_source(user: User, source: Source) -> bool:
     """
     Checks if the user can access the proofreading page of a given Source.

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -1,0 +1,140 @@
+from django.db.models import Q
+
+
+def user_can_edit_chants_in_source(user, source):
+    """
+    Checks if the user can edit Chants in a given Source.
+    Used in ChantDetail, ChantList, ChantCreate, ChantDelete, ChantEdit,
+    ChantEditSyllabification, and SourceDetail views
+    """
+    if user.is_anonymous or (source is None):
+        return False
+
+    source_id = source.id
+    user_is_assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
+
+    user_is_project_manager = user.groups.filter(name="project manager").exists()
+    user_is_editor = user.groups.filter(name="editor").exists()
+    user_is_contributor = user.groups.filter(name="contributor").exists()
+
+    return (
+        (user_is_project_manager)
+        or (user_is_editor and user_is_assigned_to_source)
+        or (user_is_editor and source.created_by == user)
+        or (user_is_contributor and user_is_assigned_to_source)
+        or (user_is_contributor and source.created_by == user)
+    )
+
+
+def user_is_proofreader(user):
+    """
+    Checks if the user is a proofreader.
+    Used in UserSourceListView
+    """
+    if user.groups.filter(Q(name="project manager") | Q(name="editor")).exists():
+        return True
+    return False
+
+
+def user_can_proofread_chants_in_source(user, source_id):
+    """
+    Checks if the user can access the proofreading page of a given Source.
+    Used in ChantProofreadView
+    """
+    if user.is_anonymous:
+        return False
+    assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
+
+    is_project_manager = user.groups.filter(name="project manager").exists()
+    is_editor = user.groups.filter(name="editor").exists()
+
+    if (is_project_manager) or (is_editor and assigned_to_source):
+        return True
+    return False
+
+
+def user_can_view_unpublished_source(user, source):
+    """
+    Checks if the user can view unpublished Sources or Chants/Sequences belonging
+    to unpublished sources on the site.
+    Used in ChantDetail, SequenceDetail, SourceDetail
+    """
+    display_unpublished = user.is_authenticated
+    if (
+        (source is not None)
+        and (source.published is False)
+        and (not display_unpublished)
+    ):
+        return False
+    return True
+
+
+def user_can_edit_sequence(user):
+    """
+    Checks if the user has permission to edit a Sequence object.
+    Used in SequenceDetail and SequenceEdit views.
+    """
+    is_project_manager = user.groups.filter(name="project manager").exists()
+
+    if is_project_manager:
+        return True
+    return False
+
+
+def user_can_create_source(user):
+    """
+    Checks if the user has permission to create a Source object.
+    Used in SourceCreateView
+    """
+
+    is_authorized = user.groups.filter(
+        Q(name="project manager") | Q(name="editor") | Q(name="contributor")
+    ).exists()
+
+    if is_authorized:
+        return True
+    return False
+
+
+def user_can_edit_source(user, source):
+    """
+    Checks if the user has permission to edit a Source object.
+    Used in SourceDetail, SourceEdit, and SourceDelete views.
+    """
+    if user.is_anonymous:
+        return False
+    source_id = source.id
+    assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
+
+    is_project_manager = user.groups.filter(name="project manager").exists()
+    is_editor = user.groups.filter(name="editor").exists()
+    is_contributor = user.groups.filter(name="contributor").exists()
+
+    if (
+        (is_project_manager)
+        or (is_editor and assigned_to_source)
+        or (is_editor and source.created_by == user)
+        or (is_contributor and source.created_by == user)
+    ):
+        return True
+    return False
+
+
+def user_can_view_user_detail(viewing_user, user):
+    """
+    Checks if the user can view the user detail pages of regular users in the database or just indexers.
+    Used in UserDetailView.
+    """
+    if not (viewing_user.is_authenticated or user.is_indexer):
+        return False
+    return True
+
+
+def user_can_manage_source_editors(user):
+    """
+    Checks if the user has permission to change the editors assigned to a Source.
+    Used in SourceDetailView.
+    """
+    if user.is_staff or user.groups.filter(name="project manager").exists():
+        return True
+    return False

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -11,11 +11,13 @@ def user_can_edit_chants_in_source(user, source) -> bool:
         return False
 
     source_id = source.id
-    user_is_assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
+    user_is_assigned_to_source: bool = user.sources_user_can_edit.filter(
+        id=source_id
+    ).exists()
 
-    user_is_project_manager = user.groups.filter(name="project manager").exists()
-    user_is_editor = user.groups.filter(name="editor").exists()
-    user_is_contributor = user.groups.filter(name="contributor").exists()
+    user_is_project_manager: bool = user.groups.filter(name="project manager").exists()
+    user_is_editor: bool = user.groups.filter(name="editor").exists()
+    user_is_contributor: bool = user.groups.filter(name="contributor").exists()
 
     return (
         (user_is_project_manager)
@@ -31,9 +33,7 @@ def user_is_proofreader(user) -> bool:
     Checks if the user is a proofreader.
     Used in UserSourceListView.
     """
-    if user.groups.filter(Q(name="project manager") | Q(name="editor")).exists():
-        return True
-    return False
+    return user.groups.filter(Q(name="project manager") | Q(name="editor")).exists()
 
 
 def user_can_proofread_chants_in_source(user, source_id) -> bool:
@@ -43,12 +43,14 @@ def user_can_proofread_chants_in_source(user, source_id) -> bool:
     """
     if user.is_anonymous:
         return False
-    assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
+    user_is_assigned_to_source: bool = user.sources_user_can_edit.filter(
+        id=source_id
+    ).exists()
 
-    is_project_manager = user.groups.filter(name="project manager").exists()
-    is_editor = user.groups.filter(name="editor").exists()
+    user_is_project_manager: bool = user.groups.filter(name="project manager").exists()
+    user_id_editor: bool = user.groups.filter(name="editor").exists()
 
-    if (is_project_manager) or (is_editor and assigned_to_source):
+    if (user_is_project_manager) or (user_id_editor and user_is_assigned_to_source):
         return True
     return False
 
@@ -59,11 +61,11 @@ def user_can_view_unpublished_source(user, source) -> bool:
     to unpublished sources on the site.
     Used in ChantDetail, SequenceDetail, and SourceDetail views.
     """
-    display_unpublished = user.is_authenticated
+    user_is_authenticated: bool = user.is_authenticated
     if (
         (source is not None)
         and (source.published is False)
-        and (not display_unpublished)
+        and (not user_is_authenticated)
     ):
         return False
     return True
@@ -74,11 +76,7 @@ def user_can_edit_sequence(user) -> bool:
     Checks if the user has permission to edit a Sequence object.
     Used in SequenceDetail and SequenceEdit views.
     """
-    is_project_manager = user.groups.filter(name="project manager").exists()
-
-    if is_project_manager:
-        return True
-    return False
+    return user.groups.filter(name="project manager").exists()
 
 
 def user_can_create_source(user) -> bool:
@@ -87,13 +85,9 @@ def user_can_create_source(user) -> bool:
     Used in SourceCreateView.
     """
 
-    is_authorized = user.groups.filter(
+    return user.groups.filter(
         Q(name="project manager") | Q(name="editor") | Q(name="contributor")
     ).exists()
-
-    if is_authorized:
-        return True
-    return False
 
 
 def user_can_edit_source(user, source) -> bool:
@@ -106,9 +100,9 @@ def user_can_edit_source(user, source) -> bool:
     source_id = source.id
     assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
 
-    is_project_manager = user.groups.filter(name="project manager").exists()
-    is_editor = user.groups.filter(name="editor").exists()
-    is_contributor = user.groups.filter(name="contributor").exists()
+    is_project_manager: bool = user.groups.filter(name="project manager").exists()
+    is_editor: bool = user.groups.filter(name="editor").exists()
+    is_contributor: bool = user.groups.filter(name="contributor").exists()
 
     if (
         (is_project_manager)
@@ -133,6 +127,4 @@ def user_can_manage_source_editors(user) -> bool:
     Checks if the user has permission to change the editors assigned to a Source.
     Used in SourceDetailView.
     """
-    if user.is_staff or user.groups.filter(name="project manager").exists():
-        return True
-    return False
+    return user.is_staff or user.groups.filter(name="project manager").exists()

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -53,7 +53,7 @@ def user_can_proofread_chants_in_source(user: User, source: Source) -> bool:
     return (user_is_project_manager) or (user_is_editor and user_is_assigned_to_source)
 
 
-def user_can_view_unpublished_source(user: User, source: Source) -> bool:
+def user_can_view_source(user: User, source: Source) -> bool:
     """
     Checks if the user can view an unpublished Source on the site.
     Used in ChantDetail, SequenceDetail, and SourceDetail views.
@@ -62,7 +62,7 @@ def user_can_view_unpublished_source(user: User, source: Source) -> bool:
     return (source.published) or (user_is_authenticated)
 
 
-def user_can_view_unpublished_chant(user: User, chant: Chant) -> bool:
+def user_can_view_chant(user: User, chant: Chant) -> bool:
     """
     Checks if the user can view a Chant belonging to an unpublished Source on the site.
     Used in ChantDetail, SequenceDetail, and SourceDetail views.
@@ -72,7 +72,7 @@ def user_can_view_unpublished_chant(user: User, chant: Chant) -> bool:
     return (source is not None) or (source.published) or (user_is_authenticated)
 
 
-def user_can_view_unpublished_sequence(user: User, sequence: Sequence) -> bool:
+def user_can_view_sequence(user: User, sequence: Sequence) -> bool:
     """
     Checks if the user can view a Sequence belonging to an unpublished Source on the site.
     Used in ChantDetail, SequenceDetail, and SourceDetail views.

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -48,17 +48,15 @@ def user_can_proofread_chants_in_source(user, source_id) -> bool:
     ).exists()
 
     user_is_project_manager: bool = user.groups.filter(name="project manager").exists()
-    user_id_editor: bool = user.groups.filter(name="editor").exists()
+    user_is_editor: bool = user.groups.filter(name="editor").exists()
 
-    if (user_is_project_manager) or (user_id_editor and user_is_assigned_to_source):
-        return True
-    return False
+    return (user_is_project_manager) or (user_is_editor and user_is_assigned_to_source)
 
 
 def user_can_view_unpublished_source(user, source) -> bool:
     """
-    Checks if the user can view unpublished Sources or Chants/Sequences belonging
-    to unpublished sources on the site.
+    Checks if the user can view an unpublished Source or Chant/Sequence belonging
+    to an unpublished Source on the site.
     Used in ChantDetail, SequenceDetail, and SourceDetail views.
     """
     user_is_authenticated: bool = user.is_authenticated

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -80,7 +80,7 @@ def user_can_edit_sequence(user: User) -> bool:
     return user.groups.filter(name="project manager").exists()
 
 
-def user_can_create_source(user: User) -> bool:
+def user_can_create_sources(user: User) -> bool:
     """
     Checks if the user has permission to create a Source object.
     Used in SourceCreateView.

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 
 
-def user_can_edit_chants_in_source(user, source):
+def user_can_edit_chants_in_source(user, source) -> bool:
     """
     Checks if the user can edit Chants in a given Source.
     Used in ChantDetail, ChantList, ChantCreate, ChantDelete, ChantEdit,
@@ -26,7 +26,7 @@ def user_can_edit_chants_in_source(user, source):
     )
 
 
-def user_is_proofreader(user):
+def user_is_proofreader(user) -> bool:
     """
     Checks if the user is a proofreader.
     Used in UserSourceListView.
@@ -36,7 +36,7 @@ def user_is_proofreader(user):
     return False
 
 
-def user_can_proofread_chants_in_source(user, source_id):
+def user_can_proofread_chants_in_source(user, source_id) -> bool:
     """
     Checks if the user can access the proofreading page of a given Source.
     Used in ChantProofreadView.
@@ -53,7 +53,7 @@ def user_can_proofread_chants_in_source(user, source_id):
     return False
 
 
-def user_can_view_unpublished_source(user, source):
+def user_can_view_unpublished_source(user, source) -> bool:
     """
     Checks if the user can view unpublished Sources or Chants/Sequences belonging
     to unpublished sources on the site.
@@ -69,7 +69,7 @@ def user_can_view_unpublished_source(user, source):
     return True
 
 
-def user_can_edit_sequence(user):
+def user_can_edit_sequence(user) -> bool:
     """
     Checks if the user has permission to edit a Sequence object.
     Used in SequenceDetail and SequenceEdit views.
@@ -81,7 +81,7 @@ def user_can_edit_sequence(user):
     return False
 
 
-def user_can_create_source(user):
+def user_can_create_source(user) -> bool:
     """
     Checks if the user has permission to create a Source object.
     Used in SourceCreateView.
@@ -96,7 +96,7 @@ def user_can_create_source(user):
     return False
 
 
-def user_can_edit_source(user, source):
+def user_can_edit_source(user, source) -> bool:
     """
     Checks if the user has permission to edit a Source object.
     Used in SourceDetail, SourceEdit, and SourceDelete views.
@@ -120,17 +120,15 @@ def user_can_edit_source(user, source):
     return False
 
 
-def user_can_view_user_detail(viewing_user, user):
+def user_can_view_user_detail(viewing_user, user) -> bool:
     """
     Checks if the user can view the user detail pages of regular users in the database or just indexers.
     Used in UserDetailView.
     """
-    if viewing_user.is_authenticated or user.is_indexer:
-        return True
-    return False
+    return viewing_user.is_authenticated or user.is_indexer
 
 
-def user_can_manage_source_editors(user):
+def user_can_manage_source_editors(user) -> bool:
     """
     Checks if the user has permission to change the editors assigned to a Source.
     Used in SourceDetailView.

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -125,9 +125,9 @@ def user_can_view_user_detail(viewing_user, user):
     Checks if the user can view the user detail pages of regular users in the database or just indexers.
     Used in UserDetailView.
     """
-    if not (viewing_user.is_authenticated or user.is_indexer):
-        return False
-    return True
+    if viewing_user.is_authenticated or user.is_indexer:
+        return True
+    return False
 
 
 def user_can_manage_source_editors(user):

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -98,7 +98,6 @@
         </div>
         
     </form>
-    <a href='#' onclick="showLoaderOnClick('{{ url_with_search_params }}')">This will take some time...</a>
 
     {% if chants.exists %}
         <small>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -295,7 +295,7 @@
                                         <a href="{% url "source-edit" source.id%}">Edit source description</a>
                                     </li>
                                 {% endif %}
-                                {% if request.user.is_staff or request.user|has_group:"project_manager" %}
+                                {% if user_can_manage_source_editors %}
                                     <li>
                                         <a href={% url 'admin:main_app_source_change' source.id %}>Manage source editors</a>
                                     </li>

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -9,7 +9,7 @@
             <a href="{% url "source-create" %}"><b>+ Add new source</b></a>
             <table class="table table-sm small table-bordered">
                 <tbody>
-                    {% for source, user_can_proofread in page_obj %}
+                    {% for source, user_can_proofread_source in page_obj %}
                         <tr>
                             <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0; text-align:center">
                                 <a href="{% url "source-detail" source.pk %}">
@@ -22,7 +22,7 @@
                                         Full text &amp; volpiano editor
                                     </a>
                                 </td>
-                                {% if user_can_proofread %}
+                                {% if user_can_proofread_source %}
                                     <td class="h-25" style="width: 30%; text-align:center">
                                         <a href="{% url "chant-proofread" source.pk %}">
                                             Proofreading form

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -9,7 +9,7 @@
             <a href="{% url "source-create" %}"><b>+ Add new source</b></a>
             <table class="table table-sm small table-bordered">
                 <tbody>
-                    {% for source in page_obj %}
+                    {% for source, user_can_proofread in page_obj %}
                         <tr>
                             <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0; text-align:center">
                                 <a href="{% url "source-detail" source.pk %}">
@@ -22,7 +22,7 @@
                                         Full text &amp; volpiano editor
                                     </a>
                                 </td>
-                                {% if user_is_proofreader %}
+                                {% if user_can_proofread %}
                                     <td class="h-25" style="width: 30%; text-align:center">
                                         <a href="{% url "chant-proofread" source.pk %}">
                                             Proofreading form

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -16,7 +16,7 @@
                                     <b>{{ source.siglum }}</b>
                                 </a>
                             </td>
-                            {% if source.chant_set.all %}
+                            {% if source.chant_set.exists %}
                                 <td class="h-25" style="width: 30%; text-align:center">
                                     <a href="{% url "source-edit-chants" source.pk %}">
                                         Full text &amp; volpiano editor
@@ -67,7 +67,7 @@
                                         &plus; Add new chant
                                     </a>
                                     <br>
-                                    {% if my_source.chant_set.all %}
+                                    {% if my_source.chant_set.exists %}
                                         <a href="{% url "source-edit-chants" my_source.pk %}">
                                             &bull; Full text &amp; volpiano editor
                                         </a>

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -16,13 +16,13 @@
                                     <b>{{ source.siglum }}</b>
                                 </a>
                             </td>
-                            {% if source.chant_set.all%}
+                            {% if source.chant_set.all %}
                                 <td class="h-25" style="width: 30%; text-align:center">
                                     <a href="{% url "source-edit-chants" source.pk %}">
                                         Full text &amp; volpiano editor
                                     </a>
                                 </td>
-                                {% if request.user|has_group:"project manager" or request.user|has_group:"editor" %}
+                                {% if user_is_proofreader %}
                                     <td class="h-25" style="width: 30%; text-align:center">
                                         <a href="{% url "chant-proofread" source.pk %}">
                                             Proofreading form

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1687,8 +1687,8 @@ class ChantProofreadView(SourceEditChantsView):
 
     def test_func(self):
         user = self.request.user
-        chant = self.get_object()
-        source = chant.source
+        source_id = self.kwargs.get(self.pk_url_kwarg)
+        source = Source.objects.get(id=source_id)
         return user_can_proofread_chants_in_source(user, source)
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -36,7 +36,7 @@ from requests import Response
 from main_app.permissions import (
     user_can_edit_chants_in_source,
     user_can_proofread_chants_in_source,
-    user_can_view_unpublished_chant,
+    user_can_view_chant,
 )
 
 CHANT_SEARCH_TEMPLATE_VALUES = (
@@ -275,7 +275,7 @@ class ChantDetailView(DetailView):
 
         # if the chant's source isn't published, only logged-in users should be able to
         # view the chant's detail page
-        if not user_can_view_unpublished_chant(user, chant):
+        if not user_can_view_chant(user, chant):
             raise PermissionDenied()
 
         context["user_can_edit_chant"] = user_can_edit_chants_in_source(user, source)

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -36,7 +36,7 @@ from requests import Response
 from main_app.permissions import (
     user_can_edit_chants_in_source,
     user_can_proofread_chants_in_source,
-    user_can_view_unpublished_source,
+    user_can_view_unpublished_chant,
 )
 
 CHANT_SEARCH_TEMPLATE_VALUES = (
@@ -271,11 +271,11 @@ class ChantDetailView(DetailView):
         context = super().get_context_data(**kwargs)
         chant = self.get_object()
         user = self.request.user
+        source = chant.source
 
         # if the chant's source isn't published, only logged-in users should be able to
         # view the chant's detail page
-        source = chant.source
-        if not user_can_view_unpublished_source(user, source):
+        if not user_can_view_unpublished_chant(user, chant):
             raise PermissionDenied()
 
         context["user_can_edit_chant"] = user_can_edit_chants_in_source(user, source)
@@ -1687,9 +1687,9 @@ class ChantProofreadView(SourceEditChantsView):
 
     def test_func(self):
         user = self.request.user
-
-        source_id = self.kwargs.get(self.pk_url_kwarg)
-        return user_can_proofread_chants_in_source(user, source_id)
+        chant = self.get_object()
+        source = chant.source
+        return user_can_proofread_chants_in_source(user, source)
 
 
 class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
@@ -1742,4 +1742,3 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
     def get_success_url(self):
         # stay on the same page after save
         return self.request.get_full_path()
-

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -33,6 +33,11 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from typing import Optional, Union
 from requests.exceptions import SSLError, Timeout, ConnectionError
 from requests import Response
+from main_app.permissions import (
+    user_can_edit_chants_in_source,
+    user_can_proofread_chants_in_source,
+    user_can_view_unpublished_source,
+)
 
 CHANT_SEARCH_TEMPLATE_VALUES = (
     # for views that use chant_search.html, this allows them to
@@ -270,8 +275,7 @@ class ChantDetailView(DetailView):
         # if the chant's source isn't published, only logged-in users should be able to
         # view the chant's detail page
         source = chant.source
-        display_unpublished = user.is_authenticated
-        if (source.published is False) and (not display_unpublished):
+        if not user_can_view_unpublished_source(user, source):
             raise PermissionDenied()
 
         context["user_can_edit_chant"] = user_can_edit_chants_in_source(user, source)
@@ -1683,21 +1687,9 @@ class ChantProofreadView(SourceEditChantsView):
 
     def test_func(self):
         user = self.request.user
-        if user.is_anonymous:
-            return False
+
         source_id = self.kwargs.get(self.pk_url_kwarg)
-
-        assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
-
-        # checks if the user is a project manager
-        is_project_manager = user.groups.filter(name="project manager").exists()
-        # checks if the user is an editor,
-        is_editor = user.groups.filter(name="editor").exists()
-
-        if (is_project_manager) or (is_editor and assigned_to_source):
-            return True
-        else:
-            return False
+        return user_can_proofread_chants_in_source(user, source_id)
 
 
 class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
@@ -1751,22 +1743,3 @@ class ChantEditSyllabificationView(LoginRequiredMixin, UserPassesTestMixin, Upda
         # stay on the same page after save
         return self.request.get_full_path()
 
-
-def user_can_edit_chants_in_source(user, source):
-    if user.is_anonymous:
-        return False
-
-    source_id = source.id
-    user_is_assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
-
-    user_is_project_manager = user.groups.filter(name="project manager").exists()
-    user_is_editor = user.groups.filter(name="editor").exists()
-    user_is_contributor = user.groups.filter(name="contributor").exists()
-
-    return (
-        (user_is_project_manager)
-        or (user_is_editor and user_is_assigned_to_source)
-        or (user_is_editor and source.created_by == user)
-        or (user_is_contributor and user_is_assigned_to_source)
-        or (user_is_contributor and source.created_by == user)
-    )

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -6,7 +6,10 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
-from main_app.views.chant import user_can_edit_chants_in_source
+from main_app.permissions import (
+    user_can_view_unpublished_source,
+    user_can_edit_sequence,
+)
 
 
 class SequenceDetailView(DetailView):
@@ -25,11 +28,7 @@ class SequenceDetailView(DetailView):
 
         # if the sequence's source isn't published,
         # only logged-in users should be able to view the sequence's detail page
-        if (
-            (source is not None)
-            and (source.published is False)
-            and (not self.request.user.is_authenticated)
-        ):
+        if not user_can_view_unpublished_source(user, source):
             raise PermissionDenied()
 
         context = super().get_context_data(**kwargs)
@@ -38,7 +37,7 @@ class SequenceDetailView(DetailView):
             .select_related("source")
             .order_by("siglum")
         )
-        context["user_can_edit_sequence"] = user_can_edit_chants_in_source(user, source)
+        context["user_can_edit_sequence"] = user_can_edit_sequence(user)
         return context
 
 
@@ -88,10 +87,4 @@ class SequenceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
     def test_func(self):
         user = self.request.user
-        # checks if the user is a project manager (they should have the privilege to edit any sequence)
-        is_project_manager = user.groups.filter(name="project manager").exists()
-
-        if is_project_manager:
-            return True
-        else:
-            return False
+        return user_can_edit_sequence(user)

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from main_app.permissions import (
-    user_can_view_unpublished_sequence,
+    user_can_view_sequence,
     user_can_edit_sequence,
 )
 
@@ -27,7 +27,7 @@ class SequenceDetailView(DetailView):
 
         # if the sequence's source isn't published,
         # only logged-in users should be able to view the sequence's detail page
-        if not user_can_view_unpublished_sequence(user, sequence):
+        if not user_can_view_sequence(user, sequence):
             raise PermissionDenied()
 
         context = super().get_context_data(**kwargs)

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from main_app.permissions import (
-    user_can_view_unpublished_source,
+    user_can_view_unpublished_sequence,
     user_can_edit_sequence,
 )
 
@@ -23,12 +23,11 @@ class SequenceDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         sequence = self.get_object()
-        source = sequence.source
         user = self.request.user
 
         # if the sequence's source isn't published,
         # only logged-in users should be able to view the sequence's detail page
-        if not user_can_view_unpublished_source(user, source):
+        if not user_can_view_unpublished_sequence(user, sequence):
             raise PermissionDenied()
 
         context = super().get_context_data(**kwargs)

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -20,7 +20,7 @@ from main_app.views.chant import (
     user_can_edit_chants_in_source,
 )
 from main_app.permissions import (
-    user_can_create_source,
+    user_can_create_sources,
     user_can_edit_source,
     user_can_view_unpublished_source,
     user_can_manage_source_editors,
@@ -200,7 +200,7 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
     def test_func(self):
         user = self.request.user
-        return user_can_create_source(user)
+        return user_can_create_sources(user)
 
     def get_success_url(self):
         return reverse("source-detail", args=[self.object.id])

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -22,7 +22,7 @@ from main_app.views.chant import (
 from main_app.permissions import (
     user_can_create_sources,
     user_can_edit_source,
-    user_can_view_unpublished_source,
+    user_can_view_source,
     user_can_manage_source_editors,
 )
 
@@ -36,7 +36,7 @@ class SourceDetailView(DetailView):
         source = self.get_object()
         user = self.request.user
 
-        if not user_can_view_unpublished_source(user, source):
+        if not user_can_view_source(user, source):
             raise PermissionDenied()
 
         context = super().get_context_data(**kwargs)

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -19,6 +19,12 @@ from main_app.views.chant import (
     get_feast_selector_options,
     user_can_edit_chants_in_source,
 )
+from main_app.permissions import (
+    user_can_create_source,
+    user_can_edit_source,
+    user_can_view_unpublished_source,
+    user_can_manage_source_editors,
+)
 
 
 class SourceDetailView(DetailView):
@@ -29,8 +35,8 @@ class SourceDetailView(DetailView):
     def get_context_data(self, **kwargs):
         source = self.get_object()
         user = self.request.user
-        display_unpublished = self.request.user.is_authenticated
-        if (source.published is False) and (not display_unpublished):
+
+        if not user_can_view_unpublished_source(user, source):
             raise PermissionDenied()
 
         context = super().get_context_data(**kwargs)
@@ -56,6 +62,7 @@ class SourceDetailView(DetailView):
 
         context["user_can_edit_chants"] = user_can_edit_chants_in_source(user, source)
         context["user_can_edit_source"] = user_can_edit_source(user, source)
+        context["user_can_manage_source_editors"] = user_can_manage_source_editors(user)
         return context
 
 
@@ -193,15 +200,7 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
     def test_func(self):
         user = self.request.user
-        # checks if the user is allowed to create sources
-        is_authorized = user.groups.filter(
-            Q(name="project manager") | Q(name="editor") | Q(name="contributor")
-        ).exists()
-
-        if is_authorized:
-            return True
-        else:
-            return False
+        return user_can_create_source(user)
 
     def get_success_url(self):
         return reverse("source-detail", args=[self.object.id])
@@ -301,26 +300,3 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             new_editor.sources_user_can_edit.add(source)
 
         return HttpResponseRedirect(self.get_success_url())
-
-
-def user_can_edit_source(user, source):
-    if user.is_anonymous:
-        return False
-    source_id = source.id
-    assigned_to_source = user.sources_user_can_edit.filter(id=source_id)
-
-    # checks if the user is a project manager
-    is_project_manager = user.groups.filter(name="project manager").exists()
-    # checks if the user is an editor
-    is_editor = user.groups.filter(name="editor").exists()
-    # checks if the user is a contributor
-    is_contributor = user.groups.filter(name="contributor").exists()
-
-    if (
-        (is_project_manager)
-        or (is_editor and assigned_to_source)
-        or (is_editor and source.created_by == user)
-        or (is_contributor and source.created_by == user)
-    ):
-        return True
-    return False

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -12,7 +12,10 @@ from django.contrib import messages
 from extra_views import SearchableListMixin
 from django.http import HttpResponseRedirect
 from django.core.exceptions import PermissionDenied
-from main_app.permissions import user_can_view_user_detail, user_is_proofreader
+from main_app.permissions import (
+    user_can_view_user_detail,
+    user_can_proofread_chants_in_source,
+)
 
 
 class UserDetailView(DetailView):
@@ -80,10 +83,11 @@ class UserSourceListView(LoginRequiredMixin, ListView):
     model = Source
     context_object_name = "sources"
     template_name = "user_source_list.html"
-    paginate_by = 100
 
-    def get_queryset(self):
-        return (
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        my_sources = (
             Source.objects.filter(
                 Q(current_editors=self.request.user)
                 | Q(created_by=self.request.user)
@@ -96,21 +100,27 @@ class UserSourceListView(LoginRequiredMixin, ListView):
             .order_by("-date_created")
             .distinct()
         )
+        user = self.request.user
+        sources_with_proofread_permissions = [
+            (source, user_can_proofread_chants_in_source(user, source))
+            for source in my_sources
+        ]
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
+        user_sources_paginator = Paginator(sources_with_proofread_permissions, 10)
+        user_sources_page_num = self.request.GET.get("page")
+        user_sources_page_obj = user_sources_paginator.get_page(user_sources_page_num)
 
         user_created_sources = (
             Source.objects.filter(created_by=self.request.user)
             .order_by("-date_created")
             .distinct()
         )
-        paginator = Paginator(user_created_sources, 6)
-        page_number = self.request.GET.get("page2")
-        page_obj = paginator.get_page(page_number)
+        user_created_paginator = Paginator(user_created_sources, 6)
+        user_created_page_num = self.request.GET.get("page2")
+        user_created_page_obj = user_created_paginator.get_page(user_created_page_num)
 
-        context["user_created_sources_page_obj"] = page_obj
-        context["user_is_proofreader"] = user_is_proofreader(self.request.user)
+        context["page_obj"] = user_sources_page_obj
+        context["user_created_sources_page_obj"] = user_created_page_obj
         return context
 
 

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -12,6 +12,7 @@ from django.contrib import messages
 from extra_views import SearchableListMixin
 from django.http import HttpResponseRedirect
 from django.core.exceptions import PermissionDenied
+from main_app.permissions import user_can_view_user_detail, user_is_proofreader
 
 
 class UserDetailView(DetailView):
@@ -30,7 +31,7 @@ class UserDetailView(DetailView):
         # they should only be able to view the detail pages of indexers,
         # and not the detail pages of run-of-the-mill users
         viewing_user = self.request.user
-        if not (viewing_user.is_authenticated or user.is_indexer):
+        if not user_can_view_user_detail(viewing_user, user):
             raise PermissionDenied()
 
         context = super().get_context_data(**kwargs)
@@ -109,6 +110,7 @@ class UserSourceListView(LoginRequiredMixin, ListView):
         page_obj = paginator.get_page(page_number)
 
         context["user_created_sources_page_obj"] = page_obj
+        context["user_is_proofreader"] = user_is_proofreader(self.request.user)
         return context
 
 

--- a/django/cantusdb_project/static/js/chant_search.js
+++ b/django/cantusdb_project/static/js/chant_search.js
@@ -2,14 +2,6 @@ function containsOnlyLettersAndSpaces(str) {
     return /^[A-Za-z\s]*$/.test(str);
   }
 
-function showLoaderOnClick(url) {
-    showLoader();
-    window.location=url;
-}
-function showLoader(){
-    $('body').append('<div style="" id="loadingDiv"><div class="loader">Loading...</div></div>');
-}
-
 window.addEventListener("load", function () {
     // Make sure the select components keep their values across multiple GET requests
     // so the user can "drill down" on what they want


### PR DESCRIPTION
This PR focuses on enhancing the maintainability of our codebase. Previously, locating the sections of code responsible for checking user permissions before rendering views or managing specific links was challenging. In response, we've implemented a restructuring effort.

In this update, we've taken all the code related to user permissions and consolidated it into a dedicated file named `permissions.py`, located under the `main_app/` directory. This aims to make it much clearer and easier to identify the parts of our codebase that handle user permissions.

Note: we still use the `has_group` helper tag in `base.html` and `default.html` to handle some user permissions to display certain links in the admin navigation and my sources sidebar. Since these templates don't have a view, we can either leave it as is or set up a function in `context_processors.py` that uses `permissions.py` to handle these cases as well, but I'm unsure if this would make things more complicated.

Resolves #962 