### PR TITLE
Redirect mass.cantusdatabase.org to cantusdatabase.org

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -13,6 +13,20 @@ server {
 }
 
 server {
+    # Redirect all https traffic for mass.cantusdatabase.org to cantusdatabase.org
+    listen 443 ssl;
+
+    server_name mass.cantusdatabase.org;
+
+    ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
+    ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
+
+    location / {
+        return 301 https://cantusdatabase.org$request_uri;
+    }
+}
+
+server {
 
     listen 443 default_server http2 ssl;
 	

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -7,4 +7,4 @@
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/db_backup.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       *       *       7       /usr/local/bin/docker-compose exec nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 
+50      4       *       *       7       /usr/local/bin/docker-compose exec nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 


### PR DESCRIPTION
This PR redirects requests to mass.cantusdatabase.org to cantusdatabase.org:

- updates `config/nginx/conf.d/cantusdb.conf` to include a permanent redirect on port 443
- updates the certificate renewal job in `cron/cron.txt` to include the `mass.cantusdatabase.org` subdomain

Closes #1255