### PR TITLE
Attempt to implement rate limiting via nginx

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -19,7 +19,10 @@ server {
     ssl_certificate /etc/nginx/ssl/live/cantusdatabase.org/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/cantusdatabase.org/privkey.pem;
 
+    limit_req_zone $binary_remote_addr zone=default:10m rate=2r/s;
+
     location / {
+        limit_req zone=default burst=30;
         proxy_pass http://django:8000;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;


### PR DESCRIPTION
This draft PR is an attempt to implement rate limiting via nginx, toward addressing #1098. In its current form, it doesn't work: I got this error message - 
```
2023-10-31 13:07:04 2023/10/31 17:07:04 [emerg] 1#1: "limit_req_zone" directive is not allowed here in /etc/nginx/conf.d/cantusdb.conf:5
2023-10-31 13:07:04 nginx: [emerg] "limit_req_zone" directive is not allowed here in /etc/nginx/conf.d/cantusdb.conf:5
2023-10-31 13:07:17 2023/10/31 17:07:17 [emerg] 1#1: "limit_req_zone" directive is not allowed here in /etc/nginx/conf.d/cantusdb.conf:5
2023-10-31 13:07:17 nginx: [emerg] "limit_req_zone" directive is not allowed here in /etc/nginx/conf.d/cantusdb.conf:5
```
\- when I tried to test this with a modified-for-local-development version of this (The first `server` block was deleted and the second server block began with `listen 80;` instead of `listen 443 etc`. `limit_req_zone $binary_remote_addr zone=default:10m rate=2r/s;` was the line identified in the error message.)

ChatGPT suggested that I wrap the entire file in an `http` block, and move `limit_req_zone` outside of the server block, but I don't know enough about nginx to know whether this is a reasonable idea or something that will cause problems.

People who know nginx (@kqct? @ahankinson? @alastair?), would one of you be able to offer some guidance as to how to proceed?