### PR TITLE
permissions: fix import statements and function calls

### DIFF
--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -69,7 +69,7 @@ def user_can_view_chant(user: User, chant: Chant) -> bool:
     """
     source = chant.source
     user_is_authenticated: bool = user.is_authenticated
-    return (source is not None) or (source.published) or (user_is_authenticated)
+    return (source is not None) and ((source.published) or (user_is_authenticated))
 
 
 def user_can_view_sequence(user: User, sequence: Sequence) -> bool:
@@ -79,7 +79,7 @@ def user_can_view_sequence(user: User, sequence: Sequence) -> bool:
     """
     source = sequence.source
     user_is_authenticated: bool = user.is_authenticated
-    return (source is not None) or (source.published) or (user_is_authenticated)
+    return (source is not None) and ((source.published) or (user_is_authenticated))
 
 
 def user_can_edit_sequences(user: User) -> bool:

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -766,6 +766,7 @@ class ChantDetailViewTest(TestCase):
         source.save()
         response = self.client.get(reverse("chant-detail", args=[chant.id]))
         self.assertEqual(response.status_code, 200)
+        print(response.context)
 
         source.published = False
         source.save()

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -8,7 +8,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from main_app.permissions import (
     user_can_view_sequence,
-    user_can_edit_sequence,
+    user_can_edit_sequences,
 )
 
 
@@ -36,7 +36,7 @@ class SequenceDetailView(DetailView):
             .select_related("source")
             .order_by("siglum")
         )
-        context["user_can_edit_sequence"] = user_can_edit_sequence(user)
+        context["user_can_edit_sequence"] = user_can_edit_sequences(user)
         return context
 
 
@@ -86,4 +86,4 @@ class SequenceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
     def test_func(self):
         user = self.request.user
-        return user_can_edit_sequence(user)
+        return user_can_edit_sequences(user)


### PR DESCRIPTION
This PR is a quick fix to the import statements and calls to the function `user_can_edit_sequences` which used to remain as the old function name `user_can_edit_sequence`