### PR TITLE
exclude fields from admin change page

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -172,7 +172,7 @@ class SequenceAdmin(BaseModelAdmin):
 
 
 class SourceAdmin(BaseModelAdmin):
-    exclude = ("source_status",)
+    exclude = EXCLUDE + ("source_status",)
 
     # These search fields are also available on the user-source inline relationship in the user admin page
     search_fields = (

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -16,14 +16,17 @@ from main_app.forms import (
 
 # these fields should not be editable by all classes
 EXCLUDE = (
-    "created_by",
-    "last_updated_by",
     "json_info",
 )
 
+READ_ONLY = (
+    "created_by",
+    "last_updated_by",
+)
 
 class BaseModelAdmin(admin.ModelAdmin):
     exclude = EXCLUDE
+    readonly_fields = READ_ONLY
 
     # if an object is created in the admin interface, assign the user to the created_by field
     # else if an object is updated in the admin interface, assign the user to the last_updated_by field
@@ -58,7 +61,7 @@ class ChantAdmin(BaseModelAdmin):
         "id",
     )
 
-    readonly_fields = (
+    readonly_fields = READ_ONLY + (
         "date_created",
         "date_updated",
     )
@@ -180,7 +183,7 @@ class SourceAdmin(BaseModelAdmin):
         "title",
         "id",
     )
-    readonly_fields = (
+    readonly_fields = READ_ONLY + (
         "number_of_chants",
         "number_of_melodies",
         "date_created",


### PR DESCRIPTION
The base `EXCLUDE`, which is used in most of our other admin panels, was not included in the source admin. I suspect this happened when `source_status` was added as an exclude field in #1116. For reference:
```
EXCLUDE = (
    "created_by",
    "last_updated_by",
    "json_info",
)
```

This might also be a good time to consider having the `created_by` and `last_updated_by` fields as readonly instead of excluded. This information might still be useful to view on the admin change pages. @jacobdgm, let me know if I should make this change as well.

Fixes #1181 