### PR TITLE
Source Detail: ensure line breaks are preserved when displaying TextFields

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -36,17 +36,17 @@
 
                 {% if source.liturgical_occasions %}
                     <dt>Liturgical Occasions</dt>
-                    <dd>{{ source.liturgical_occasions }}</dd>
+                    <dd>{{ source.liturgical_occasions|linebreaks }}</dd>
                 {% endif %}
 
                 {% if source.description %}
                     <dt>Description</dt>
-                    <dd>{{ source.description|safe }}</dd>
+                    <dd>{{ source.description|safe|linebreaks }}</dd>
                 {% endif %}
 
                 {% if source.selected_bibliography %}
                     <dt>Selected Bibilography</dt>
-                    <dd>{{ source.selected_bibliography|safe }}</dd>
+                    <dd>{{ source.selected_bibliography|safe|linebreaks }}</dd>
                 {% endif %}
 
                 {% if source.indexing_notes %}


### PR DESCRIPTION
fixes #1085 

This PR fixes a bug on the Source Detail page, where the source description would all run together even if line breaks had been added while writing the description in the Source Edit page. Adding a `linebreaks` tag to the field in the template causes line breaks to be preserved.

While fixing this, I looked at several of the other TextFields in our models to see if they would benefit from similar treatment.
- I chose to apply `linebreaks` tags to the **Liturgical Occasions** and **Selected Bibliography** fields in addition to the **Description** field, as they often contain extended descriptions.
- For the Source Detail page, I chose not to apply the tag to the _Summary_ and _Indexing Notes_ fields, as they seem to usually contain single-line values.
- I also chose not to apply these tags to several fields on the Chant and Sequence Detail pages. These fields include the two *Full Text* fields, the *Volpiano* field, and the *Indexing Notes* field.

@annamorphism, perhaps you can comment on whether there are other places I should look at for applying a similar treatment, or whether there are reasons that linebreaks should not be preserved where I just added them. I'll wait for a researcher approval from you and for a technical approval from @dchiller or @lucasmarchd01 before merging this.