### PR TITLE
Add css styling for autocomplete widgets

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -127,6 +127,9 @@
         .guillemet::before {
             content: "» "
         }
+        .select2 {
+            width: 100%!important;
+          }
 
         /* this class is used for displaying results under the global search bar */
         .list-group-item-action:hover {


### PR DESCRIPTION
Looking into #1199, I found that a general recommendation for the select2 autocomoplete widgets is to add css styling that fits the widget to 100% of the container width. This recommendation Fixes #1199.

The original idea was to truncate the labels in the widget. I tried this and found that it did in fact truncate the results in the widget dropdown but not the label that shows inside the widget if the field already has a selection.

<img width="735" alt="image" src="https://github.com/DDMAL/CantusDB/assets/71031342/67290e8e-b5f0-4ea5-a79d-4cd76291f01e">
