### PR TITLE
Disable remap_user_ids command

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/remap_user_ids.py
+++ b/django/cantusdb_project/main_app/management/commands/remap_user_ids.py
@@ -124,6 +124,11 @@ def reassign_chants() -> None:
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
+        error_message = (
+            "As of late November 2023, this command is not working. "
+            "It has been temporarily disabled until the bugs have been worked out."
+        )
+        raise NotImplementedError(error_message)
         stdout.write("\n\n==== Reassigning Sources ====\n")
         reassign_sources()
         stdout.write("\n== All sources successfully remapped! ==\n")


### PR DESCRIPTION
fixes #1166

```
root@fd1bb918c18d:/code/django/cantusdb_project# python manage.py remap_user_ids
Traceback (most recent call last):
  File "/code/django/cantusdb_project/manage.py", line 32, in <module>
    main()
  File "/code/django/cantusdb_project/manage.py", line 28, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/code/django/cantusdb_project/main_app/management/commands/remap_user_ids.py", line 131, in handle
    raise NotImplementedError(error_message)
NotImplementedError: As of late November 2023, this command is not working. It has been temporarily disabled until the bugs have been worked out.
```