### PR TITLE
Footer: Remove links to databases other than Cantus Index

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -378,47 +378,7 @@
                         <ul class="list-group list-group-flush">
                             <li class="list-group-item p-0">
                                 <a href="https://cantusindex.org/" target="_blank">
-                                    Cantus Index (all chants catalogue)
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="https://pemdatabase.eu/" target="_blank">
-                                    Portuguese Early Music Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://cantus.sk" target="_blank">
-                                    Slovak Early Music Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://hun-chant.eu" target="_blank">
-                                    Hungarian Chant Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://cantusbohemiae.cz" target="_blank">
-                                    Fontes Cantus Bohemiae
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://cantus.ispan.pl" target="_blank">
-                                    Cantus Planus in Polonia
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://musicahispanica.eu" target="_blank">
-                                    Spanish Early Music Manuscript Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://musmed.eu" target="_blank">
-                                    Medieval Music Manuscripts Online
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://comparatio.irht.cnrs.fr" target="_blank">
-                                    Comparatio
+                                    Cantus Index
                                 </a>
                             </li>
                         </ul>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -320,7 +320,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-6" id="logos">
+                    <div class="col-md-8" id="logos">
                         <div class="row">
                             <div class="col-md-6">
                                 <a href="https://uwaterloo.ca/" target="_blank">
@@ -373,17 +373,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="col-md-3" id="database-links">
-                        <h5>Database Links</h5>
-                        <ul class="list-group list-group-flush">
-                            <li class="list-group-item p-0">
-                                <a href="https://cantusindex.org/" target="_blank">
-                                    Cantus Index
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="col-md-3" id="login">
+                    <div class="col-md-4" id="login">
                         {% if not request.user.is_anonymous %}
                             {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
                                 <h5>Admin Navigation</h5>


### PR DESCRIPTION
fixes #1103

How it looks now:

Logged out:
![Screenshot 2023-12-07 at 1 25 27 PM](https://github.com/DDMAL/CantusDB/assets/58090591/90060a37-91c8-45c0-8074-a4ae153fd7a6)
[Previous version](https://github.com/DDMAL/CantusDB/assets/58090591/60613512-7c69-4cc5-930b-8cbf7124426b)

Logged in:
![Screenshot 2023-12-07 at 1 25 42 PM](https://github.com/DDMAL/CantusDB/assets/58090591/d6101ae6-4db6-480f-ac30-66134ed163d5)
[Previous version](https://github.com/DDMAL/CantusDB/assets/58090591/08423240-e039-4b4f-bec4-28824a9d8f39)

Logged in, narrow window:
![Screenshot 2023-12-07 at 1 26 03 PM](https://github.com/DDMAL/CantusDB/assets/58090591/723f3157-9039-4886-8390-9f718b5b943b)
[Previous version](https://github.com/DDMAL/CantusDB/assets/58090591/33481530-c752-47dc-8e50-97e240d13ad0)