### PR TITLE
Chant admin: fix manuscript full text std spelling widget size

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -556,6 +556,9 @@ class AdminChantForm(forms.ModelForm):
         'the first word of each chant, and the first word after "Alleluia" for '
         "Mass Alleluias. Punctuation is omitted.",
     )
+    # Django's default text area widget selection for form inputs is non-intuitive
+    # and manual updates to fields (e.g., changing required=True) affect widget properties unexpectedly;
+    # this workaround is our current best solution.
     manuscript_full_text_std_spelling.widget.attrs.update(
         {"style": "width: 610px; height: 170px;"}
     )

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -556,6 +556,9 @@ class AdminChantForm(forms.ModelForm):
         'the first word of each chant, and the first word after "Alleluia" for '
         "Mass Alleluias. Punctuation is omitted.",
     )
+    manuscript_full_text_std_spelling.widget.attrs.update(
+        {"style": "width: 610px; height: 170px;"}
+    )
 
     folio = forms.CharField(
         required=True,


### PR DESCRIPTION
Fixes #1065. Matches the size of the other larger text area input widgets.