### PR TITLE
Fixes to certificate renewal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ django/cantusdb_project/main_app/fixtures
 #
 config/envs/dev_env
 .devcontainer/
+certificates/
 
 # Drupal scripts from old Cantus
 django/cantusdb_project/Drupal_scripts

--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -16,8 +16,8 @@ server {
 
     listen 443 default_server http2 ssl;
 	
-    ssl_certificate /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.crt;
-    ssl_certificate_key /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.key;
+    ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
+    ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
 
     location / {
         proxy_pass http://django:8000;

--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -16,8 +16,8 @@ server {
 
     listen 443 default_server http2 ssl;
 	
-    ssl_certificate /etc/nginx/ssl/live/cantusdatabase.org/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/cantusdatabase.org/privkey.pem;
+    ssl_certificate /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.crt;
+    ssl_certificate_key /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.key;
 
     location / {
         proxy_pass http://django:8000;

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -7,4 +7,4 @@
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/db_backup.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       7       *       *       /usr/local/bin/docker-compose run nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 
+50      4       *       *       7       /usr/local/bin/docker-compose exec nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
       - media_volume:/resources/media
+      - ./certificates:/etc/nginx/ssl/live
     restart: always
     depends_on:
       - django


### PR DESCRIPTION
This PR: 

- adds `./certificates` to `.gitignore` so that certificates are not accidentally committed to the repo (even though we would rarely open a PR from changes made on staging or production)
- modifies certificate paths in `docker-compose.yml` and the nginx config file
- uses `exec` rather than `run` in the certificate renewal command


Closes #1262.