### PR TITLE
Chant Create: fix bug in chant suggestions

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -249,10 +249,10 @@
                         Cantus ID: <a href="https://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a><br>
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}
-                                    <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid }}()"></input>
+                                    <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid_clean }}()"></input>
                                     <strong>{{ chant.genre }}</strong> - {{ chant.fulltext|truncatechars:100 }} (<strong>{{ chant.count }}x</strong>)<br>
                                     <script>
-                                        function autoFill{{ chant.cid }}() {
+                                        function autoFill{{ chant.cid_clean }}() {
                                             document.getElementById('id_cantus_id').value = "{{ chant.cid }}";
                                             document.getElementById('id_genre').value = {{ chant.genre_id }};
                                             document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ chant.fulltext }}";

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -248,14 +248,14 @@
                         {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{% url 'chant-detail' previous_chant.id %}" target="_blank">{{ previous_chant.incipit }}</a><br>
                         Cantus ID: <a href="https://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a><br>
                             {% if suggested_chants %}
-                                {% for chant in suggested_chants %}
-                                    <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid_clean }}()" title="{{ chant.cid }}"></input>
-                                    <strong>{{ chant.genre }}</strong> - <span title="{{ chant.fulltext }}">{{ chant.fulltext|truncatechars:100 }}</span> (<strong>{{ chant.count }}x</strong>)<br>
+                                {% for cantus_id in suggested_chants %}
+                                    <input type="button" style="width: 80px" value="{{ cantus_id.cid }}" onclick="autoFill{{ cantus_id.cid_clean }}()" title="{{ cantus_id.cid }}"></input>
+                                    <strong>{{ cantus_id.genre }}</strong> - <span title="{{ cantus_id.fulltext }}">{{ cantus_id.fulltext|truncatechars:100 }}</span> (<strong>{{ cantus_id.count }}x</strong>)<br>
                                     <script>
-                                        function autoFill{{ chant.cid_clean }}() {
-                                            document.getElementById('id_cantus_id').value = "{{ chant.cid }}";
-                                            document.getElementById('id_genre').value = {{ chant.genre_id }};
-                                            document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ chant.fulltext }}";
+                                        function autoFill{{ cantus_id.cid_clean }}() {
+                                            document.getElementById('id_cantus_id').value = "{{ cantus_id.cid }}";
+                                            document.getElementById('id_genre').value = {{ cantus_id.genre_id }};
+                                            document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ cantus_id.fulltext }}";
                                         }
                                     </script>
                                 {% endfor %}

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -249,8 +249,8 @@
                         Cantus ID: <a href="https://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a><br>
                             {% if suggested_chants %}
                                 {% for chant in suggested_chants %}
-                                    <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid_clean }}()"></input>
-                                    <strong>{{ chant.genre }}</strong> - {{ chant.fulltext|truncatechars:100 }} (<strong>{{ chant.count }}x</strong>)<br>
+                                    <input type="button" style="width: 80px" value="{{ chant.cid }}" onclick="autoFill{{ chant.cid_clean }}()" title="{{ chant.cid }}"></input>
+                                    <strong>{{ chant.genre }}</strong> - <span title="{{ chant.fulltext }}">{{ chant.fulltext|truncatechars:100 }}</span> (<strong>{{ chant.count }}x</strong>)<br>
                                     <script>
                                         function autoFill{{ chant.cid_clean }}() {
                                             document.getElementById('id_cantus_id').value = "{{ chant.cid }}";

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -206,7 +206,8 @@ def make_suggested_chant_dict(
     cid_dict["genre_id"] = genre_id
     # in the template, we create a js function based on the cantus ID. The function name
     # cannot include a "." or a ":", so we have to use a cleaned version
-    cid_clean = cantus_id.replace(".", "").replace(":", "")
+    cid_clean = cantus_id.replace(".", "d").replace(":", "c")
+    #                                  "d"ot             "c"olon
     cid_dict["cid_clean"] = cid_clean
     return cid_dict
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -205,8 +205,8 @@ def make_suggested_chant_dict(
     genre_id = Genre.objects.get(name=genre_name).id
     cid_dict["genre_id"] = genre_id
     # in the template, we create a js function based on the cantus ID. The function name
-    # cannot include a ".", so we have to use a cleaned version
-    cid_clean = cantus_id.replace(".", "")
+    # cannot include a "." or a ":", so we have to use a cleaned version
+    cid_clean = cantus_id.replace(".", "").replace(":", "")
     cid_dict["cid_clean"] = cid_clean
     return cid_dict
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -204,6 +204,10 @@ def make_suggested_chant_dict(
     genre_name = cid_dict["genre"]
     genre_id = Genre.objects.get(name=genre_name).id
     cid_dict["genre_id"] = genre_id
+    # in the template, we create a js function based on the cantus ID. The function name
+    # cannot include a ".", so we have to use a cleaned version
+    cid_clean = cantus_id.replace(".", "")
+    cid_dict["cid_clean"] = cid_clean
     return cid_dict
 
 


### PR DESCRIPTION
This PR fixes a bug on the Chant Create page in the Suggested Chants feature (i.e. fixes #998, #815). Previously, we created a bunch of functions, each named after the Cantus ID of one of the suggested chants/cantus_ids, that we would call when the corresponding button was pressed. If the Cantus ID had a period in it, however, the function name would be invalid, preventing the button from working.

This PR:
- changes how these functions are named, ensuring the function name does not contain any periods or colons
- adds `title` attributes to various elements in the Suggested Chants panel (this way, if a Cantus ID is too long for its button, or if the full text is truncated with an ellipsis, the user can mouse over these elements to see the entire value)
- renames a variable in the templates: previously, we iterated through each of the suggestions with `{% for chant in suggested_chants %}`. But each suggestion was really a Cantus ID rather than a chant, so this has been changed to `{% for cantus_id in suggested_chants %}`