### PR TITLE
search bar, Chant Search page: Update policy on when we search by incipit and when we search by Cantus ID

### DIFF
--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -411,7 +411,7 @@ def ajax_search_bar(request, search_term):
     # load only the first seven chants
     CHANT_CNT = 7
 
-    if not search_term.replace(" ", "").isalpha():
+    if any(map(str.isdigit, search_term)):
         # if the search term contains at least one digit, assume user is searching by Cantus ID
         chants = Chant.objects.filter(cantus_id__istartswith=search_term).order_by("id")
     else:

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -430,7 +430,7 @@ def ajax_search_bar(request, search_term):
         "feast__name",
         "cantus_id",
         "mode",
-        "siglum",
+        "source__siglum",
         "office__name",
         "folio",
         "c_sequence",

--- a/django/cantusdb_project/static/js/chant_search.js
+++ b/django/cantusdb_project/static/js/chant_search.js
@@ -1,5 +1,5 @@
-function containsOnlyLettersAndSpaces(str) {
-    return /^[A-Za-z\s]*$/.test(str);
+function containsNoNumerals(str) {
+    return /^\D*$/.test(str);
   }
 
 window.addEventListener("load", function () {
@@ -27,7 +27,7 @@ window.addEventListener("load", function () {
     }
     if (urlParams.has("search_bar")) {
         search_term = urlParams.get("search_bar");
-        if (containsOnlyLettersAndSpaces(search_term)) {
+        if (containsNoNumerals(search_term)) {
             // assume user is doing an incipit search
             opFilter.value = "starts_with"
             keywordField.value = search_term

--- a/django/cantusdb_project/static/js/search_bar.js
+++ b/django/cantusdb_project/static/js/search_bar.js
@@ -41,7 +41,7 @@ function globalSearch() {
                 const feast = chant.feast__name ?? "";
                 const cantus_id = chant.cantus_id ?? "";
                 const mode = chant.mode ?? "";
-                const siglum = chant.siglum ?? "";
+                const siglum = chant.source__siglum ?? "";
                 const folio = chant.folio ?? "";
                 const sequence = chant.c_sequence ?? "";
                 // add an entry to the list-group


### PR DESCRIPTION
This PR updates the incipit-vs-Cantus-ID policy for searches, adds tests for our ajax_search_view, and applies some light refactoring and type annotation.

In doing so, it fixes #1138 and #1185.

In more detail, the following changes were involved:
- When deciding whether to search by incipit or by Cantus ID, we had previously checked whether there were any non-letter characters, and if there were, we would search by Cantus ID. Now, we check whether there are any numerals.
  - this is now true for both the real-time results displayed below the search bar, and for the results when landing on the Chant Search page with a `search_bar` query parameter
- We didn't have any tests for the AJAX search, so I wrote several
- While writing the tests, I discovered a small bug where we were displaying the value stored in chants' `siglum` field, rather than the chant's source's siglum. We don't keep the values in chants' `siglum` fields up-to-date, so these values will either be wrong, for chants whose sources' sigla have changed, or missing, for chants created in NewCantus
- While fixing this bug, I did some light refactoring of `ajax_search_view`, and also added type annotations so I could keep track of things

I thought this would be a simple fix, but it turned out to be connected to a bunch of things! I'm glad I did it - now we have cleaner code, one fewer bug, and a more complete test suite.