### PR TITLE
Update Diff DB labels and links

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -149,12 +149,15 @@
                 </div>
 
                 <div class="form-row">
-                    <div class="form-group m-1 col-lg-3">
+                    <div class="form-group m-1 col-lg-12">
                         <label for="{{ form.diff_db.id_for_label }}"><small>Differentia Database</small></label>
                         <br>{{ form.diff_db }}
-                        <p>
-                            <small class="text-muted">Diff. IDs: <a href="https://differentiaedatabase.ca/">differentiaedatabase.ca</a></small>
-                        </p>
+                        <div>
+                            <small>
+                                For a list of Differentia IDs, refer to
+                                the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
+                            </small>
+                        </div>
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -153,7 +153,7 @@
                         <label for="{{ form.diff_db.id_for_label }}"><small>Differentiae Database:</small></label>
                         <br>{{ form.diff_db }}
                         <div>
-                            <small>
+                            <small class="text-muted">
                                 For a list of Differentia IDs, refer to
                                 the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
                             </small>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -150,7 +150,7 @@
 
                 <div class="form-row">
                     <div class="form-group m-1 col-lg-12">
-                        <label for="{{ form.diff_db.id_for_label }}"><small>Differentia Database</small></label>
+                        <label for="{{ form.diff_db.id_for_label }}"><small>Differentiae Database:</small></label>
                         <br>{{ form.diff_db }}
                         <div>
                             <small>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -124,7 +124,7 @@
                             </label>
                             <br>{{ form.diff_db }}
                             <div>
-                                <small>
+                                <small class="text-muted">
                                     For a list of Differentia IDs, refer to
                                     the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
                                 </small>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -120,7 +120,7 @@
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.diff_db.id_for_label }}">
-                                <small>Differentia DB:</small>
+                                <small>Differentiae Database:</small>
                             </label>
                             <br>{{ form.diff_db }}
                             <div>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -118,11 +118,17 @@
                         </div>
                     </div>
                     <div class="form-row">
-                        <div class="form-group m-1 col-lg-2">
+                        <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.diff_db.id_for_label }}">
                                 <small>Differentia DB:</small>
                             </label>
                             <br>{{ form.diff_db }}
+                            <div>
+                                <small>
+                                    For a list of Differentia IDs, refer to
+                                    the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
+                                </small>
+                            </div>
                         </div>
                     </div>
                     <div class="form-row">


### PR DESCRIPTION
As it was simple to implement, this PR fixes #1137.

This PR:
- adds a link to access the Differentiae Database on the Chant Edit page
  - Since we have more space below our Diff DB field than OldCantus did, I added a whole sentence ("For a list of Differentia IDs, refer to the [Differentiae Database](https://differentiaedatabase.ca/index)") rather than an abbreviated "Diff. IDs: [differentiaedatabase.ca](https://differentiaedatabase.ca)".
  - This link points to https://differentiaedatabase.ca/index rather than the homepage
- The label for the field has been standardized. It now reads "Differentiae Database:" in both places, rather than "Differentia DB:" and "Differentia Database"

### Edit page:
![Screenshot 2023-11-28 at 6 07 11 PM](https://github.com/DDMAL/CantusDB/assets/58090591/5df99f1b-e896-4742-a7e1-ab7d45a22408)

### Create page:
![Screenshot 2023-11-28 at 6 07 33 PM](https://github.com/DDMAL/CantusDB/assets/58090591/cd55dd95-d57a-470e-80b2-56b724d81b62)