### PR TITLE
Create provenance_json_export and notation_json_export APIs

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -38,6 +38,7 @@ from main_app.models import (
     Feast,
     Genre,
     Office,
+    Provenance,
     Segment,
     Sequence,
     Source,
@@ -4653,6 +4654,37 @@ class JsonNodeExportTest(TestCase):
             reverse("json-node-export", args=[sequence_id])
         )
         self.assertEqual(unpublished_sequence_response.status_code, 404)
+
+
+class ProvenanceJsonTest(TestCase):
+    def test_response(self):
+        provenance: Provenance = make_fake_provenance()
+        id: int = provenance.id
+
+        response = self.client.get(reverse("provenance-json-export", args=[id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, JsonResponse)
+
+    def test_keys(self):
+        provenance: Provenance = make_fake_provenance()
+        id: int = provenance.id
+
+        response = self.client.get(reverse("provenance-json-export", args=[id]))
+        response_json: dict = response.json()
+        response_keys = response_json.keys()
+
+        expected_keys = [
+            # inherited from BaseModel
+            "date_created",
+            "date_updated",
+            "created_by_id",
+            "last_updated_by_id",
+            # defined in Provenance
+            "name",
+        ]
+        for key in expected_keys:
+            with self.subTest(key=key):
+                self.assertIn(key, response_keys)
 
 
 class JsonSourcesExportTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -20,6 +20,7 @@ from .make_fakes import (
     make_fake_chant,
     make_fake_feast,
     make_fake_genre,
+    make_fake_notation,
     make_fake_office,
     make_fake_provenance,
     make_fake_rism_siglum,
@@ -37,6 +38,7 @@ from main_app.models import (
     Differentia,
     Feast,
     Genre,
+    Notation,
     Office,
     Provenance,
     Segment,
@@ -4656,6 +4658,37 @@ class JsonNodeExportTest(TestCase):
         self.assertEqual(unpublished_sequence_response.status_code, 404)
 
 
+class NotationJsonTest(TestCase):
+    def test_response(self):
+        notation: Notation = make_fake_notation()
+        id: int = notation.id
+
+        response = self.client.get(reverse("notation-json-export", args=[id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, JsonResponse)
+
+    def test_keys(self):
+        notation: Notation = make_fake_notation()
+        id: int = notation.id
+
+        response = self.client.get(reverse("notation-json-export", args=[id]))
+        response_json: dict = response.json()
+        response_keys = response_json.keys()
+
+        expected_keys = [
+            # defined in BaseModel
+            "date_created",
+            "date_updated",
+            "created_by_id",
+            "last_updated_by_id",
+            # defined in Notation
+            "name",
+        ]
+        for key in expected_keys:
+            with self.subTest(key=key):
+                self.assertIn(key, response_keys)
+
+
 class ProvenanceJsonTest(TestCase):
     def test_response(self):
         provenance: Provenance = make_fake_provenance()
@@ -4674,7 +4707,7 @@ class ProvenanceJsonTest(TestCase):
         response_keys = response_json.keys()
 
         expected_keys = [
-            # inherited from BaseModel
+            # defined in BaseModel
             "date_created",
             "date_updated",
             "created_by_id",

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -345,6 +345,11 @@ urlpatterns = [
         name="json-node-export",
     ),
     path(
+        "notation/<int:id>/json",
+        views.notation_json_export,
+        name="notation-json-export",
+    ),
+    path(
         "provenance/<int:id>/json",
         views.provenance_json_export,
         name="provenance-json-export",

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -324,11 +324,6 @@ urlpatterns = [
         name="json-sources-export",
     ),
     path(
-        "json-node/<int:id>",
-        views.json_node_export,
-        name="json-node-export",
-    ),
-    path(
         "json-nextchants/<str:cantus_id>",
         views.json_nextchants,
         name="json-nextchants",
@@ -342,6 +337,17 @@ urlpatterns = [
         "json-cid/<str:cantus_id>",
         views.json_cid_export,
         name="json-cid-export",
+    ),
+    # JSON APIs for returning data on individual objects in the database
+    path(
+        "json-node/<int:id>",
+        views.json_node_export,
+        name="json-node-export",
+    ),
+    path(
+        "provenance/<int:id>/json",
+        views.provenance_json_export,
+        name="provenance-json-export",
     ),
     # misc search
     path(

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -744,6 +744,19 @@ def json_node_export(request, id: int) -> JsonResponse:
     return HttpResponseNotFound()
 
 
+def provenance_json_export(request, id: int) -> JsonResponse:
+    """
+    Return all fields of the provenance with the specified ID
+    """
+
+    provenance_qs: QuerySet[Provenance] = Provenance.objects.filter(id=id)
+    if len(provenance_qs) == 0:
+        return HttpResponseNotFound()
+
+    values: dict = dict(*provenance_qs.values())
+    return JsonResponse(values)
+
+
 def articles_list_export(request) -> HttpResponse:
     """Returns a list of URLs of all articles on the site
 

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -744,6 +744,19 @@ def json_node_export(request, id: int) -> JsonResponse:
     return HttpResponseNotFound()
 
 
+def notation_json_export(request, id: int) -> JsonResponse:
+    """
+    Return all fields of the notation with the specified ID
+    """
+
+    notation_qs: QuerySet[Notation] = Notation.objects.filter(id=id)
+    if len(notation_qs) == 0:
+        return HttpResponseNotFound()
+
+    values: dict = dict(*notation_qs.values())
+    return JsonResponse(values)
+
+
 def provenance_json_export(request, id: int) -> JsonResponse:
     """
     Return all fields of the provenance with the specified ID


### PR DESCRIPTION
This PR goes partway toward f\ixing #564. It includes two new APIs, for exporting information on CantusDB's Provenances and Notations.

Now that I've figured out how to set this up (deciding on how best to approach the tests was actually the main stumbling block), it will be easy to set up similar APIs for all our other objects, which will be useful for the general LinkedMusic project as well as (potentially) Cantus Ultimus (though I think the APIs for the two models in question are the ones most immediately needed by CU).

Sample output for `/notation/3870/json`:
```json
{
    "id": 3870,
    "date_created": "2020-07-09T21:21:57.919Z",
    "date_updated": "2020-07-09T21:21:57.921Z",
    "created_by_id": null,
    "last_updated_by_id": null,
    "name": "dtrns (???)"
}
```

Sample output for `/provenance/3622/json`:
```json
{
    "id": 3622,
    "date_created": "2020-07-09T21:22:28.612Z",
    "date_updated": "2020-07-09T21:22:28.613Z",
    "created_by_id": null,
    "last_updated_by_id": null,
    "name": "St-Lambrecht"
}
```

Figured I would get feedback on these two before implementing the rest. @lucasmarchd01 and @dchiller, I'd appreciate your thoughts!