### PR TITLE
Fix cron job command for lego certificate renewal

### DIFF
--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -7,4 +7,4 @@
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/db_backup.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       *       *       7       /usr/local/bin/docker-compose exec nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 
+50      4       *       *       7       /usr/local/bin/docker-compose -f /home/ubuntu/code/CantusDB/docker-compose.yml exec nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -7,4 +7,4 @@
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/db_backup.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       *       *       7       /usr/local/bin/docker-compose -f /home/ubuntu/code/CantusDB/docker-compose.yml exec nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 
+50      4       *       *       7       /usr/local/bin/docker-compose -f /home/ubuntu/code/CantusDB/docker-compose.yml exec -T nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -7,4 +7,4 @@
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/db_backup.sh
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
-50      4       *       *       7       /usr/local/bin/docker-compose -f /home/ubuntu/code/CantusDB/docker-compose.yml exec -T nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 
+50      4       *       *       7       /usr/local/bin/docker-compose -f /home/ubuntu/code/CantusDB/docker-compose.yml exec -T nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org -m updateme@example.com --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 


### PR DESCRIPTION
This PR:

- provides a full path to the `docker-compose.yml` file (since the cron job is not run from the directory containing the `docker-compose.yml` file)
- adds the `-T` flag to `docker-compose exec` command
- add the `-m` flag with dummy email to the `lego` command