### PR TITLE
Revert "chant detail: change viewing permissions for proofread fields"

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -167,69 +167,23 @@
                     {% endif %}
                 </div>
 
-                {% if user.is_authenticated %}
-                    {% if chant.manuscript_full_text_std_spelling %}
-                        {% if chant.manuscript_full_text_std_proofread %}
-                            <dt>Manuscript Reading Full Text (standardized spelling)</dt>
-                            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
-                        {% else %}
-                            <dt>Manuscript Reading Full Text (standardized spelling)
-                                <span style="font-weight:normal"><i> (not proofread)</i></span>
-                            </dt>
-                            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
-                        {% endif %}
-                    {% endif %}
-                {% else %}
-                    {% if chant.manuscript_full_text_std_spelling and chant.manuscript_full_text_std_proofread %}
-                        <dt>Manuscript Reading Full Text (standardized spelling)</dt>
-                        <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
-                    {% endif %}
+                {% if chant.manuscript_full_text_std_spelling %}
+                    <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                    <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
                 {% endif %}
 
-                {% if user.is_authenticated %}
-                    {% if chant.manuscript_full_text %}
-                        {% if chant.manuscript_full_text_proofread %}
-                            <dt>Manuscript Reading Full Text (MS spelling)</dt>
-                            <dd>{{ chant.manuscript_full_text }}</dd>
-                        {% else %}
-                            <dt>Manuscript Reading Full Text (MS spelling)
-                                <span style="font-weight:normal"><i> (not proofread)</i></span>
-                            </dt>
-                            <dd>{{ chant.manuscript_full_text }}</dd>
-                        {% endif %}
-                    {% endif %}
-                {% else %}
-                    {% if chant.manuscript_full_text and chant.manuscript_full_text_proofread %}
-                        <dt>Manuscript Reading Full Text (MS spelling)</dt>
-                        <dd>{{ chant.manuscript_full_text }}</dd>
-                    {% endif %}
+                {% if chant.manuscript_full_text %}
+                    <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                    <dd>{{ chant.manuscript_full_text }}</dd>
                 {% endif %}
 
-                {% if user.is_authenticated %}
-                    {% if chant.volpiano %}
-                        {% if chant.volpiano_proofread %}
-                            <dt>Volpiano</dt>
-                            <dd>
-                                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
-                            </dd>
-                        {% else %}
-                            <dt>Volpiano
-                                <span style="font-weight:normal"><i> (not proofread)</i></span>
-                            </dt>
-                            <dd>
-                                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
-                            </dd>
-                        {% endif%}
-                    {% endif %}
-                {% else %}
-                    {% if chant.volpiano and chant.volpiano_proofread %}
-                        <dt>Volpiano</dt>
-                        <dd>
-                            <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
-                        </dd>
-                    {% endif %}
+                {% if chant.volpiano %}
+                    <dt>Volpiano</dt>
+                    <dd>
+                        <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                    </dd>
                 {% endif %}
-                    
+
                 {% if chant.indexing_notes %}
                     <dt>Indexing Notes</dt>
                     <dd>{{ chant.indexing_notes }}</dd>


### PR DESCRIPTION
This PR reverts commit b364fda7d2ae0d61c9e01e6df8acc1902d6a542e.

By reverting this, it will allow us to test #1146 and deploy those changes to Production. Basically, we didn't realize that there were a number of related changes that needed to be made when implementing #1100, and those related changes have a bunch of edge cases we need to properly consider. For a discussion/summary of these considerations, refer to https://github.com/DDMAL/CantusDB/pull/1121#issuecomment-1811390790.