### PR TITLE
Chant Detail: fix bug where we would send a request to a cantusindex.org/json-con/cantus_id/refresh

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -155,7 +155,7 @@ def touch_ci_json_con_api(cantus_id: str) -> None:
     """
     t = threading.Thread(
         target=_refresh_ci_json_con_api,
-        args={"cantus_id": f"{cantus_id}"},
+        args=[cantus_id],
     )
     t.start()
 


### PR DESCRIPTION
fixes #1052

When starting the thread to ping `cantusindex.org/json-con/{some cantus id}/refresh`, we were passing in a dictionary. Python was calling `_refresh_ci_json_con_api` using the key, `"cantus_id"`, as an argument, rather than using the value. I'm confident this was working several months ago when first implemented, so I don't know what changed to create this bug. In any case, since `_refresh_ci_json_con_api` takes only a single argument, we can start the thread by passing in a list of arguments rather than a dictionary.

Once this change ends up on production, I need to remember to send Jan an email saying this is fixed.