### PR TITLE
Prevent users from appearing twice in proofreader fields

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -585,6 +585,7 @@ class AdminChantForm(forms.ModelForm):
     proofread_by = forms.ModelMultipleChoiceField(
         queryset=get_user_model()
         .objects.filter(Q(groups__name="project manager") | Q(groups__name="editor"))
+        .distinct()
         .order_by("last_name"),
         required=False,
         widget=FilteredSelectMultiple(verbose_name="proofread by", is_stacked=False),
@@ -679,6 +680,7 @@ class AdminSequenceForm(forms.ModelForm):
     proofread_by = forms.ModelMultipleChoiceField(
         queryset=get_user_model()
         .objects.filter(Q(groups__name="project manager") | Q(groups__name="editor"))
+        .distinct()
         .order_by("last_name"),
         required=False,
         widget=FilteredSelectMultiple(verbose_name="proofread by", is_stacked=False),

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1026,6 +1026,7 @@ class ProofreadByAutocomplete(autocomplete.Select2QuerySetView):
             .objects.filter(
                 Q(groups__name="project manager") | Q(groups__name="editor")
             )
+            .distinct()
             .order_by("full_name")
         )
         if self.q:


### PR DESCRIPTION
Fixes #1062. Using `.distinct()`, we can ensure that users will not appear twice in the proofreader widgets. Previously, they would filter based on user groups, sometimes presenting two of the same user if they belong to two different groups at the same time.