### PR TITLE
Improve loading of chants for index view

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1067,7 +1067,7 @@ class ChantIndexView(TemplateView):
             queryset = (
                 source.chant_set.annotate(record_type=Value("chant"))
                 .order_by("folio", "c_sequence")
-                .select_related("feast", "office", "genre")
+                .select_related("feast", "office", "genre", "diff_db")
             )
 
         context["source"] = source


### PR DESCRIPTION
Adding `diff_db` to `select_related` on ChantIndexView reduces the number of queries significantly. 

e.g., On `/index/?source=123723` it reduced it from 344 queries to 4 queries on page load.