### PR TITLE
Use icontains for provenance autocomplete

### DIFF
--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -1063,7 +1063,7 @@ class ProvenanceAutocomplete(autocomplete.Select2QuerySetView):
             return Provenance.objects.none()
         qs = Provenance.objects.all().order_by("name")
         if self.q:
-            qs = qs.filter(name__istartswith=self.q)
+            qs = qs.filter(name__icontains=self.q)
         return qs
 
 


### PR DESCRIPTION
Use icontains for the provenance autocomplete widget instead of istartswith so that search terms are matched anywhere in the field. Fixes #1160 