### PR TITLE
Create save_concordances_to_file command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ django/cantusdb_project/Drupal_scripts
 
 # in case you're working on importing data from a database dump
 *.sql
+
+# cached files for APIs
+api_cache/
+

--- a/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
+++ b/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
@@ -2,6 +2,7 @@ import json
 import os
 from sys import stdout
 from datetime import datetime
+from collections import defaultdict
 from django.db.models.query import QuerySet
 from django.core.management.base import BaseCommand
 from main_app.models import Chant
@@ -10,103 +11,41 @@ from main_app.models import Chant
 class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
         CACHE_DIR: str = "api_cache"
-        FILEPATH: str = "api_cache/all_concordances.json"
+        FILEPATH: str = "api_cache/concordances.json"
         start_time: str = datetime.now().isoformat()
         stdout.write("Running save_concordances_to_file " f"at {start_time}.\n")
-        concordance_info: dict = get_concordance_info_for_all_cantus_ids()
+        concordances: dict = get_concordances()
         write_time: str = datetime.now().isoformat()
         metadata: dict = {
             "last_updated": write_time,
         }
         data_and_metadata: dict = {
-            "data": concordance_info,
+            "data": concordances,
             "metadata": metadata,
         }
-        stdout.write(
-            "  save_concordances_to_file: attempting to make directory "
-            f"at {CACHE_DIR} to hold cache: "
-        )
+        stdout.write("Attempting to make directory " f"at {CACHE_DIR} to hold cache: ")
         try:
             os.mkdir(CACHE_DIR)
             stdout.write(f"successfully created directory at {CACHE_DIR}.\n")
         except FileExistsError:
             stdout.write(f"directory at {CACHE_DIR} already exists.\n")
-        stdout.write(
-            "  save_concordances_to_file: Writing concordances "
-            f"information to {FILEPATH} "
-            f"at {write_time}.\n"
-        )
+        stdout.write(f"Writing concordances to {FILEPATH} " f"at {write_time}.\n")
         with open(FILEPATH, "w") as json_file:
             json.dump(data_and_metadata, json_file)
-        stdout.write(
-            "save_concordances_to_file: Concordances successfully written to "
-            f"{FILEPATH}.\n\n"
-        )
+        stdout.write(f"Concordances successfully written to {FILEPATH}.\n\n")
 
 
-def get_concordance_info_for_all_cantus_ids() -> dict:
-    """
-    Create a dictionary with information on all published chants
-    in the database, grouped by Cantus ID
+def get_concordances() -> dict:
+    DOMAIN: str = "https://cantusdatabase.org"
 
-    Returns:
-        dict: a dictionary, with each key being one Cantus ID, and each
-        value being a list of chants in the database matching that ID
-    """
-    cantus_ids = list(get_set_of_cantus_ids())
-    cantus_id_count = len(cantus_ids)
-    stdout.write(
-        f"  save_concordances_to_file: Computing concordances "
-        f"information for {cantus_id_count} Cantus IDs.\n"
-    )
-    dictionary: dict = {
-        cantus_id: get_concordance_info_for_cantus_id(cantus_id)
-        for cantus_id in cantus_ids
-    }
-
-    return dictionary
-
-
-def get_set_of_cantus_ids() -> set[str]:
-    """
-    Create a set of all Cantus IDs in the database.
-
-    Returns only those Cantus IDs associated with published chants,
-    and ignoring those from the Bower Database.
-
-    Returns [set[str]]: a set of strings, each string being
-        a single Cantus ID
-    """
+    stdout.write("Querying database for published chants\n")
     published_chants: QuerySet[Chant] = Chant.objects.filter(source__published=True)
-    published_cantus_ids: QuerySet[dict] = published_chants.values("cantus_id")
-    unique_cantus_ids: set[str] = set(c["cantus_id"] for c in published_cantus_ids)
-
-    return unique_cantus_ids
-
-
-def get_concordance_info_for_cantus_id(cantus_id: str) -> list[dict]:
-    """
-    Given a Cantus ID, return a list of dictionareis containing
-    information on all published chants in the database with that Cantus ID
-
-    Args:
-    - cantus_id [str]: the Cantus ID
-
-    Returns [list[dict]]: a list of dictionaries, with each dictionary representing
-    one chant
-    """
-    published_chants: QuerySet[Chant] = Chant.objects.filter(source__published=True)
-    chants_matching_cantus_id: QuerySet[Chant] = published_chants.filter(
-        cantus_id=cantus_id
-    ).prefetch_related(
-        # .prefetch_related() is necessary in order to be able to follow
-        # source__siglum, feast__name, etc. when using .values(), below
+    values: QuerySet[dict] = published_chants.select_related(
         "source",
         "feast",
         "genre",
         "office",
-    )
-    chants_values: QuerySet[dict] = chants_matching_cantus_id.values(
+    ).values(
         "id",
         "source_id",
         "source__siglum",
@@ -123,31 +62,36 @@ def get_concordance_info_for_cantus_id(cantus_id: str) -> list[dict]:
         "manuscript_full_text_std_spelling",
         "volpiano",
     )
-    return [build_chant_dictionary(chant) for chant in chants_values]
 
+    stdout.write("Processing chants\n")
+    concordances: defaultdict = defaultdict(list)
+    for chant in values:
+        source_id: int = chant["source_id"]
+        source_absolute_url: str = f"{DOMAIN}/source/{source_id}/"
+        chant_id: int = chant["id"]
+        chant_absolute_url: str = f"{DOMAIN}/source/{chant_id}/"
 
-def build_chant_dictionary(chant: dict) -> dict:
-    DOMAIN: str = "https://cantusdatabase.org"
-    source_id: str = chant["source_id"]
-    chant_id: str = chant["id"]
-    source_absolute_uri: str = f"{DOMAIN}/source/{source_id}/"
-    chant_absolute_uri: str = f"{DOMAIN}/chant/{chant_id}/"
-    dictionary = {
-        "siglum": chant["source__siglum"],
-        "srclink": source_absolute_uri,
-        "chantlink": chant_absolute_uri,
-        "folio": chant["folio"],
-        "sequence": chant["c_sequence"],
-        "incipit": chant["incipit"],
-        "feast": chant["feast__name"],
-        "genre": chant["genre__name"],
-        "office": chant["office__name"],
-        "position": chant["position"],
-        "cantus_id": chant["cantus_id"],
-        "image": chant["image_link"],
-        "mode": chant["mode"],
-        "full_text": chant["manuscript_full_text_std_spelling"],
-        "melody": chant["volpiano"],
-        "db": "CD",
-    }
-    return dictionary
+        concordances[chant["cantus_id"]].append(
+            {
+                "siglum": chant["source__siglum"],
+                "srclink": source_absolute_url,
+                "chantlink": chant_absolute_url,
+                "folio": chant["folio"],
+                "sequence": chant["c_sequence"],
+                "incipit": chant["incipit"],
+                "feast": chant["feast__name"],
+                "genre": chant["genre__name"],
+                "office": chant["office__name"],
+                "position": chant["position"],
+                "cantus_id": chant["cantus_id"],
+                "image": chant["image_link"],
+                "mode": chant["mode"],
+                "full_text": chant["manuscript_full_text_std_spelling"],
+                "melody": chant["volpiano"],
+                "db": "CD",
+            }
+        )
+
+    stdout.write(f"All chants processed - found {len(concordances)} Cantus IDs\n")
+
+    return dict(concordances)

--- a/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
+++ b/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
@@ -1,0 +1,153 @@
+import json
+import os
+from sys import stdout
+from datetime import datetime
+from django.db.models.query import QuerySet
+from django.core.management.base import BaseCommand
+from main_app.models import Chant
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs) -> None:
+        CACHE_DIR: str = "api_cache"
+        FILEPATH: str = "api_cache/all_concordances.json"
+        start_time: str = datetime.now().isoformat()
+        stdout.write("Running save_concordances_to_file " f"at {start_time}.\n")
+        concordance_info: dict = get_concordance_info_for_all_cantus_ids()
+        write_time: str = datetime.now().isoformat()
+        metadata: dict = {
+            "last_updated": write_time,
+        }
+        data_and_metadata: dict = {
+            "data": concordance_info,
+            "metadata": metadata,
+        }
+        stdout.write(
+            "  save_concordances_to_file: attempting to make directory "
+            f"at {CACHE_DIR} to hold cache: "
+        )
+        try:
+            os.mkdir(CACHE_DIR)
+            stdout.write(f"successfully created directory at {CACHE_DIR}.\n")
+        except FileExistsError:
+            stdout.write(f"directory at {CACHE_DIR} already exists.\n")
+        stdout.write(
+            "  save_concordances_to_file: Writing concordances "
+            f"information to {FILEPATH} "
+            f"at {write_time}.\n"
+        )
+        with open(FILEPATH, "w") as json_file:
+            json.dump(data_and_metadata, json_file)
+        stdout.write(
+            "save_concordances_to_file: Concordances successfully written to "
+            f"{FILEPATH}.\n\n"
+        )
+
+
+def get_concordance_info_for_all_cantus_ids() -> dict:
+    """
+    Create a dictionary with information on all published chants
+    in the database, grouped by Cantus ID
+
+    Returns:
+        dict: a dictionary, with each key being one Cantus ID, and each
+        value being a list of chants in the database matching that ID
+    """
+    cantus_ids = list(get_set_of_cantus_ids())
+    cantus_id_count = len(cantus_ids)
+    stdout.write(
+        f"  save_concordances_to_file: Computing concordances "
+        f"information for {cantus_id_count} Cantus IDs\n"
+    )
+    dictionary: dict = {
+        cantus_id: get_concordance_info_for_cantus_id(cantus_id)
+        for cantus_id in cantus_ids
+    }
+
+    return dictionary
+
+
+def get_set_of_cantus_ids() -> set[str]:
+    """
+    Create a set of all Cantus IDs in the database.
+
+    Returns only those Cantus IDs associated with published chants,
+    and ignoring those from the Bower Database.
+
+    Returns [set[str]]: a set of strings, each string being
+        a single Cantus ID
+    """
+    published_chants: QuerySet[Chant] = Chant.objects.filter(source__published=True)
+    published_cantus_ids: QuerySet[dict] = published_chants.values("cantus_id")
+    unique_cantus_ids: set[str] = set(c["cantus_id"] for c in published_cantus_ids)
+
+    return unique_cantus_ids
+
+
+def get_concordance_info_for_cantus_id(cantus_id: str) -> list[dict]:
+    """
+    Given a Cantus ID, return a list of dictionareis containing
+    information on all published chants in the database with that Cantus ID
+
+    Args:
+    - cantus_id [str]: the Cantus ID
+
+    Returns [list[dict]]: a list of dictionaries, with each dictionary representing
+    one chant
+    """
+    published_chants: QuerySet[Chant] = Chant.objects.filter(source__published=True)
+    chants_matching_cantus_id: QuerySet[Chant] = published_chants.filter(
+        cantus_id=cantus_id
+    ).prefetch_related(
+        # .prefetch_related() is necessary in order to be able to follow
+        # source__siglum, feast__name, etc. when using .values(), below
+        "source",
+        "feast",
+        "genre",
+        "office",
+    )
+    chants_values: QuerySet[dict] = chants_matching_cantus_id.values(
+        "id",
+        "source_id",
+        "source__siglum",
+        "folio",
+        "c_sequence",
+        "incipit",
+        "feast__name",
+        "genre__name",
+        "office__name",
+        "position",
+        "cantus_id",
+        "image_link",
+        "mode",
+        "manuscript_full_text_std_spelling",
+        "volpiano",
+    )
+    return [build_cid_dictionary(chant) for chant in chants_values]
+
+
+def build_cid_dictionary(chant: dict) -> dict:
+    DOMAIN: str = "https://cantusdatabase.org"
+    source_id: str = chant["source_id"]
+    chant_id: str = chant["id"]
+    source_absolute_uri: str = f"{DOMAIN}/source/{source_id}/"
+    chant_absolute_uri: str = f"{DOMAIN}/chant/{chant_id}/"
+    dictionary = {
+        "siglum": chant["source__siglum"],
+        "srclink": source_absolute_uri,
+        "chantlink": chant_absolute_uri,
+        "folio": chant["folio"],
+        "sequence": chant["c_sequence"],
+        "incipit": chant["incipit"],
+        "feast": chant["feast__name"],
+        "genre": chant["genre__name"],
+        "office": chant["office__name"],
+        "position": chant["position"],
+        "cantus_id": chant["cantus_id"],
+        "image": chant["image_link"],
+        "mode": chant["mode"],
+        "full_text": chant["manuscript_full_text_std_spelling"],
+        "melody": chant["volpiano"],
+        "db": "CD",
+    }
+    return dictionary

--- a/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
+++ b/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
@@ -123,10 +123,10 @@ def get_concordance_info_for_cantus_id(cantus_id: str) -> list[dict]:
         "manuscript_full_text_std_spelling",
         "volpiano",
     )
-    return [build_cid_dictionary(chant) for chant in chants_values]
+    return [build_chant_dictionary(chant) for chant in chants_values]
 
 
-def build_cid_dictionary(chant: dict) -> dict:
+def build_chant_dictionary(chant: dict) -> dict:
     DOMAIN: str = "https://cantusdatabase.org"
     source_id: str = chant["source_id"]
     chant_id: str = chant["id"]

--- a/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
+++ b/django/cantusdb_project/main_app/management/commands/save_concordances_to_file.py
@@ -57,7 +57,7 @@ def get_concordance_info_for_all_cantus_ids() -> dict:
     cantus_id_count = len(cantus_ids)
     stdout.write(
         f"  save_concordances_to_file: Computing concordances "
-        f"information for {cantus_id_count} Cantus IDs\n"
+        f"information for {cantus_id_count} Cantus IDs.\n"
     )
     dictionary: dict = {
         cantus_id: get_concordance_info_for_cantus_id(cantus_id)

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         CACHE_DIR: str = "api_cache"
         FILEPATH: str = "api_cache/concordances.json"
         start_time: str = datetime.now().isoformat()
-        stdout.write("Running save_concordances_to_file " f"at {start_time}.\n")
+        stdout.write("Running update_cached_concordances " f"at {start_time}.\n")
         concordances: dict = get_concordances()
         write_time: str = datetime.now().isoformat()
         metadata: dict = {

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -11,7 +11,7 @@ from main_app.models import Chant
 class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
         CACHE_DIR: str = "api_cache"
-        FILEPATH: str = "api_cache/concordances.json"
+        FILEPATH: str = f"{CACHE_DIR}/concordances.json"
         start_time: str = datetime.now().isoformat()
         stdout.write(f"Running update_cached_concordances at {start_time}.\n")
         concordances: dict = get_concordances()

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         CACHE_DIR: str = "api_cache"
         FILEPATH: str = "api_cache/concordances.json"
         start_time: str = datetime.now().isoformat()
-        stdout.write("Running update_cached_concordances " f"at {start_time}.\n")
+        stdout.write(f"Running update_cached_concordances at {start_time}.\n")
         concordances: dict = get_concordances()
         write_time: str = datetime.now().isoformat()
         metadata: dict = {

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -23,13 +23,13 @@ class Command(BaseCommand):
             "data": concordances,
             "metadata": metadata,
         }
-        stdout.write("Attempting to make directory " f"at {CACHE_DIR} to hold cache: ")
+        stdout.write(f"Attempting to make directory at {CACHE_DIR} to hold cache: ")
         try:
             os.mkdir(CACHE_DIR)
             stdout.write(f"successfully created directory at {CACHE_DIR}.\n")
         except FileExistsError:
             stdout.write(f"directory at {CACHE_DIR} already exists.\n")
-        stdout.write(f"Writing concordances to {FILEPATH} " f"at {write_time}.\n")
+        stdout.write(f"Writing concordances to {FILEPATH} at {write_time}.\n")
         with open(FILEPATH, "w") as json_file:
             json.dump(data_and_metadata, json_file)
         end_time = datetime.now().isoformat()

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -1,4 +1,4 @@
-import json
+import ujson
 import os
 from sys import stdout
 from datetime import datetime
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             stdout.write(f"directory at {CACHE_DIR} already exists.\n")
         stdout.write(f"Writing concordances to {FILEPATH} at {write_time}.\n")
         with open(FILEPATH, "w") as json_file:
-            json.dump(data_and_metadata, json_file)
+            ujson.dump(data_and_metadata, json_file)
         end_time = datetime.now().isoformat()
         stdout.write(
             f"Concordances successfully written to {FILEPATH} at {end_time}.\n\n"

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -32,7 +32,10 @@ class Command(BaseCommand):
         stdout.write(f"Writing concordances to {FILEPATH} " f"at {write_time}.\n")
         with open(FILEPATH, "w") as json_file:
             json.dump(data_and_metadata, json_file)
-        stdout.write(f"Concordances successfully written to {FILEPATH}.\n\n")
+        end_time = datetime.now().isoformat()
+        stdout.write(
+            f"Concordances successfully written to {FILEPATH} at {end_time}.\n\n"
+        )
 
 
 def get_concordances() -> dict:
@@ -69,7 +72,7 @@ def get_concordances() -> dict:
         source_id: int = chant["source_id"]
         source_absolute_url: str = f"{DOMAIN}/source/{source_id}/"
         chant_id: int = chant["id"]
-        chant_absolute_url: str = f"{DOMAIN}/source/{chant_id}/"
+        chant_absolute_url: str = f"{DOMAIN}/chant/{chant_id}/"
 
         concordances[chant["cantus_id"]].append(
             {

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -1,8 +1,18 @@
 from django.test import TestCase
+from typing import Union
 from latin_syllabification import (
     clean_transcript,
     syllabify_word,
 )
+from main_app.models import (
+    Chant,
+    Source,
+)
+from main_app.tests.make_fakes import (
+    make_fake_chant,
+    make_fake_source,
+)
+from main_app.management.commands import update_cached_concordances
 
 # run with `python -Wa manage.py test main_app.tests.test_functions`
 # the -Wa flag tells Python to display deprecation warnings
@@ -188,3 +198,122 @@ class LatinSyllabificationTest(TestCase):
 
     def test_syllabify_text(self):
         pass
+
+
+class UpdateCachedConcordancesCommandTest(TestCase):
+    def test_concordances_structure(self):
+        chant: Chant = make_fake_chant(cantus_id="123456")
+        concordances: dict = update_cached_concordances.get_concordances()
+
+        with self.subTest(test="Ensure get_concordances returns dict"):
+            self.assertIsInstance(concordances, dict)
+
+        concordances_for_single_cantus_id: list = concordances["123456"]
+        with self.subTest(test="Ensure values are lists"):
+            self.assertIsInstance(concordances_for_single_cantus_id, list)
+
+        single_concordance = concordances_for_single_cantus_id[0]
+        with self.subTest(test="Ensure each concordance is a dict"):
+            single_concordance: dict = concordances_for_single_cantus_id[0]
+            self.assertIsInstance(single_concordance, dict)
+
+        expected_keys = (
+            "siglum",
+            "srclink",
+            "chantlink",
+            "folio",
+            "sequence",
+            "incipit",
+            "feast",
+            "genre",
+            "office",
+            "position",
+            "cantus_id",
+            "image",
+            "mode",
+            "full_text",
+            "melody",
+            "db",
+        )
+        concordance_keys = single_concordance.keys()
+        for key in expected_keys:
+            with self.subTest(key=key):
+                self.assertIn(key, concordance_keys)
+        with self.subTest(test="Ensure no unexpected keys present"):
+            self.assertEqual(len(concordance_keys), len(expected_keys))
+
+    def test_number_of_concordances_returned(self):
+        cantus_ids: tuple[tuple[str, int]] = (
+            ("000002", 2),
+            ("000003", 3),
+            ("000005", 5),
+            ("000007", 7),
+            ("000011", 11),
+        )
+        for cantus_id, n in cantus_ids:
+            for _ in range(n):
+                make_fake_chant(cantus_id=cantus_id)
+
+        concordances: dict = update_cached_concordances.get_concordances()
+        with self.subTest(test="Test all Cantus IDs present"):
+            self.assertEqual(len(concordances), len(cantus_ids))
+
+        for cantus_id, n in cantus_ids:
+            concordances_for_id: list = concordances[cantus_id]
+            with self.subTest(n=n):
+                self.assertEqual(len(concordances_for_id), n)
+
+    def test_published_vs_unpublished(self):
+        published_source: Source = make_fake_source(published=True)
+        published_chant: Chant = make_fake_chant(
+            source=published_source,
+            cantus_id="123456",
+            incipit="chant in a published source",
+        )
+        unpublished_source: Source = make_fake_source(published=False)
+        unpublished_chant: Chant = make_fake_chant(
+            source=unpublished_source,
+            cantus_id="123456",
+            incipit="chant in an unpublished source",
+        )
+
+        concordances: dict = update_cached_concordances.get_concordances()
+        concordances_for_single_id: list = concordances["123456"]
+        self.assertEqual(len(concordances), 1)
+
+        single_concordance: dict = concordances_for_single_id[0]
+        expected_incipit: str = published_chant.incipit
+        observed_incipit: str = single_concordance["incipit"]
+        self.assertEqual(expected_incipit, observed_incipit)
+
+    def test_concordances_values(self):
+        chant: Chant = make_fake_chant()
+        cantus_id: str = chant.cantus_id
+
+        concordances: dict = update_cached_concordances.get_concordances()
+        concordances_for_single_id: list = concordances[cantus_id]
+        single_concordance: dict = concordances_for_single_id[0]
+
+        expected_items: tuple = (
+            ("siglum", chant.source.siglum),
+            ("srclink", f"https://cantusdatabase.org/source/{chant.source.id}/"),
+            ("chantlink", f"https://cantusdatabase.org/chant/{chant.id}/"),
+            ("folio", chant.folio),
+            ("sequence", chant.c_sequence),
+            ("incipit", chant.incipit),
+            ("feast", chant.feast.name),
+            ("genre", chant.genre.name),
+            ("office", chant.office.name),
+            ("position", chant.position),
+            ("cantus_id", chant.cantus_id),
+            ("image", chant.image_link),
+            ("mode", chant.mode),
+            ("full_text", chant.manuscript_full_text_std_spelling),
+            ("melody", chant.volpiano),
+            ("db", "CD"),
+        )
+
+        for key, value in expected_items:
+            observed_value: Union[str, int, None] = single_concordance[key]
+            with self.subTest(key=key):
+                self.assertEqual(observed_value, value)

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -38,5 +38,6 @@ text-unidecode==1.3
 toml==0.10.1
 typed-ast==1.4.1
 typing-extensions==3.10.0.0
+ujson==5.9.0
 urllib3==1.26.18
 wrapt==1.12.1


### PR DESCRIPTION
This PR adds a new management command, `save_concordances_to_file`, working towards implementing #1209.

The command compiles a list of all the unique Cantus IDs in the database, then for each ID, it returns an array of JSON objects, each representing a chant matching that ID. All published chants in the database should thus be returned, grouped by Cantus ID.

I chose to put the list of Cantus IDs with their chants in a nested JSON object at `["data"]`, and I included the date the file was last updated in another nested object at `["metadata"]`. Open to suggestions as to where/whether to include the date last updated, and also to additional metadata that could be useful to developers.

I didn't take the time to transplant the logic into a view so I could profile it with DDT, but the command runs to completion in about 1.5 minutes on my local machine - every time I ran it, it took about 75s to compute the concordances, and about 20s to write the results to file. I'm hoping that, by using `.prefetch_related()` and `.values()`, I've avoided any unnecessary database queries (one query to establish the list of Cantus IDs, and one query per Cantus ID); everything should already be a `dict` by the time it reaches `[build_cid_dictionary(chant) for chant in chants_values]`. I'm open, of course, to suggestions as to how to further optimize this.

Here's a substantially-trimmed example of the file created at `cantusdb_project/api_cache/all_concordances.json`:
```
{
    "data": {
        ...
        "006014c": [
            ...
            {
                "siglum": "F-R 248",
                "srclink": "https://cantusdatabase.org/source/123662/",
                "chantlink": "https://cantusdatabase.org/chant/442642/",
                "folio": "079v",
                "sequence": 1,
                "incipit": "Jussu Herodis amputatum est",
                "feast": "Decoll. Jo. Bapt.",
                "genre": "V",
                "office": "M",
                "position": "01",
                "cantus_id": "006014c",
                "image": null,
                "mode": "1",
                "full_text": null,
                "melody": null,
                "db": "CD"
            },
            {
                "siglum": "F-Pn Lat. 12044",
                "srclink": "https://cantusdatabase.org/source/123628/",
                "chantlink": "https://cantusdatabase.org/chant/402573/",
                "folio": "180r",
                "sequence": 10,
                "incipit": "Jussu Herodis amputatum est caput ",
                "feast": "Decoll. Jo. Bapt.",
                "genre": "V",
                "office": "M",
                "position": "01",
                "cantus_id": "006014c",
                "image": "http://gallica.bnf.fr/ark:/12148/btv1b6000531z/f363.image",
                "mode": "1",
                "full_text": "Jussu Herodis amputatum est caput Joannis in carcere quo audito discipuli ejus",
                "melody": "1---h--hghg-gf---g--gh--g---g--g--gh--g---g---g--g---g--hF--gh---gH---h7--hijh--h---gf---gh--hj--h---h--hghg--gf--fgh---hgfe-gh--gf---3---d--fgh--g---3",
                "db": "CD"
            },
            ...
        ],
        ...
    },
    "metadata": {
        "last_updated": "2024-01-23T19:03:09.528799"
    }
}
```

And STDOUT looks something like this:
```
root@acb3b5443859:/code/django/cantusdb_project# python manage.py save_concordances_to_file
Running save_concordances_to_file at 2024-01-23T19:59:50.398818.
  save_concordances_to_file: Computing concordances information for 30589 Cantus IDs
  save_concordances_to_file: attempting to make directory at api_cache to hold cache: successfully created directory at api_cache.
  save_concordances_to_file: Writing concordances information to api_cache/all_concordances.json at 2024-01-23T20:00:42.436162.
save_concordances_to_file: Concordances successfully written to api_cache/all_concordances.json.
```

Things that remain to be done toward resolving #1209 after this PR is reviewed and merged:
- [x] Configure Nginx to find and serve the file at `cantusdb_project/api_cache/all_concordances.json` (completed with #1280)
- [x] Add a new cron job to run `save_concordances_to_file` periodically (completed with #1280)
- [x] Add documentation to https://github.com/DDMAL/CantusDB/wiki/APIs