### PR TITLE
Update json-cid API to conform to new specification

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4923,7 +4923,10 @@ class JsonCidTest(TestCase):
         chant = make_fake_chant(cantus_id="100000")
         expected_values = {
             "siglum": chant.source.siglum,
+            "srclink": f"http://testserver/source/{chant.source.id}",
+            "chantlink": f"http://testserver/chant/{chant.id}",
             "folio": chant.folio,
+            "sequence": chant.c_sequence,
             "incipit": chant.incipit,
             "feast": chant.feast.name,
             "genre": chant.genre.name,
@@ -4932,7 +4935,7 @@ class JsonCidTest(TestCase):
             "mode": chant.mode,
             "image": chant.image_link,
             "melody": chant.volpiano,
-            "fulltext": chant.manuscript_full_text_std_spelling,
+            "full_text": chant.manuscript_full_text_std_spelling,
             "db": "CD",
         }
         response_1 = self.client.get(
@@ -4961,7 +4964,14 @@ class JsonCidTest(TestCase):
         )
         json_for_one_chant_2 = response_2.json()["chants"][0]["chant"]
         for item in json_for_one_chant_2.items():
-            self.assertIsInstance(item[1], str)  # we shouldn't see any Nones or nulls
+            self.assertIsInstance(
+                item[1],
+                (
+                    int,  # ["sequence"] should be an int
+                    str,  # all other keys should be strings, and there should
+                    # be no Nones or nulls
+                ),
+            )
 
         chant.manuscript_full_text = "nahn-staendrd spillynge"
         chant.manuscript_full_text_std_spelling = "standard spelling"
@@ -4970,7 +4980,7 @@ class JsonCidTest(TestCase):
             reverse("json-cid-export", args=["100000"]),
         )
         json_for_one_chant_3 = response_3.json()["chants"][0]["chant"]
-        self.assertEqual(json_for_one_chant_3["fulltext"], "standard spelling")
+        self.assertEqual(json_for_one_chant_3["full_text"], "standard spelling")
 
 
 class CsvExportTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4854,19 +4854,21 @@ class JsonCidTest(TestCase):
         {
             "chants": [
                 "chant": {
-                    "siglum": "some value"
-                    "srclink": "some value"
-                    "chantlink": "some value"
-                    "folio": "some value"
-                    "incipit": "some value"
-                    "feast": "some value"
-                    "genre": "some value"
-                    "office": "some value"
-                    "position": "some value"
-                    "mode": "some value"
-                    "image": "some value"
-                    "melody": "some value"
-                    "fulltext": "some value"
+                    "siglum": "some string"
+                    "srclink": "some string"
+                    "chantlink": "some string"
+                    "folio": "some string"
+                    "sequence": some_integer
+                    "incipit": "some string"
+                    "feast": "some string"
+                    "genre": "some string"
+                    "office": "some string"
+                    "position": "some string"
+                    "cantus_id": "some string"
+                    "image": "some string"
+                    "mode": "some string"
+                    "full_text": "some string"
+                    "melody": "some string"
                     "db": "CD"
                 },
                 "chant": {
@@ -4874,6 +4876,8 @@ class JsonCidTest(TestCase):
                 },
             ]
         }
+        A more complete specification can be found at
+        https://github.com/DDMAL/CantusDB/issues/1170.
         """
         for _ in range(7):
             make_fake_chant(cantus_id="3.14159")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4899,23 +4899,25 @@ class JsonCidTest(TestCase):
 
         first_chant = first_item["chant"]
         chant_keys = first_chant.keys()
-        expected_keys = [
+        expected_keys = {
             "siglum",
             "srclink",
             "chantlink",
             "folio",
+            "sequence",
             "incipit",
             "feast",
             "genre",
             "office",
             "position",
-            "mode",
+            "cantus_id",
             "image",
+            "mode",
+            "full_text",
             "melody",
-            "fulltext",
             "db",
-        ]
-        self.assertEqual(list(chant_keys), expected_keys)
+        }
+        self.assertEqual(set(chant_keys), expected_keys)
 
     def test_values(self):
         chant = make_fake_chant(cantus_id="100000")

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4963,15 +4963,18 @@ class JsonCidTest(TestCase):
             reverse("json-cid-export", args=["100000"]),
         )
         json_for_one_chant_2 = response_2.json()["chants"][0]["chant"]
-        for item in json_for_one_chant_2.items():
-            self.assertIsInstance(
-                item[1],
-                (
-                    int,  # ["sequence"] should be an int
-                    str,  # all other keys should be strings, and there should
+
+        sequence_value = json_for_one_chant_2.pop("sequence")
+        self.assertIsInstance(sequence_value, int)
+
+        for key, value in json_for_one_chant_2.items():
+            with self.subTest(key=key):
+                self.assertIsInstance(
+                    value,
+                    str,  # we've already removed ["sequence"], which should
+                    # be an int. All other keys should be strings, and there should
                     # be no Nones or nulls
-                ),
-            )
+                )
 
         chant.manuscript_full_text = "nahn-staendrd spillynge"
         chant.manuscript_full_text_std_spelling = "standard spelling"

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -610,22 +610,22 @@ def build_json_cid_dictionary(chant, request) -> dict:
         "siglum": chant.source.siglum,
         "srclink": source_absolute_url,
         "chantlink": chant_absolute_url,
-        # "chantlinkOLD":  # OldCantus included a URL using http:// here,
-        #                  # whereas "chantlink" had a URL with https://
         "folio": chant.folio if chant.folio else "",
+        "sequence": chant.c_sequence if chant.c_sequence else 0,
         "incipit": chant.incipit if chant.incipit else "",
         "feast": chant.feast.name if chant.feast else "",
         "genre": chant.genre.name if chant.genre else "",
         "office": chant.office.name if chant.office else "",
         "position": chant.position if chant.position else "",
-        "mode": chant.mode if chant.mode else "",
+        "cantus_id": chant.cantus_id if chant.cantus_id else "",
         "image": chant.image_link if chant.image_link else "",
-        "melody": chant.volpiano if chant.volpiano else "",
+        "mode": chant.mode if chant.mode else "",
         "fulltext": (
             chant.manuscript_full_text_std_spelling
             if chant.manuscript_full_text_std_spelling
             else ""
         ),
+        "melody": chant.volpiano if chant.volpiano else "",
         "db": "CD",
     }
     return dictionary

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -620,7 +620,7 @@ def build_json_cid_dictionary(chant, request) -> dict:
         "cantus_id": chant.cantus_id if chant.cantus_id else "",
         "image": chant.image_link if chant.image_link else "",
         "mode": chant.mode if chant.mode else "",
-        "fulltext": (
+        "full_text": (
             chant.manuscript_full_text_std_spelling
             if chant.manuscript_full_text_std_spelling
             else ""


### PR DESCRIPTION
This PR makes changes to our json-cid API, so that it conforms to the new standard specified by Jan (i.e., it fixes #1170)

The changes that occurred:
- In the API,
  - we now include a `"sequence"` key, which is an integer
  - we now include a `"cantus_id"` key, a string
  - our previous `"fulltext"` key is now called `"full_text"`
  - in the code, the order of these keys has been rearranged, and a comment has been removed (it was from back when we were just recreating what was on OldCantus, and were not working from a specification)
- `JsonCidTest.test_structure` and `.test_values` have been updated to reflect the new specification