### PR TITLE
Add automatic certificate renewal with lego

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -4,7 +4,7 @@ server {
     server_tokens off;
 
     location ^~ /.well-known/acme-challenge/ {
-        root /var/www/certbot;
+        root /var/www/lego;
     }
 
     location / {

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -10,4 +10,4 @@
 20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
 30      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       *       *       0       /usr/local/bin/docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d cantusdatabase.org -d www.cantusdatabase.org --renew-hook "nginx -s reload"
+50      4       *       *       0       /usr/local/bin/docker-compose run nginx lego -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 30 --renew-hook "nginx -s reload" 

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -10,4 +10,4 @@
 20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
 30      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       *       *       0       /usr/local/bin/docker-compose run nginx lego -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 30 --renew-hook "nginx -s reload" 
+50      4       7       *       *       /usr/local/bin/docker-compose run nginx lego -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -10,4 +10,4 @@
 20      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/monthly.sh
 30      4       1       1       *       bash /home/ubuntu/code/CantusDB/cron/postgres/yearly.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       7       *       *       /usr/local/bin/docker-compose run nginx lego -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 
+50      4       7       *       *       /usr/local/bin/docker-compose run nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,18 +25,9 @@ services:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
       - media_volume:/resources/media
-      - certbot_data:/var/www/certbot/:ro
-      - certificates:/etc/nginx/ssl/:ro
     restart: always
     depends_on:
       - django
-
-  certbot:
-    image: certbot/certbot:latest
-    volumes:
-      - certbot_data:/var/www/certbot/:rw
-      - certificates:/etc/letsencrypt/:rw
-    restart: always
 
   postgres:
     build:
@@ -50,5 +41,3 @@ volumes:
   postgres_data:
   static_volume:
   media_volume:
-  certbot_data:
-  certificates:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,8 @@
 FROM nginx:1.24
+ARG LEGOCHECKSUM="f5a978397802a2eb20771925ceb173dff88705b45fdbb2e68312269e205fa85d"
+RUN curl -LJO https://github.com/go-acme/lego/releases/download/v4.14.2/lego_v4.14.2_linux_amd64.tar.gz && \
+    echo "$LEGOCHECKSUM lego_v4.14.2_linux_amd64.tar.gz" | sha256sum -c && \
+    tar -xvf lego_v4.14.2_linux_amd64.tar.gz && \
+    mv lego /usr/local/bin/lego && \
+    rm lego_v4.14.2_linux_amd64.tar.gz
 COPY error_pages .


### PR DESCRIPTION
Simplifies certificate management on the Cantus DB production server. Removes the use of `certbot` for certificate renewal and introduces `lego`. 

- Removes constantly-restarting `certbot` container and associate cron job.
- Intalls `lego` in the `nginx` container, removing need for certificate renewal process to touch multiple containers.
- Updates timing of certificate renewal in cron job (Thinking: we can check for renewal once-per-month and only renew if certificate expires within 45 days).