### PR TITLE
admin: add read_only fields to Chant and Source models

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -57,6 +57,12 @@ class ChantAdmin(BaseModelAdmin):
         "cantus_id",
         "id",
     )
+
+    readonly_fields = (
+        "date_created",
+        "date_updated",
+    )
+
     list_filter = (
         "genre",
         "office",
@@ -160,6 +166,12 @@ class SourceAdmin(BaseModelAdmin):
         "siglum",
         "title",
         "id",
+    )
+    readonly_fields = (
+        "number_of_chants",
+        "number_of_melodies",
+        "date_created",
+        "date_updated",
     )
     # from the Django docs:
     # Adding a ManyToManyField to this list will instead use a nifty unobtrusive JavaScript “filter” interface


### PR DESCRIPTION
Fixes #1022. In the Source admin area, we have changed the `number_of_melodies`, `number_of_chants` fields to readonly_fields. Additionally, on the Chant and Source admin area, we have added `date_created` and `date_updated` readonly_fields.