### PR TITLE
Insert "add chant" links to chant-proofread and chant-edit pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -235,18 +235,20 @@
                     <dd><small>3) The <b>fulltext</b> and <b>Volpiano</b> fields should appear in this area</small></dd>
                     <dd><small>4) Edit the fields <b>according to the manuscript, following the fulltext guidelines created by Cantus</b></small></dd>
                     <dd><small>5) Click <b>"SAVE"</b></small></dd>
-                </dl> 
-                <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="display: inline-block; margin-top:5px;">
-                    {{ source.siglum }}
-                </a>
-                <br>
-                <a href="{% url "chant-create" source.pk %}" style="display: inline-block; margin-top:5px;">
-                    <small><b>&plus; Add new chant</b></small>
-                </a>
-                <br>
-                <a href="{% url "source-create" %}" style="display: inline-block; margin-top:5px;">
-                    <small><b>&plus; Add new source</b></small>
-                </a>
+                </dl>
+                <div>
+                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="margin-top:5px;">
+                        {{ source.siglum }}
+                    </a>
+                </div>
+                    <a href="{% url "chant-create" source.pk %}" style="margin-top:5px;">
+                        <small><b>&plus; Add new chant</b></small>
+                    </a>
+                <div>
+                    <a href="{% url "source-create" %}" style="margin-top:5px;">
+                        <small><b>&plus; Add new source</b></small>
+                    </a>
+                </div>
             {% endif %}
         </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -236,16 +236,18 @@
                     <dd><small>4) Edit the fields <b>according to the manuscript, following the fulltext guidelines created by Cantus</b></small></dd>
                     <dd><small>5) Click <b>"SAVE"</b></small></dd>
                 </dl>
-                <div>
-                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="margin-top:5px;">
+                <div style="margin-top:5px;">
+                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">
                         {{ source.siglum }}
                     </a>
                 </div>
-                    <a href="{% url "chant-create" source.pk %}" style="margin-top:5px;">
+                <div style="margin-top:5px;">
+                    <a href="{% url "chant-create" source.pk %}">
                         <small><b>&plus; Add new chant</b></small>
                     </a>
-                <div>
-                    <a href="{% url "source-create" %}" style="margin-top:5px;">
+                </div>
+                <div style="margin-top:5px;">
+                    <a href="{% url "source-create" %}">
                         <small><b>&plus; Add new source</b></small>
                     </a>
                 </div>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -236,12 +236,16 @@
                     <dd><small>4) Edit the fields <b>according to the manuscript, following the fulltext guidelines created by Cantus</b></small></dd>
                     <dd><small>5) Click <b>"SAVE"</b></small></dd>
                 </dl> 
-                <a href="{% url "source-create" %}" style="display: inline-block; margin-top:5px;">
-                    <small><b>&plus; Add new source</b></small>
-                </a>
-                <br>
                 <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="display: inline-block; margin-top:5px;">
                     {{ source.siglum }}
+                </a>
+                <br>
+                <a href="{% url "chant-create" source.pk %}" style="display: inline-block; margin-top:5px;">
+                    <small><b>&plus; Add new chant</b></small>
+                </a>
+                <br>
+                <a href="{% url "source-create" %}" style="display: inline-block; margin-top:5px;">
+                    <small><b>&plus; Add new source</b></small>
                 </a>
             {% endif %}
         </div>

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -244,17 +244,21 @@
                     <dd><small>2) Click <b>"EDIT"</b> next to any chant</small></dd>
                     <dd><small>3) Proofread the chant and click <b>"SAVE"</b></small></dd>
                 </dl>
-                <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="display: inline-block; margin-top:5px;">
-                    {{ source.siglum }}
-                </a>
-                <br>
-                <a href="{% url "chant-create" source.pk %}" style="display: inline-block; margin-top:5px;">
-                    <small><b>&plus; Add new chant</b></small>
-                </a>
-                <br>
-                <a href="{% url "source-create" %}" style="display: inline-block; margin-top:5px;">
-                    <small><b>&plus; Add new source</b></small>
-                </a>
+                <div style="margin-top:5px;">
+                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">
+                        {{ source.siglum }}
+                    </a>
+                </div>
+                <div style="margin-top:5px;">
+                    <a href="{% url "chant-create" source.pk %}">
+                        <small><b>&plus; Add new chant</b></small>
+                    </a>
+                </div>
+                <div style="margin-top:5px;">
+                    <a href="{% url "source-create" %}">
+                        <small><b>&plus; Add new source</b></small>
+                    </a>
+                </div>
             {% endif %}
         </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_proofread.html
+++ b/django/cantusdb_project/main_app/templates/chant_proofread.html
@@ -243,7 +243,18 @@
                     <dd><small>1) Select a <b>folio</b> or a <b>feast</b> (in the right block)</small></dd>
                     <dd><small>2) Click <b>"EDIT"</b> next to any chant</small></dd>
                     <dd><small>3) Proofread the chant and click <b>"SAVE"</b></small></dd>
-                </dl> 
+                </dl>
+                <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}" style="display: inline-block; margin-top:5px;">
+                    {{ source.siglum }}
+                </a>
+                <br>
+                <a href="{% url "chant-create" source.pk %}" style="display: inline-block; margin-top:5px;">
+                    <small><b>&plus; Add new chant</b></small>
+                </a>
+                <br>
+                <a href="{% url "source-create" %}" style="display: inline-block; margin-top:5px;">
+                    <small><b>&plus; Add new source</b></small>
+                </a>
             {% endif %}
         </div>
 


### PR DESCRIPTION
Resolves #1004. We now display a link to edit chants in a given source on the full text & volpiano edit page as well as the chant-proofread page.

<img width="1168" alt="image" src="https://github.com/DDMAL/CantusDB/assets/71031342/f991feed-00b6-46cd-9cd5-32a816d1529b">
