### PR TITLE
Refactor provenance- and notation-json-export APIs

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4676,13 +4676,12 @@ class NotationJsonTest(TestCase):
         response_keys = response_json.keys()
 
         expected_keys = [
-            # defined in BaseModel
+            "id",
+            "name",
             "date_created",
             "date_updated",
-            "created_by_id",
-            "last_updated_by_id",
-            # defined in Notation
-            "name",
+            "created_by",
+            "last_updated_by",
         ]
         for key in expected_keys:
             with self.subTest(key=key):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4706,13 +4706,12 @@ class ProvenanceJsonTest(TestCase):
         response_keys = response_json.keys()
 
         expected_keys = [
-            # defined in BaseModel
+            "id",
+            "name",
             "date_created",
             "date_updated",
-            "created_by_id",
-            "last_updated_by_id",
-            # defined in Provenance
-            "name",
+            "created_by",
+            "last_updated_by",
         ]
         for key in expected_keys:
             with self.subTest(key=key):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -424,8 +424,12 @@ class ChantByCantusIDView(ListView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        chant_set = Chant.objects.filter(cantus_id=self.cantus_id).select_related("source", "office", "genre", "feast")
-        sequence_set = Sequence.objects.filter(cantus_id=self.cantus_id).select_related("source", "office", "genre", "feast")
+        chant_set = Chant.objects.filter(cantus_id=self.cantus_id).select_related(
+            "source", "office", "genre", "feast"
+        )
+        sequence_set = Sequence.objects.filter(cantus_id=self.cantus_id).select_related(
+            "source", "office", "genre", "feast"
+        )
         display_unpublished = self.request.user.is_authenticated
         if not display_unpublished:
             chant_set = chant_set.filter(source__published=True)

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -783,12 +783,25 @@ def provenance_json_export(request, id: int) -> JsonResponse:
     Return all fields of the provenance with the specified ID
     """
 
-    provenance_qs: QuerySet[Provenance] = Provenance.objects.filter(id=id)
-    if len(provenance_qs) == 0:
+    try:
+        provenance: Provenance = Provenance.objects.get(id=id)
+    except Provenance.DoesNotExist:
         return HttpResponseNotFound()
 
-    values: dict = dict(*provenance_qs.values())
-    return JsonResponse(values)
+    User = get_user_model()
+    created_by: Optional[User] = provenance.created_by
+    last_updated_by: Optional[User] = provenance.last_updated_by
+
+    data = {
+        "id": provenance.id,
+        "name": provenance.name,
+        "date_created": provenance.date_created,
+        "date_updated": provenance.date_updated,
+        "created_by": created_by.id if created_by else None,
+        "last_updated_by": last_updated_by.id if last_updated_by else None,
+    }
+
+    return JsonResponse(data)
 
 
 def articles_list_export(request) -> HttpResponse:

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -36,6 +36,7 @@ from django.templatetags.static import static
 from django.contrib.flatpages.models import FlatPage
 from dal import autocomplete
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 
 
 @login_required
@@ -749,12 +750,32 @@ def notation_json_export(request, id: int) -> JsonResponse:
     Return all fields of the notation with the specified ID
     """
 
-    notation_qs: QuerySet[Notation] = Notation.objects.filter(id=id)
-    if len(notation_qs) == 0:
+    # notation_qs: QuerySet[Notation] = Notation.objects.filter(id=id)
+    # if len(notation_qs) == 0:
+    #     return HttpResponseNotFound()
+
+    # values: dict = dict(*notation_qs.values())
+    # return JsonResponse(values)
+
+    try:
+        notation: Notation = Notation.objects.get(id=id)
+    except Notation.DoesNotExist:
         return HttpResponseNotFound()
 
-    values: dict = dict(*notation_qs.values())
-    return JsonResponse(values)
+    User = get_user_model()
+    created_by: Optional[User] = notation.created_by
+    last_updated_by: Optional[User] = notation.last_updated_by
+
+    data = {
+        "id": notation.id,
+        "name": notation.name,
+        "date_created": notation.date_created,
+        "date_updated": notation.date_updated,
+        "created_by": created_by.id if created_by else None,
+        "last_updated_by": last_updated_by.id if last_updated_by else None,
+    }
+
+    return JsonResponse(data)
 
 
 def provenance_json_export(request, id: int) -> JsonResponse:

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -775,10 +775,7 @@ def provenance_json_export(request, id: int) -> JsonResponse:
     for the provenance with the specified ID
     """
 
-    try:
-        provenance: Provenance = Provenance.objects.get(id=id)
-    except Provenance.DoesNotExist:
-        return HttpResponseNotFound()
+    provenance: Provenance = get_object_or_404(Provenance, id=id)
 
     User = get_user_model()
     created_by: Optional[User] = provenance.created_by

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -747,20 +747,11 @@ def json_node_export(request, id: int) -> JsonResponse:
 
 def notation_json_export(request, id: int) -> JsonResponse:
     """
-    Return all fields of the notation with the specified ID
+    Return JsonResponse containing several key:value pairs
+    for the notation with the specified ID
     """
 
-    # notation_qs: QuerySet[Notation] = Notation.objects.filter(id=id)
-    # if len(notation_qs) == 0:
-    #     return HttpResponseNotFound()
-
-    # values: dict = dict(*notation_qs.values())
-    # return JsonResponse(values)
-
-    try:
-        notation: Notation = Notation.objects.get(id=id)
-    except Notation.DoesNotExist:
-        return HttpResponseNotFound()
+    notation: Notation = get_object_or_404(Notation, id=id)
 
     User = get_user_model()
     created_by: Optional[User] = notation.created_by
@@ -780,7 +771,8 @@ def notation_json_export(request, id: int) -> JsonResponse:
 
 def provenance_json_export(request, id: int) -> JsonResponse:
     """
-    Return all fields of the provenance with the specified ID
+    Return JsonResponse containing several key:value pairs
+    for the provenance with the specified ID
     """
 
     try:


### PR DESCRIPTION
This PR amends the changes in #1251 based on comments on that PR after it was merged:

- `notation_` and `provenance_json_export` now use `get_object_or_404` instead of `queryset.filter(id=id)`
- the keys in the JsonResponse are now specified explicitly, rather than just getting all the fields for the model with `queryset.values()`. This change was necessitated by the use of `get_object_or_404`, but also has the effect of ensuring that these APIs will return data in the same format even if we make changes to the models in question.
- several keys were updated: `"created_by_id"` is now `"created_by"`, and `"last_updated_by_id"` is now `"last_updated_by"`.

Coming along for the ride is a commit updating the formatting of `views/chant.py` to comply with Black.