### PR TITLE
Source List: remove errant closing anchor tag

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -85,7 +85,7 @@
                             <a href="{% url 'source-detail' source.id %}"><b>{{ source.title|truncatechars_html:50 }}</b></a>
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            <b>{{ source.siglum }}</b></a>
+                            <b>{{ source.siglum }}</b>
                         </td>
                         <td class="text-wrap" style="text-align:center" title="{{ source.summary|default:""|truncatechars_html:500 }}">
                             {{ source.summary|default:""|truncatechars_html:120 }}


### PR DESCRIPTION
There's an unnecessary `</a>` in the source list page, as found by @ahankinson in https://github.com/DDMAL/CantusDB/pull/1257#pullrequestreview-1822673411. This PR removes it.