### PR TITLE
Add updated google analytics tag to base.html

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -5,15 +5,14 @@
 
 <head>
     {% if PROJECT_ENVIRONMENT == "PRODUCTION" %}
-        {# To ensure site is tracked in Google Analytics #}
         <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-YSGM9EQBGL"></script>
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-JXEY1VRT2W"></script>
         <script>
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            
-            gtag('config', 'G-YSGM9EQBGL');
+
+            gtag('config', 'G-JXEY1VRT2W');
         </script>
     {% endif %}
     {% if not PROJECT_ENVIRONMENT == "PRODUCTION" %}


### PR DESCRIPTION
This PR adds updated GA4 tags to all our pages (which will only be displayed when PROJECT_ENVIRONMENT is PRODUCTION). In doing so, it resolves #520.

This PR formalizes changes already made on our production server (i.e. the changes made in this PR were made as a hotfix on Production, where the changed code is already running), which @ahankinson and I set up together yesterday. All indications are that it is already working as expected.