### PR TITLE
Add Feast autocomplete for chant create/edit pages

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -298,7 +298,7 @@ class ChantEditForm(forms.ModelForm):
             "marginalia": TextInputWidget(),
             # folio: defined below (required)
             # c_sequence: defined below (required)
-            # feast: defined below (foreignkey)
+            "feast": autocomplete.ModelSelect2(url="feast-autocomplete"),
             # office: defined below (foreignkey)
             # genre: defined below (foreignkey)
             "position": TextInputWidget(),
@@ -335,11 +335,6 @@ class ChantEditForm(forms.ModelForm):
         widget=TextInputWidget,
         help_text="Each folio starts with '1'.",
     )
-
-    feast = forms.ModelChoiceField(
-        queryset=Feast.objects.all().order_by("name"), required=False
-    )
-    feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
     # instead of [name] + description

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -109,7 +109,7 @@ class ChantCreateForm(forms.ModelForm):
             # genre: defined below (foreignkey)
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
-            #'feast': defined below (foreignkey)
+            "feast": autocomplete.ModelSelect2(url="feast-autocomplete"),
             "mode": TextInputWidget(),
             "differentia": TextInputWidget(),
             "differentia_new": TextInputWidget(),
@@ -153,11 +153,6 @@ class ChantCreateForm(forms.ModelForm):
         required=False,
     )
     genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    feast = forms.ModelChoiceField(
-        queryset=Feast.objects.all().order_by("name"), required=False
-    )
-    feast.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
 
     manuscript_full_text_std_spelling = forms.CharField(
         required=True,

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
+{% load static %}
 {% block content %}
 <title>Create Chant | Cantus Manuscript Database</title>
 <script src="/static/js/chant_create.js"></script>
+<script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+{{ form.media }}
 <div class="container">
     <div class="row">
         <div class="mr-3 p-3 col-md-8 bg-white rounded">
@@ -83,7 +86,7 @@
 
                 <div class="form-row">
 
-                    <div class="form-group m-1 col-lg-5">
+                    <div class="form-group m-1 col-lg-3">
                         <small>{{ form.feast.label_tag }}</small>
                         {{ form.feast }}
                     </div>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -88,7 +88,7 @@
 
                     <div class="form-group m-1 col-lg-3">
                         <small>{{ form.feast.label_tag }}</small>
-                        {{ form.feast }}
+                        <br>{{ form.feast }}
                     </div>
                     
                 </div>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
+{% load static %}
 <title>{{ source.title }} | Cantus Manuscript Database</title>
 <script src="/static/js/chant_edit.js"></script>
-
+<script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+{{ form.media }}
 <div class="container">
     <div class="row">
         <div class="mr-3 p-3 col-lg-8 bg-white rounded">
@@ -55,9 +57,12 @@
                             </label>
                             {{ form.c_sequence }}
                         </div>
-                        <div class="form-group m-1 col-lg-4">
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-3">
                             <small>{{ form.feast.label_tag }}</small>
-                            {{ form.feast }}
+                            <br>{{ form.feast }}
                         </div>
                     </div>
 

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -68,6 +68,7 @@ from main_app.views.views import (
     AllUsersAutocomplete,
     CenturyAutocomplete,
     RismSiglumAutocomplete,
+    FeastAutocomplete,
 )
 
 urlpatterns = [
@@ -465,6 +466,11 @@ urlpatterns = [
         "rismsiglum-autocomplete/",
         RismSiglumAutocomplete.as_view(),
         name="rismsiglum-autocomplete",
+    ),
+    path(
+        "feast-autocomplete/",
+        FeastAutocomplete.as_view(),
+        name="feast-autocomplete",
     ),
 ]
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1003,3 +1003,15 @@ class RismSiglumAutocomplete(autocomplete.Select2QuerySetView):
         if self.q:
             qs = qs.filter(name__istartswith=self.q)
         return qs
+
+
+class FeastAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Feast.objects.none()
+        qs = Feast.objects.all().order_by("name")
+        if self.q:
+            qs = qs.filter(
+                Q(name__istartswith=self.q) | Q(feast_code__istartswith=self.q)
+            )
+        return qs


### PR DESCRIPTION
Resolves #987. Now feasts come in a searchable dropdown widget where the user can search by feast name or feast code. This makes it easier and faster to find the desired feast rather than having to scroll through hundreds of list items in a regular dropdown.

<img width="765" alt="image" src="https://github.com/DDMAL/CantusDB/assets/71031342/170ecf05-c7ae-4fc5-b0fa-bebd7232b82d">
