### PR TITLE
Admin Source Change: prevent users from appearing twice in Current Editors widget

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -838,6 +838,7 @@ class AdminSourceForm(forms.ModelForm):
             | Q(groups__name="editor")
             | Q(groups__name="contributor")
         )
+        .distinct()
         .order_by("full_name"),
         required=False,
         widget=FilteredSelectMultiple(verbose_name="current editors", is_stacked=False),


### PR DESCRIPTION
Testing locally, removing Gen from one of her two user groups causes her name to appear only once, so that was indeed the bug going on with #1021. Adding this `.distinct()` to the queryset here also causes her name to appear only once, no matter how many user groups she belongs to.

fixes #1021

