### PR TITLE
Change viewing permissions for proofread fields on chant detail page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -167,23 +167,69 @@
                     {% endif %}
                 </div>
 
-                {% if chant.manuscript_full_text_std_spelling %}
-                    <dt>Manuscript Reading Full Text (standardized spelling)</dt>
-                    <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                {% if user.is_authenticated %}
+                    {% if chant.manuscript_full_text_std_spelling %}
+                        {% if chant.manuscript_full_text_std_proofread %}
+                            <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                        {% else %}
+                            <dt>Manuscript Reading Full Text (standardized spelling)
+                                <span style="font-weight:normal"><i> (not proofread)</i></span>
+                            </dt>
+                            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                        {% endif %}
+                    {% endif %}
+                {% else %}
+                    {% if chant.manuscript_full_text_std_spelling and chant.manuscript_full_text_std_proofread %}
+                        <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                        <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                    {% endif %}
                 {% endif %}
 
-                {% if chant.manuscript_full_text %}
-                    <dt>Manuscript Reading Full Text (MS spelling)</dt>
-                    <dd>{{ chant.manuscript_full_text }}</dd>
+                {% if user.is_authenticated %}
+                    {% if chant.manuscript_full_text %}
+                        {% if chant.manuscript_full_text_proofread %}
+                            <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                            <dd>{{ chant.manuscript_full_text }}</dd>
+                        {% else %}
+                            <dt>Manuscript Reading Full Text (MS spelling)
+                                <span style="font-weight:normal"><i> (not proofread)</i></span>
+                            </dt>
+                            <dd>{{ chant.manuscript_full_text }}</dd>
+                        {% endif %}
+                    {% endif %}
+                {% else %}
+                    {% if chant.manuscript_full_text and chant.manuscript_full_text_proofread %}
+                        <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                        <dd>{{ chant.manuscript_full_text }}</dd>
+                    {% endif %}
                 {% endif %}
 
-                {% if chant.volpiano %}
-                    <dt>Volpiano</dt>
-                    <dd>
-                        <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
-                    </dd>
+                {% if user.is_authenticated %}
+                    {% if chant.volpiano %}
+                        {% if chant.volpiano_proofread %}
+                            <dt>Volpiano</dt>
+                            <dd>
+                                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                            </dd>
+                        {% else %}
+                            <dt>Volpiano
+                                <span style="font-weight:normal"><i> (not proofread)</i></span>
+                            </dt>
+                            <dd>
+                                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                            </dd>
+                        {% endif%}
+                    {% endif %}
+                {% else %}
+                    {% if chant.volpiano and chant.volpiano_proofread %}
+                        <dt>Volpiano</dt>
+                        <dd>
+                            <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                        </dd>
+                    {% endif %}
                 {% endif %}
-
+                    
                 {% if chant.indexing_notes %}
                     <dt>Indexing Notes</dt>
                     <dd>{{ chant.indexing_notes }}</dd>


### PR DESCRIPTION
On the chant detail page, we make several modifications to field viewing permissions based on if they have been proofread or not. Specifically:
- logged in users will be able to see proofread and non-proofread fields
- for logged in users non-proofread fields, we will show a message indicating they are not yet proofread
- non-logged in users will only be able to see fields if they have been proofread.

Resolves #1100 (special debra request!)
