### PR TITLE
Merge Staging into Production, 2023 December 18 edition

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -16,14 +16,13 @@ from main_app.forms import (
 )
 
 # these fields should not be editable by all classes
-EXCLUDE = (
-    "json_info",
-)
+EXCLUDE = ("json_info",)
 
 READ_ONLY = (
     "created_by",
     "last_updated_by",
 )
+
 
 class BaseModelAdmin(VersionAdmin):
     exclude = EXCLUDE

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -172,7 +172,7 @@ class SequenceAdmin(BaseModelAdmin):
 
 
 class SourceAdmin(BaseModelAdmin):
-    exclude = ("source_status",)
+    exclude = EXCLUDE + ("source_status",)
 
     # These search fields are also available on the user-source inline relationship in the user admin page
     search_fields = (

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -16,14 +16,17 @@ from main_app.forms import (
 
 # these fields should not be editable by all classes
 EXCLUDE = (
-    "created_by",
-    "last_updated_by",
     "json_info",
 )
 
+READ_ONLY = (
+    "created_by",
+    "last_updated_by",
+)
 
 class BaseModelAdmin(admin.ModelAdmin):
     exclude = EXCLUDE
+    readonly_fields = READ_ONLY
 
     # if an object is created in the admin interface, assign the user to the created_by field
     # else if an object is updated in the admin interface, assign the user to the last_updated_by field
@@ -58,7 +61,7 @@ class ChantAdmin(BaseModelAdmin):
         "id",
     )
 
-    readonly_fields = (
+    readonly_fields = READ_ONLY + (
         "date_created",
         "date_updated",
     )
@@ -180,7 +183,7 @@ class SourceAdmin(BaseModelAdmin):
         "title",
         "id",
     )
-    readonly_fields = (
+    readonly_fields = READ_ONLY + (
         "number_of_chants",
         "number_of_melodies",
         "date_created",

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -63,7 +63,7 @@
                     <div class="form-group m-1 col-lg-2">
                         <label for="{{ form.office.id_for_label }}"><small>Office/Mass:</small></label>
                         <br>{{ form.office }}
-                        <a href="/field-descriptions/#Office"><small>?</small></a>
+                        <a href="/description/#Office"><small>?</small></a>
                     </div>
                 </div>
 

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -45,7 +45,7 @@
                 {% endif %}
 
                 {% if source.selected_bibliography %}
-                    <dt>Selected Bibilography</dt>
+                    <dt>Selected Bibliography</dt>
                     <dd>{{ source.selected_bibliography|safe|linebreaks }}</dd>
                 {% endif %}
 

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -64,7 +64,7 @@
                 {% endif %}
 
                 {% if source.full_text_entered_by.exists %}
-                    <dt>Full Text Entered by</dt>
+                    <dt>Full Texts Entered by</dt>
                     <dd>
                         {% for editor in source.full_text_entered_by.all %}
                             <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -71,20 +71,24 @@
             <thead>
                 <tr>
                     <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Source</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Chants/Melodies</th>
+                    <th scope="col" class="text-wrap" style="text-align:center">Chants<br>/&nbsp;Melodies</th>
                 </tr>
             </thead>
             <tbody>
                 {% for source in sources %}
                     <tr>
                         <td class="text-wrap" style="text-align:center">
-                            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"><b>{{ source.siglum }}</b></a>
+                            <b>{{ source.siglum }}</b></a>
                         </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {{ source.summary|default:""|truncatechars_html:140 }}
+                        <td class="text-wrap" style="text-align:center" title="{{ source.title }}">
+                            <a href="{% url 'source-detail' source.id %}"><b>{{ source.title|truncatechars_html:50 }}</b></a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center" title="{{ source.summary|default:""|truncatechars_html:500 }}">
+                            {{ source.summary|default:""|truncatechars_html:120 }}
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             {% if source.century.exists %}

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -378,47 +378,7 @@
                         <ul class="list-group list-group-flush">
                             <li class="list-group-item p-0">
                                 <a href="https://cantusindex.org/" target="_blank">
-                                    Cantus Index (all chants catalogue)
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="https://pemdatabase.eu/" target="_blank">
-                                    Portuguese Early Music Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://cantus.sk" target="_blank">
-                                    Slovak Early Music Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://hun-chant.eu" target="_blank">
-                                    Hungarian Chant Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://cantusbohemiae.cz" target="_blank">
-                                    Fontes Cantus Bohemiae
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://cantus.ispan.pl" target="_blank">
-                                    Cantus Planus in Polonia
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://musicahispanica.eu" target="_blank">
-                                    Spanish Early Music Manuscript Database
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://musmed.eu" target="_blank">
-                                    Medieval Music Manuscripts Online
-                                </a>
-                            </li>
-                            <li class="list-group-item p-0">
-                                <a href="http://comparatio.irht.cnrs.fr" target="_blank">
-                                    Comparatio
+                                    Cantus Index
                                 </a>
                             </li>
                         </ul>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -320,7 +320,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-6" id="logos">
+                    <div class="col-md-8" id="logos">
                         <div class="row">
                             <div class="col-md-6">
                                 <a href="https://uwaterloo.ca/" target="_blank">
@@ -373,17 +373,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="col-md-3" id="database-links">
-                        <h5>Database Links</h5>
-                        <ul class="list-group list-group-flush">
-                            <li class="list-group-item p-0">
-                                <a href="https://cantusindex.org/" target="_blank">
-                                    Cantus Index
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="col-md-3" id="login">
+                    <div class="col-md-4" id="login">
                         {% if not request.user.is_anonymous %}
                             {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
                                 <h5>Admin Navigation</h5>


### PR DESCRIPTION
I just updated the staging server. All tests are passing there.

Pages Changed:
- All pages
  - [x] In the footer, links to the other databases in the Cantus Network have been removed; the only such link that remains is the link to Cantus Index
- Admin area
  - All Change pages
    - [x] the "created by" and "last updated by fields" are no longer hidden, and are currently visible as read-only fields
  - Source Change page
    - [x] the "json info" field has been hidden
- Chant Create
  - [x] The link to the Fields and Content Descriptions page was broken. It has now been fixed.
- Source Detail
  - [x] What used to be "Selected Bibilography" now reads "Selected Bibliography"
  - [x] What used to be "Full Text Entered by" now reads "Full Texts Entered by"