### PR TITLE
Fix failing tests in JsonSourcesExportTest

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4651,8 +4651,16 @@ class JsonNodeExportTest(TestCase):
 
 
 class JsonSourcesExportTest(TestCase):
+    def setUp(self):
+        # the JsonSourcesExport View uses the CANTUS Segment's .source_set property,
+        # so we need to make sure to set up a CANTUS segment with the right ID for each test.
+        self.cantus_segment = make_fake_segment(
+            id="4063", name="Bower Sequence Database"
+        )
+        self.bower_segment = make_fake_segment(id="4064", name="CANTUS Database")
+
     def test_json_sources_response(self):
-        source = make_fake_source(published=True)
+        source = make_fake_source(published=True, segment=self.cantus_segment)
 
         response_1 = self.client.get(f"/json-sources/")
         self.assertEqual(response_1.status_code, 200)
@@ -4666,7 +4674,9 @@ class JsonSourcesExportTest(TestCase):
         NUMBER_OF_SOURCES = 10
         sample_source = None
         for _ in range(NUMBER_OF_SOURCES):
-            sample_source = make_fake_source(published=True)
+            sample_source = make_fake_source(
+                published=True, segment=self.cantus_segment
+            )
 
         # there should be one item for each source
         response = self.client.get(reverse("json-sources-export"))
@@ -4690,9 +4700,13 @@ class JsonSourcesExportTest(TestCase):
         NUM_PUBLISHED_SOURCES = 3
         NUM_UNPUBLISHED_SOURCES = 5
         for _ in range(NUM_PUBLISHED_SOURCES):
-            sample_published_source = make_fake_source(published=True)
+            sample_published_source = make_fake_source(
+                published=True, segment=self.cantus_segment
+            )
         for _ in range(NUM_UNPUBLISHED_SOURCES):
-            sample_unpublished_source = make_fake_source(published=False)
+            sample_unpublished_source = make_fake_source(
+                published=False, segment=self.cantus_segment
+            )
 
         response = self.client.get(reverse("json-sources-export"))
         unpacked_response = json.loads(response.content)

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4718,6 +4718,28 @@ class JsonSourcesExportTest(TestCase):
         self.assertIn(published_id, response_keys)
         self.assertNotIn(unpublished_id, response_keys)
 
+    def test_only_sources_from_cantus_segment_appear_in_results(self):
+        NUM_CANTUS_SOURCES = 5
+        NUM_BOWER_SOURCES = 7
+        for _ in range(NUM_CANTUS_SOURCES):
+            sample_cantus_source = make_fake_source(
+                published=True, segment=self.cantus_segment
+            )
+        for _ in range(NUM_BOWER_SOURCES):
+            sample_bower_source = make_fake_source(
+                published=True, segment=self.bower_segment
+            )
+
+        response = self.client.get(reverse("json-sources-export"))
+        unpacked_response = json.loads(response.content)
+        response_keys = unpacked_response.keys()
+        self.assertEqual(len(unpacked_response), NUM_CANTUS_SOURCES)
+
+        cantus_id = str(sample_cantus_source.id)
+        bower_id = str(sample_bower_source.id)
+        self.assertIn(cantus_id, response_keys)
+        self.assertNotIn(bower_id, response_keys)
+
 
 class JsonNextChantsTest(TestCase):
     def test_existing_cantus_id(self):


### PR DESCRIPTION
And also add an additional test to ensure only sources from the CANTUS segment appear in the results in the json-sources view.

fixes #1058