### PR TITLE
Footer: update email address and copyright year

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -485,7 +485,7 @@
             <a href="mailto:debra.lacoste@dal.ca">
                 <img src="{% static "sendMailIcon.png" %}" alt="Send us email" loading="lazy">
             </a>
-            <small style="float: right">Cantus Database © 2012-2022</small>
+            <small style="float: right">Cantus Database © 2012-2023</small>
         </div>
     </footer>
 </body>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -482,7 +482,7 @@
             <a href="https://www.facebook.com/CantusDatabase">
                 <img src="{% static "facebookIcon.png" %}" alt="Facebook link" loading="lazy">
             </a>
-            <a href="mailto:cantus@cantusindex.org">
+            <a href="mailto:debra.lacoste@dal.ca">
                 <img src="{% static "sendMailIcon.png" %}" alt="Send us email" loading="lazy">
             </a>
             <small style="float: right">Cantus Database © 2012-2022</small>


### PR DESCRIPTION
This PR updates the email address in the footer to email Debra rather than cantus@cantusindex.org, to match the address displayed on the Contact page. In doing so, it fixes #1122.

It also updates the copyright date from "Cantus Database © 2012-202**2**" to "Cantus Database © 2012-202**3**"