### PR TITLE
Add django-reversion

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
     "main_app",
     "articles",
     "django_quill",  # to provide rich-text field for articles
+    "reversion",  # django-reversion, for version history of objects in database
     "users",
 ]
 
@@ -73,6 +74,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
+    "reversion.middleware.RevisionMiddleware",
 ]
 
 ROOT_URLCONF = "cantusdb.urls"

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from reversion.admin import VersionAdmin
 from main_app.models import *
 from main_app.forms import (
     AdminCenturyForm,
@@ -22,7 +23,7 @@ EXCLUDE = (
 )
 
 
-class BaseModelAdmin(admin.ModelAdmin):
+class BaseModelAdmin(VersionAdmin):
     exclude = EXCLUDE
 
     # if an object is created in the admin interface, assign the user to the created_by field

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -13,6 +13,7 @@ Django==4.2.3
 django-autocomplete-light==3.9.4
 django-extra-views==0.13.0
 django-quill-editor==0.1.40
+django-reversion==5.0.8
 django_debug_toolbar==3.8.1
 Faker==4.1.0
 gunicorn==20.0.4


### PR DESCRIPTION
This PR fixes #430 by installing `django-reversion`.

When this change makes its way to Staging and then to Production, we'll need to run both of the following commands:
- `python manage.py migrate`
  - for reasons I don't understand, migrations related to `django-reversion` are listed among the migrations when I run `showmigrations`, even without me having first run `makemigrations`. So, there are no migrations included in this PR. It seems to work fine anyways. 
- `python manage.py createinitialrevisions`

By adding django-revision to INSTALLED_APPS and to MIDDLEWARE, this ensures that all modifications made to objects via our views (and perhaps also via the admin interface, but not via the shell) are added as revisions. By setting `BaseModelAdmin` to inherit from `reversion.admin.VersionAdmin`, this adds a "History" button on all Change {Model} pages in the Admin area, where all modifications to the object in question are listed. It also adds a "Restore Deleted {Model}s" button allowing a user to view and to restore deleted objects.