### PR TITLE
Create webroot path during `nginx` container build

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -5,4 +5,5 @@ RUN curl -LJO https://github.com/go-acme/lego/releases/download/v4.14.2/lego_v4.
     tar -xvf lego_v4.14.2_linux_amd64.tar.gz && \
     mv lego /usr/local/bin/lego && \
     rm lego_v4.14.2_linux_amd64.tar.gz
+RUN mkdir -p /var/www/lego
 COPY error_pages .


### PR DESCRIPTION
`config/nginx/conf.d/cantusdb.conf` configures `/var/www/lego` as the location of the challenge for certificate creation and renwal. This update to the nginx `Dockerfile` ensures that this path exists.