### PR TITLE
Hide `source_status` on admin source change page

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -172,6 +172,8 @@ class SequenceAdmin(BaseModelAdmin):
 
 
 class SourceAdmin(BaseModelAdmin):
+    exclude = ("source_status",)
+
     # These search fields are also available on the user-source inline relationship in the user admin page
     search_fields = (
         "siglum",


### PR DESCRIPTION
Fixes #1107 by hiding `source_status` on the admin source change page.