### PR TITLE
Chant Detail: refactor and tweak concordances summary

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -111,7 +111,7 @@ CANTUS_NETWORK_DATABASES: Tuple[dict] = (
         "results_fstring": "http://hun-chant.eu/id/{cantus_id}",
     },
     {
-        "name": "Slovak Early Music Database",
+        "name": "Cantus Planus in Slovakia",
         "initialism": "CSK",
         "base_url": "http://cantus.sk",
         "results_fstring": "http://cantus.sk/id/{cantus_id}",

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -164,13 +164,11 @@ def make_concordances_database_summary(
             "results_url": results_url,
             "results_count": results_count,
         }
-        database_summaries.append(database_summary)
+        if results_count > 0:
+            database_summaries.append(database_summary)
 
-    filtered_database_summaries: List[dict] = [
-        d for d in database_summaries if "results_count" in d and d["results_count"] > 0
-    ]
     sorted_database_summaries: List[dict] = sorted(
-        filtered_database_summaries, key=lambda db: db["results_count"], reverse=True
+        database_summaries, key=lambda db: db["results_count"], reverse=True
     )
 
     gregorien_response: Optional[Response] = None

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -172,6 +172,7 @@ def make_concordances_database_summary(
     sorted_database_summaries: List[dict] = sorted(
         filtered_database_summaries, key=lambda db: db["results_count"], reverse=True
     )
+
     gregorien_response: Optional[Response] = None
     try:
         gregorien_response = requests.get(
@@ -185,7 +186,6 @@ def make_concordances_database_summary(
             f"https://gregorien.info/chant/cid/{cantus_id}/en:",
             exc,
         )
-
     if gregorien_response and gregorien_response.status_code == 200:
         gregorien_database_dict: dict = {
             "name": "Gregorien.info",
@@ -196,6 +196,7 @@ def make_concordances_database_summary(
             "alternate_results_count_text": "VIEW AT GREGORIEN.INFO",
         }
         sorted_database_summaries.append(gregorien_database_dict)
+
     return sorted_database_summaries
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -171,7 +171,7 @@ def make_concordances_database_summary(
         for d in concordances_databases
         if "results_count" in d and d["results_count"] > 0
     ]
-
+    database_summary.sort(key=lambda db: db["results_count"], reverse=True)
     try:
         gregorien_response = requests.get(
             f"https://gregorien.info/chant/cid/{cantus_id}/en",

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -149,7 +149,7 @@ def make_concordances_database_summary(
             databases. Each item in the list is a dictionary corresponding
             to a single database in the Cantus Network.
     """
-    concordances_databases: List[dict] = []
+    database_summaries: List[dict] = []
     for database in CANTUS_NETWORK_DATABASES:
         name: str = database["name"]
         initialism: str = database["initialism"]
@@ -164,14 +164,15 @@ def make_concordances_database_summary(
             "results_url": results_url,
             "results_count": results_count,
         }
-        concordances_databases.append(database_summary)
+        database_summaries.append(database_summary)
 
-    database_summary = [
-        d
-        for d in concordances_databases
-        if "results_count" in d and d["results_count"] > 0
+    filtered_database_summaries: List[dict] = [
+        d for d in database_summaries if "results_count" in d and d["results_count"] > 0
     ]
-    database_summary.sort(key=lambda db: db["results_count"], reverse=True)
+    sorted_database_summaries: List[dict] = sorted(
+        filtered_database_summaries, key=lambda db: db["results_count"], reverse=True
+    )
+    gregorien_response: Optional[Response] = None
     try:
         gregorien_response = requests.get(
             f"https://gregorien.info/chant/cid/{cantus_id}/en",
@@ -184,7 +185,6 @@ def make_concordances_database_summary(
             f"https://gregorien.info/chant/cid/{cantus_id}/en:",
             exc,
         )
-        gregorien_response = None
 
     if gregorien_response and gregorien_response.status_code == 200:
         gregorien_database_dict: dict = {
@@ -195,8 +195,8 @@ def make_concordances_database_summary(
             "results_count": None,
             "alternate_results_count_text": "VIEW AT GREGORIEN.INFO",
         }
-        database_summary.append(gregorien_database_dict)
-    return database_summary
+        sorted_database_summaries.append(gregorien_database_dict)
+    return sorted_database_summaries
 
 
 def parse_json_from_api(url: str) -> Union[list, None]:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -29,7 +29,7 @@ from django.http import Http404
 from next_chants import next_chants
 from collections import Counter
 from django.contrib.auth.mixins import UserPassesTestMixin
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 from requests.exceptions import SSLError, Timeout, ConnectionError
 from requests import Response
 from main_app.permissions import (
@@ -38,7 +38,7 @@ from main_app.permissions import (
     user_can_view_chant,
 )
 
-CHANT_SEARCH_TEMPLATE_VALUES = (
+CHANT_SEARCH_TEMPLATE_VALUES: Tuple[str] = (
     # for views that use chant_search.html, this allows them to
     # fetch only those values needed for rendering the template
     "id",
@@ -64,6 +64,64 @@ CHANT_SEARCH_TEMPLATE_VALUES = (
     "genre__id",
     "genre__description",
     "genre__name",
+)
+
+
+CANTUS_NETWORK_DATABASES: Tuple[dict] = (
+    {
+        "name": "Cantus Database",
+        "initialism": "CD",
+        "base_url": "/",
+        "results_fstring": "/id/{cantus_id}",
+    },
+    {
+        "name": "Fontes Cantus Bohemiae",
+        "initialism": "FCB",
+        "base_url": "http://cantusbohemiae.cz",
+        "results_fstring": "http://cantusbohemiae.cz/id/{cantus_id}",
+    },
+    {
+        "name": "Medieval Music Manuscripts Online",
+        "initialism": "MMMO",
+        "base_url": "http://musmed.eu",
+        "results_fstring": "http://musmed.eu/id/{cantus_id}",
+    },
+    {
+        "name": "Portuguese Early Music Database",
+        "initialism": "PEM",
+        "base_url": "https://pemdatabase.eu",
+        "results_fstring": "https://pemdatabase.eu/id/{cantus_id}",
+    },
+    {
+        "name": "Spanish Early Music Manuscript Database",
+        "initialism": "SEMM",
+        "base_url": "http://musicahispanica.eu",
+        "results_fstring": "http://musicahispanica.eu/id/{cantus_id}",
+    },
+    {
+        "name": "Cantus Planus in Polonia",
+        "initialism": "CPL",
+        "base_url": "http://cantus.ispan.pl",
+        "results_fstring": "http://cantus.ispan.pl/id/{cantus_id}",
+    },
+    {
+        "name": "Hungarian Chant Database",
+        "initialism": "HCD",
+        "base_url": "http://hun-chant.eu",
+        "results_fstring": "http://hun-chant.eu/id/{cantus_id}",
+    },
+    {
+        "name": "Slovak Early Music Database",
+        "initialism": "CSK",
+        "base_url": "http://cantus.sk",
+        "results_fstring": "http://cantus.sk/id/{cantus_id}",
+    },
+    {
+        "name": "Fragmenta Manuscriptorum Musicalium Hungariae",
+        "initialism": "FRH",
+        "base_url": "http://fragmenta.zti.hu/en/",
+        "results_fstring": "http://fragmenta.zti.hu/en/id/{cantus_id}",
+    },
 )
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -29,7 +29,7 @@ from django.http import Http404
 from next_chants import next_chants
 from collections import Counter
 from django.contrib.auth.mixins import UserPassesTestMixin
-from typing import Optional, Union, Tuple
+from typing import Optional, Union, Tuple, List
 from requests.exceptions import SSLError, Timeout, ConnectionError
 from requests import Response
 from main_app.permissions import (
@@ -386,89 +386,27 @@ class ChantDetailView(DetailView):
             #   Fontes Cantus Bohemiae (FCB) - N chants
             #   etc...
             #   Gregorien.info - VIEW AT GREGORIEN.INFO
-            concordances_databases = [
-                {
-                    "name": "Cantus Database",
-                    "initialism": "CD",
-                    "base_url": "/",
-                    "results_url": f"{reverse('chant-by-cantus-id', args=[chant.cantus_id])}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "CD"]
-                    ),
-                },
-                {
-                    "name": "Fontes Cantus Bohemiae",
-                    "initialism": "FCB",
-                    "base_url": "http://cantusbohemiae.cz",
-                    "results_url": f"http://cantusbohemiae.cz/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "FCB"]
-                    ),
-                },
-                {
-                    "name": "Medieval Music Manuscripts Online",
-                    "initialism": "MMMO",
-                    "base_url": "http://musmed.eu",
-                    "results_url": f"http://musmed.eu/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "MMMO"]
-                    ),
-                },
-                {
-                    "name": "Portuguese Early Music Database",
-                    "initialism": "PEM",
-                    "base_url": "https://pemdatabase.eu",
-                    "results_url": f"https://pemdatabase.eu/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "PEM"]
-                    ),
-                },
-                {
-                    "name": "Spanish Early Music Manuscript Database",
-                    "initialism": "SEMM",
-                    "base_url": "http://musicahispanica.eu",
-                    "results_url": f"http://musicahispanica.eu/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "SEMM"]
-                    ),
-                },
-                {
-                    "name": "Cantus Planus in Polonia",
-                    "initialism": "CPL",
-                    "base_url": "http://cantus.ispan.pl",
-                    "results_url": f"http://cantus.ispan.pl/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "CPL"]
-                    ),
-                },
-                {
-                    "name": "Hungarian Chant Database",
-                    "initialism": "HCD",
-                    "base_url": "http://hun-chant.eu",
-                    "results_url": f"http://hun-chant.eu/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "HCD"]
-                    ),
-                },
-                {
-                    "name": "Slovak Early Music Database",
-                    "initialism": "CSK",
-                    "base_url": "http://cantus.sk",
-                    "results_url": f"http://cantus.sk/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "CSK"]
-                    ),
-                },
-                {
-                    "name": "Fragmenta Manuscriptorum Musicalium Hungariae",
-                    "initialism": "FRH",
-                    "base_url": "http://fragmenta.zti.hu/en/",
-                    "results_url": f"http://fragmenta.zti.hu/en/id/{chant.cantus_id}",
-                    "results_count": len(
-                        [True for c in concordance_chants if c["db"] == "FRH"]
-                    ),
-                },
-            ]
+            concordances_databases: List[dict] = []
+            for database in CANTUS_NETWORK_DATABASES:
+                name: str = database["name"]
+                initialism: str = database["initialism"]
+                base_url: str = database["base_url"]
+                results_url_template: str = database["results_fstring"]
+                results_url: str = results_url_template.format(
+                    cantus_id=chant.cantus_id
+                )
+                results_count: int = len(
+                    [True for c in concordance_chants if c["db"] == initialism]
+                )
+                database_summary: dict = {
+                    "name": name,
+                    "initialism": initialism,
+                    "base_url": base_url,
+                    "results_url": results_url,
+                    "results_count": results_count,
+                }
+                concordances_databases.append(database_summary)
+
             context["concordances_databases"] = [
                 d
                 for d in concordances_databases


### PR DESCRIPTION
This PR primarily refactors the concordances summary displayed on the Chant Detail page, creating a new function in order to decrease nesting and adding type annotations.

It also makes a couple of tweaks to this summary:
- the Slovak Early Music Database is now called Cantus Planus in Slovakia, 
- the databases in the summary are now sorted by the number of concordant chants they contain. 

This PR works towards solving #1033. It was initially meant to add two new databases to the list of databases, but these databases no longer appear in the concordances provided by Cantus Index, so this feature is currently neither testable nor necessary.

Screenshots to illustrate sorting and updated spelling:
Before:
![Screenshot 2023-09-29 at 1 42 25 PM](https://github.com/DDMAL/CantusDB/assets/58090591/687595a3-5935-4073-aef5-af176cfa544d)
After (much neater!):
![Screenshot 2023-09-29 at 1 42 33 PM](https://github.com/DDMAL/CantusDB/assets/58090591/efc23dae-f491-489c-a57c-c7e613e6c991)
