### PR TITLE
Chant Detail: Add Differentia DB field

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -129,6 +129,17 @@
                         </div>
                     {% endif %}
 
+                    {% if chant.differentia_new %}
+                        <div class="col">
+                            <dt>Differentia&nbsp;Database</dt>
+                            <dd>
+                                <a href="https://differentiaedatabase.ca/differentia/{{ chant.differentia_new }}" target="_blank">
+                                    {{ chant.differentia_new }}
+                                </a>
+                            </dd>
+                        </div>
+                    {% endif %}
+
                     {% if chant.chant_range %}
                         <div class="col">
                             <dt>Range</dt>


### PR DESCRIPTION
with link to differentiaedatabase.ca

fixes #1014

Reference: OldCantus:
![Screenshot 2023-08-29 at 1 04 52 PM](https://github.com/DDMAL/CantusDB/assets/58090591/dbbb39ff-5a9a-4bf8-85fe-bf10bb2554ed)

NewCantus, previously:
![Screenshot 2023-08-29 at 1 05 40 PM](https://github.com/DDMAL/CantusDB/assets/58090591/138a31a3-c880-42f5-bfbf-50923fc6cd6c)

NewCantus, following these changes:
![Screenshot 2023-08-29 at 1 06 10 PM](https://github.com/DDMAL/CantusDB/assets/58090591/ef688b74-a9e8-4323-a841-bfd669827cab)

NewCantus, following these changes (a chant with an addendum):
![Screenshot 2023-08-29 at 1 06 48 PM](https://github.com/DDMAL/CantusDB/assets/58090591/c9981727-1d2d-4c0c-880f-a5fe7b1bf50e)

(note that I've not made an effort to display a volpiano preview for the differentia - this requires a call to an API we haven't figured out yet)