### PR TITLE
autocomplete: change genre, office, feast to use icontains search

### DIFF
--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1014,7 +1014,7 @@ class FeastAutocomplete(autocomplete.Select2QuerySetView):
         qs = Feast.objects.all().order_by("name")
         if self.q:
             qs = qs.filter(
-                Q(name__istartswith=self.q) | Q(feast_code__istartswith=self.q)
+                Q(name__icontains=self.q) | Q(feast_code__istartswith=self.q)
             )
         return qs
 
@@ -1029,7 +1029,7 @@ class OfficeAutocomplete(autocomplete.Select2QuerySetView):
         qs = Office.objects.all().order_by("name")
         if self.q:
             qs = qs.filter(
-                Q(name__istartswith=self.q) | Q(description__istartswith=self.q)
+                Q(name__istartswith=self.q) | Q(description__icontains=self.q)
             )
         return qs
 
@@ -1044,7 +1044,7 @@ class GenreAutocomplete(autocomplete.Select2QuerySetView):
         qs = Genre.objects.all().order_by("name")
         if self.q:
             qs = qs.filter(
-                Q(name__istartswith=self.q) | Q(description__istartswith=self.q)
+                Q(name__istartswith=self.q) | Q(description__icontains=self.q)
             )
         return qs
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1013,9 +1013,7 @@ class FeastAutocomplete(autocomplete.Select2QuerySetView):
             return Feast.objects.none()
         qs = Feast.objects.all().order_by("name")
         if self.q:
-            qs = qs.filter(
-                Q(name__icontains=self.q) | Q(feast_code__istartswith=self.q)
-            )
+            qs = qs.filter(name__icontains=self.q)
         return qs
 
 


### PR DESCRIPTION
Fixes #1155 

Office and Genre autocomplete widgets are now using icontains search filter on `description` (`name` is still istartswith since they are the shorthand letter representation). Feast are now using icontains search filter on `name`.