### PR TITLE
Fix "Feasts that follow" links

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -101,7 +101,18 @@
                                     <a href="javascript:" onclick="autoFillFeast{{ feast.id }}();">{{ feast.name }}</a> ({{ count }}x) |
                                     <script>
                                         function autoFillFeast{{ feast.id }}() {
-                                            document.getElementById('id_feast').value = "{{ feast.id }}";
+                                            var feast_id = {{ feast.id }};
+                                            var feast_name = "{{ feast.name }}";
+
+                                            // Set the value, creating a new option if necessary
+                                            if ($('#id_feast').find("option[value='" + feast_id + "']").length) {
+                                                $('#id_feast').val(feast_id).trigger('change');
+                                            } else { 
+                                                // Create a DOM Option and pre-select by default
+                                                var newOption = new Option(feast_name, feast_id, true, true);
+                                                // Append it to the select
+                                                $('#id_feast').append(newOption).trigger('change');
+                                            };
                                         }
                                     </script>
                                {% endfor %}                                                                                                      


### PR DESCRIPTION
Since updating the Feast select field on the chant create page, the autoFillFeast function did not work correctly anymore. Clicking on one of the Feasts that follow links would not autopopulate the Django Autocomplete Light field as it did with the default dropdown select. 

 In django autocomplete with select2, items are loaded async. So if you want to programatically select, you need to add the value first. This is also explained in the [select2 documentation](https://select2.org/programmatic-control/add-select-clear-items#create-if-not-exists) 

Now, the autocomplete widget acts as expected, matching the behaviour of OldCantus and NewCantus before updating the autocomplete widgets. Fixes #1050 