### PR TITLE
Chant Create: Change '?' link to point to `/description` page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -63,7 +63,7 @@
                     <div class="form-group m-1 col-lg-2">
                         <label for="{{ form.office.id_for_label }}"><small>Office/Mass:</small></label>
                         <br>{{ form.office }}
-                        <a href="/field-descriptions/#Office"><small>?</small></a>
+                        <a href="/description/#Office"><small>?</small></a>
                     </div>
                 </div>
 


### PR DESCRIPTION
fixes #1203 