### PR TITLE
Source List: Create separate columns for source title and siglum

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -71,20 +71,24 @@
             <thead>
                 <tr>
                     <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Source</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Chants/Melodies</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Chants<br>/&nbsp;Melodies</th>
                 </tr>
             </thead>
             <tbody>
                 {% for source in sources %}
                     <tr>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"><b>{{ source.siglum }}</b></a>
+                            <b>{{ source.siglum }}</b></a>
                         </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {{ source.summary|default:""|truncatechars_html:140 }}
+                        <td class="text-wrap" style="text-align:center" title="{{ source.title }}">
+                            <a href="{% url 'source-detail' source.id %}"><b>{{ source.title|truncatechars_html:50 }}</b></a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center" title="{{ source.summary|default:""|truncatechars_html:500 }}">
+                            {{ source.summary|default:""|truncatechars_html:120 }}
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             {% if source.century.exists %}


### PR DESCRIPTION
This PR fixes #1216.

- There is a new "Siglum" column on the far left, and changes the "Source" column to display the source's title (rather than its siglum).
- Sources' titles are now truncated at 50 characters
- Sources' descriptions are now truncated at 120 characters (rather than 140).
- Users can now get full titles and longer descriptions by mousing over the relevant cell.
- The Chants/Melodies `<th>` is now split onto two lines, making that column narrower.

Screenshots of the page with a wide window and a narrower one:
![Screenshot 2023-12-15 at 3 43 20 PM](https://github.com/DDMAL/CantusDB/assets/58090591/9e364776-aec8-4ee0-877a-ecdef076768e)
![Screenshot 2023-12-15 at 3 55 02 PM](https://github.com/DDMAL/CantusDB/assets/58090591/596398fc-e0dc-4bfd-bf5a-9af23ba8fe85)