### PR TITLE
Source Detail/Edit, Chant List: in sidebar, replace 'image gallery' with 'images'

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_list.html
+++ b/django/cantusdb_project/main_app/templates/chant_list.html
@@ -168,7 +168,7 @@
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
                         <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
                         {% if source.image_link %}
-                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>
+                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Images</a>
                         {% endif %}
                         <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
                         <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -197,7 +197,7 @@
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
                         <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
                         {% if source.image_link %}
-                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>
+                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Images</a>
                         {% endif %}
                         <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
                         <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -264,7 +264,7 @@
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
                         <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
                         {% if source.image_link %}
-                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Image gallery</a>
+                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">Images</a>
                         {% endif %}
                         <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
                         <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>


### PR DESCRIPTION
fixes #1224.

Note that on the Source Edit page, I haven't changed the description beneath the Image Link field (i.e., this PR only makes this substitution in sidebar cards):
![Screenshot 2023-12-18 at 3 18 43 PM](https://github.com/DDMAL/CantusDB/assets/58090591/e7286427-438e-41fd-8fd4-272bfea6b9ed)
