### PR TITLE
Remove unnecessary print statements in views/redirect_documents

### DIFF
--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -947,8 +947,6 @@ def redirect_documents(request) -> HttpResponse:
     try:
         new_path = mapping[old_path]
     except KeyError:
-        print("key error!")
-        print(old_path)
         raise Http404
     return redirect(new_path)
 


### PR DESCRIPTION
I noticed some weird output while running tests on the Staging server, so went hunting for errant print statements. I don't think I found the print statements responsible for the weird output, but I found a few unrelated unnecessary print statements.