### PR TITLE
Add autocomplete widgets for `provenance`, `office`, `genre`, `diff_db`

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -191,6 +191,7 @@ class SourceCreateForm(forms.ModelForm):
         widgets = {
             "title": TextInputWidget(),
             "siglum": TextInputWidget(),
+            "provenance": autocomplete.ModelSelect2(url="provenance-autocomplete"),
             "provenance_notes": TextInputWidget(),
             "date": TextInputWidget(),
             "cursus": SelectWidget(),
@@ -222,13 +223,6 @@ class SourceCreateForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
         }
-
-    provenance = forms.ModelChoiceField(
-        queryset=Provenance.objects.all().order_by("name"), required=False
-    )
-    provenance.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )
 
     TRUE_FALSE_CHOICES_SOURCE = (
         (True, "Full source"),

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -411,6 +411,7 @@ class SourceEditForm(forms.ModelForm):
             "title": TextInputWidget(),
             "rism_siglum": autocomplete.ModelSelect2(url="rismsiglum-autocomplete"),
             "siglum": TextInputWidget(),
+            "provenance": autocomplete.ModelSelect2(url="provenance-autocomplete"),
             "provenance_notes": TextInputWidget(),
             "date": TextInputWidget(),
             "summary": TextAreaWidget(),
@@ -441,13 +442,6 @@ class SourceEditForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
         }
-
-    provenance = forms.ModelChoiceField(
-        queryset=Provenance.objects.all().order_by("name"), required=False
-    )
-    provenance.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
-    )  # adds styling
 
     CHOICES_FULL_SOURCE = (
         (None, "None"),

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -104,13 +104,14 @@ class ChantCreateForm(forms.ModelForm):
             "marginalia": TextInputWidget(),
             # folio: defined below (required)
             # c_sequence: defined below (required)
-            # office: defined below (foreignkey)
-            # genre: defined below (foreignkey)
+            "office": autocomplete.ModelSelect2(url="office-autocomplete"),
+            "genre": autocomplete.ModelSelect2(url="genre-autocomplete"),
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
             "feast": autocomplete.ModelSelect2(url="feast-autocomplete"),
             "mode": TextInputWidget(),
             "differentia": TextInputWidget(),
+            "diff_db": autocomplete.ModelSelect2(url="differentia-autocomplete"),
             "finalis": TextInputWidget(),
             "extra": TextInputWidget(),
             "chant_range": VolpianoInputWidget(),
@@ -134,30 +135,6 @@ class ChantCreateForm(forms.ModelForm):
         required=True,
         widget=TextInputWidget,
         help_text="Each folio starts with '1'.",
-    )
-
-    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
-    # instead of [name] + description
-    office = NameModelChoiceField(
-        queryset=Office.objects.all().order_by("name"),
-        required=False,
-    )
-    office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    # We use NameModelChoiceField here so the dropdown list of genres displays the name
-    # instead of [name] + description
-    genre = NameModelChoiceField(
-        queryset=Genre.objects.all().order_by("name"),
-        required=False,
-    )
-    genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    diff_db = forms.ModelChoiceField(
-        queryset=Differentia.objects.all().order_by("id"),
-        required=False,
-    )
-    diff_db.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
     )
 
     manuscript_full_text_std_spelling = forms.CharField(
@@ -310,14 +287,15 @@ class ChantEditForm(forms.ModelForm):
             # folio: defined below (required)
             # c_sequence: defined below (required)
             "feast": autocomplete.ModelSelect2(url="feast-autocomplete"),
-            # office: defined below (foreignkey)
-            # genre: defined below (foreignkey)
+            "office": autocomplete.ModelSelect2(url="office-autocomplete"),
+            "genre": autocomplete.ModelSelect2(url="genre-autocomplete"),
             "position": TextInputWidget(),
             "cantus_id": TextInputWidget(),
             "melody_id": TextInputWidget(),
             "mode": TextInputWidget(),
             "finalis": TextInputWidget(),
             "differentia": TextInputWidget(),
+            "diff_db": autocomplete.ModelSelect2(url="differentia-autocomplete"),
             "extra": TextInputWidget(),
             "image_link": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
@@ -351,30 +329,6 @@ class ChantEditForm(forms.ModelForm):
         required=True,
         widget=TextInputWidget,
         help_text="Each folio starts with '1'.",
-    )
-
-    # We use NameModelChoiceField here so the dropdown list of office/mass displays the name
-    # instead of [name] + description
-    office = NameModelChoiceField(
-        queryset=Office.objects.all().order_by("name"),
-        required=False,
-    )
-    office.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    # We use NameModelChoiceField here so the dropdown list of genres displays the name
-    # instead of [name] + description
-    genre = NameModelChoiceField(
-        queryset=Genre.objects.all().order_by("name"),
-        required=False,
-    )
-    genre.widget.attrs.update({"class": "form-control custom-select custom-select-sm"})
-
-    diff_db = forms.ModelChoiceField(
-        queryset=Differentia.objects.all().order_by("id"),
-        required=False,
-    )
-    diff_db.widget.attrs.update(
-        {"class": "form-control custom-select custom-select-sm"}
     )
 
 

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -60,18 +60,21 @@
                 </div>
 
                 <div class="form-row">
-
                     <div class="form-group m-1 col-lg-2">
                         <label for="{{ form.office.id_for_label }}"><small>Office/Mass:</small></label>
-                        {{ form.office }}
+                        <br>{{ form.office }}
                         <a href="/field-descriptions/#Office"><small>?</small></a>
                     </div>
+                </div>
 
+                <div class="form-row">
                     <div class="form-group m-1 col-lg-2">
                         <small>{{ form.genre.label_tag }}</small>
-                        {{ form.genre }}
+                        <br>{{ form.genre }}
                     </div>
+                </div>
 
+                <div class="form-row">
                     <div class="form-group m-1 col-lg-2">
                         <small>{{ form.position.label_tag }}</small>
                         {{ form.position }}
@@ -81,7 +84,6 @@
                         <label for="{{ form.cantus_id.id_for_label }}"><small>Cantus ID:</small></label>
                         {{ form.cantus_id }}
                     </div>
-
                 </div>
 
                 <div class="form-row">
@@ -140,17 +142,19 @@
                         {{ form.differentia }}
                     </div>
 
-                    <div class="form-group m-1 col-lg-3">
-                        <label for="{{ form.diff_db.id_for_label }}"><small>Differentia Database</small></label>
-                        {{ form.diff_db }}
-                        <p>
-                            <small class="text-muted">Diff. IDs: <a href="https://differentiaedatabase.ca/">differentiaedatabase.ca</a></small>
-                        </p>
-                    </div>
-
                     <div class="form-group m-1 col-lg-2">
                         <small>{{ form.extra.label_tag }}</small>
                         {{ form.extra }}
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-3">
+                        <label for="{{ form.diff_db.id_for_label }}"><small>Differentia Database</small></label>
+                        <br>{{ form.diff_db }}
+                        <p>
+                            <small class="text-muted">Diff. IDs: <a href="https://differentiaedatabase.ca/">differentiaedatabase.ca</a></small>
+                        </p>
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -167,23 +167,69 @@
                     {% endif %}
                 </div>
 
-                {% if chant.manuscript_full_text_std_spelling %}
-                    <dt>Manuscript Reading Full Text (standardized spelling)</dt>
-                    <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                {% if user.is_authenticated %}
+                    {% if chant.manuscript_full_text_std_spelling %}
+                        {% if chant.manuscript_full_text_std_proofread %}
+                            <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                        {% else %}
+                            <dt>Manuscript Reading Full Text (standardized spelling)
+                                <span style="font-weight:normal"><i> (not proofread)</i></span>
+                            </dt>
+                            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                        {% endif %}
+                    {% endif %}
+                {% else %}
+                    {% if chant.manuscript_full_text_std_spelling and chant.manuscript_full_text_std_proofread %}
+                        <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                        <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+                    {% endif %}
                 {% endif %}
 
-                {% if chant.manuscript_full_text %}
-                    <dt>Manuscript Reading Full Text (MS spelling)</dt>
-                    <dd>{{ chant.manuscript_full_text }}</dd>
+                {% if user.is_authenticated %}
+                    {% if chant.manuscript_full_text %}
+                        {% if chant.manuscript_full_text_proofread %}
+                            <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                            <dd>{{ chant.manuscript_full_text }}</dd>
+                        {% else %}
+                            <dt>Manuscript Reading Full Text (MS spelling)
+                                <span style="font-weight:normal"><i> (not proofread)</i></span>
+                            </dt>
+                            <dd>{{ chant.manuscript_full_text }}</dd>
+                        {% endif %}
+                    {% endif %}
+                {% else %}
+                    {% if chant.manuscript_full_text and chant.manuscript_full_text_proofread %}
+                        <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                        <dd>{{ chant.manuscript_full_text }}</dd>
+                    {% endif %}
                 {% endif %}
 
-                {% if chant.volpiano %}
-                    <dt>Volpiano</dt>
-                    <dd>
-                        <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
-                    </dd>
+                {% if user.is_authenticated %}
+                    {% if chant.volpiano %}
+                        {% if chant.volpiano_proofread %}
+                            <dt>Volpiano</dt>
+                            <dd>
+                                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                            </dd>
+                        {% else %}
+                            <dt>Volpiano
+                                <span style="font-weight:normal"><i> (not proofread)</i></span>
+                            </dt>
+                            <dd>
+                                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                            </dd>
+                        {% endif%}
+                    {% endif %}
+                {% else %}
+                    {% if chant.volpiano and chant.volpiano_proofread %}
+                        <dt>Volpiano</dt>
+                        <dd>
+                            <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                        </dd>
+                    {% endif %}
                 {% endif %}
-
+                    
                 {% if chant.indexing_notes %}
                     <dt>Indexing Notes</dt>
                     <dd>{{ chant.indexing_notes }}</dd>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -67,14 +67,20 @@
                     </div>
 
                     <div class="form-row">
-                        <div class="form-group m-1 col-lg-2">
+                        <div class="form-group m-1 col-lg-3">
                             <small>{{ form.office.label_tag }}</small>
-                            {{ form.office }}
+                            <br>{{ form.office }}
                         </div>
-                        <div class="form-group m-1 col-lg-2">
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-3">
                             <small>{{ form.genre.label_tag }}</small>
-                            {{ form.genre }}
+                            <br>{{ form.genre }}
                         </div>
+                    </div>
+
+                    <div class="form-row">
                         <div class="form-group m-1 col-lg-2">
                             <small>{{ form.position.label_tag }}</small>
                             {{ form.position }}
@@ -107,14 +113,16 @@
                             {{ form.differentia }}
                         </div>
                         <div class="form-group m-1 col-lg-2">
+                            <small>{{ form.extra.label_tag }}</small>
+                            {{ form.extra }}
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group m-1 col-lg-2">
                             <label for="{{ form.diff_db.id_for_label }}">
                                 <small>Differentia DB:</small>
                             </label>
-                            {{ form.diff_db }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.extra.label_tag }}</small>
-                            {{ form.extra }}
+                            <br>{{ form.diff_db }}
                         </div>
                     </div>
                     <div class="form-row">

--- a/django/cantusdb_project/main_app/templates/source_create_form.html
+++ b/django/cantusdb_project/main_app/templates/source_create_form.html
@@ -49,7 +49,7 @@
                         <label for="{{ form.rism_siglum.id_for_label }}">
                             <small>RISM:</small>
                         </label>
-                        {{ form.rism_siglum }}
+                        <br>{{ form.rism_siglum }}
                         <small>
                             <a href="https://rism.info/community/sigla.html" target="_blank">Browse RISM sigla</a>
                             (opens in new tab)
@@ -70,7 +70,7 @@
                         <label for="{{ form.provenance.id_for_label }}">
                             <small>Provenance (origin / history):</small>
                         </label>
-                        {{ form.provenance }}
+                        <br>{{ form.provenance }}
                         <p class=text-muted><small>{{ form.provenance.help_text }}</small></p>
                     </div>
                 </div>

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -72,7 +72,7 @@
                             Provenance (origin / history):
                         </label>
                         {{ form.provenance }}
-                        <small>If the origin is unknown, select a location where the source was used later in its lifetime and provide details in the "Provenance notes" field.</small>
+                        <small><br>If the origin is unknown, select a location where the source was used later in its lifetime and provide details in the "Provenance notes" field.</small>
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -68,6 +68,7 @@ from main_app.views.views import (
     CenturyAutocomplete,
     RismSiglumAutocomplete,
     FeastAutocomplete,
+    ProvenanceAutocomplete,
     ProofreadByAutocomplete,
 )
 
@@ -471,6 +472,11 @@ urlpatterns = [
         "proofread-by-autocomplete/",
         ProofreadByAutocomplete.as_view(),
         name="proofread-by-autocomplete",
+    ),
+    path(
+        "provenance-autocomplete/",
+        ProvenanceAutocomplete.as_view(),
+        name="provenance-autocomplete",
     ),
 ]
 

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -68,6 +68,9 @@ from main_app.views.views import (
     CenturyAutocomplete,
     RismSiglumAutocomplete,
     FeastAutocomplete,
+    OfficeAutocomplete,
+    GenreAutocomplete,
+    DifferentiaAutocomplete,
     ProvenanceAutocomplete,
     ProofreadByAutocomplete,
 )
@@ -477,6 +480,21 @@ urlpatterns = [
         "provenance-autocomplete/",
         ProvenanceAutocomplete.as_view(),
         name="provenance-autocomplete",
+    ),
+    path(
+        "office-autocomplete/",
+        OfficeAutocomplete.as_view(),
+        name="office-autocomplete",
+    ),
+    path(
+        "genre-autocomplete/",
+        GenreAutocomplete.as_view(),
+        name="genre-autocomplete",
+    ),
+    path(
+        "differentia-autocomplete/",
+        DifferentiaAutocomplete.as_view(),
+        name="differentia-autocomplete",
     ),
 ]
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -8,6 +8,7 @@ from articles.models import Article
 from main_app.models import (
     Century,
     Chant,
+    Differentia,
     Feast,
     Genre,
     Notation,
@@ -1015,6 +1016,43 @@ class FeastAutocomplete(autocomplete.Select2QuerySetView):
             qs = qs.filter(
                 Q(name__istartswith=self.q) | Q(feast_code__istartswith=self.q)
             )
+        return qs
+
+
+class OfficeAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Office.objects.none()
+        qs = Office.objects.all().order_by("name")
+        if self.q:
+            qs = qs.filter(
+                Q(name__istartswith=self.q) | Q(description__istartswith=self.q)
+            )
+        return qs
+
+
+class GenreAutocomplete(autocomplete.Select2QuerySetView):
+    def get_result_label(self, item):
+        return item.name
+
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Genre.objects.none()
+        qs = Genre.objects.all().order_by("name")
+        if self.q:
+            qs = qs.filter(
+                Q(name__istartswith=self.q) | Q(description__istartswith=self.q)
+            )
+        return qs
+
+
+class DifferentiaAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Differentia.objects.none()
+        qs = Differentia.objects.all().order_by("differentia_id")
+        if self.q:
+            qs = qs.filter(differentia_id__istartswith=self.q)
         return qs
 
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1020,6 +1020,9 @@ class FeastAutocomplete(autocomplete.Select2QuerySetView):
 
 
 class OfficeAutocomplete(autocomplete.Select2QuerySetView):
+    def get_result_label(self, office):
+        return f"{office.name} - {office.description}"
+
     def get_queryset(self):
         if not self.request.user.is_authenticated:
             return Office.objects.none()
@@ -1032,8 +1035,8 @@ class OfficeAutocomplete(autocomplete.Select2QuerySetView):
 
 
 class GenreAutocomplete(autocomplete.Select2QuerySetView):
-    def get_result_label(self, item):
-        return item.name
+    def get_result_label(self, genre):
+        return f"{genre.name} - {genre.description}"
 
     def get_queryset(self):
         if not self.request.user.is_authenticated:

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1018,6 +1018,16 @@ class FeastAutocomplete(autocomplete.Select2QuerySetView):
         return qs
 
 
+class ProvenanceAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Provenance.objects.none()
+        qs = Provenance.objects.all().order_by("name")
+        if self.q:
+            qs = qs.filter(name__istartswith=self.q)
+        return qs
+
+
 class ProofreadByAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         if not self.request.user.is_authenticated:


### PR DESCRIPTION
This PR utilizes django autocomplete light to add autocomplete widgets for the source `provenance` field on the source create and edit page. Additionally, autocomplete widgets are added for the `office`, `genre`, and `diff_db` fields on the chant create and edit pages.

On chant create and edit pages, the result list of office are now displaying the name + description string representation (previously it was just name). Users can search the office and genre by name or by description. 

Fixes #1120 