### PR TITLE
Hide "title" field in chant admin.

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -78,6 +78,7 @@ class ChantAdmin(BaseModelAdmin):
         "date",
         "volpiano_notes",
         "volpiano_intervals",
+        "title",
     )
     form = AdminChantForm
     raw_id_fields = (


### PR DESCRIPTION
Fixes #1075, since this field is associated with sequences, not chants.