### PR TITLE
Clean up test_views.py

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3282,22 +3282,6 @@ class SourceEditChantsViewTest(TestCase):
         chant.refresh_from_db()
         self.assertIs(chant.manuscript_full_text_std_proofread, True)
 
-    def test_chant_with_volpiano_with_no_incipit(self):
-        # in the past, a Chant Proofread page will error rather than loading properly when the chant has volpiano but no fulltext/incipit
-        source = make_fake_source()
-        chant = make_fake_chant(
-            source=source,
-            volpiano="1---m---l---k---m---h",
-        )
-        chant.manuscript_full_text = None
-        chant.manuscript_full_text_std_spelling = None
-        chant.incipit = None
-        chant.save()
-        response = self.client.get(
-            reverse("source-edit-chants", args=[source.id]), {"pk": chant.id}
-        )
-        self.assertEqual(response.status_code, 200)
-
 
 class ChantEditSyllabificationViewTest(TestCase):
     @classmethod

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5584,9 +5584,13 @@ class AjaxSearchBarTest(TestCase):
         self.assertEqual(asterisk_chant["id"], chant_with_asterisk.id)
 
     def test_cantus_id_search(self):
-        chant_with_normal_cantus_id = make_fake_chant(cantus_id="012345")
+        chant_with_normal_cantus_id = make_fake_chant(
+            cantus_id="012345",
+            incipit="This incipit contains no numerals",
+        )
         chant_with_numerals_in_incipit = make_fake_chant(
-            incipit="0 me! 0 my! This is unexpected!"
+            cantus_id="123456",
+            incipit="0 me! 0 my! This is unexpected!",
         )
 
         # for search terms that contain numerals, we should only return
@@ -5604,7 +5608,7 @@ class AjaxSearchBarTest(TestCase):
         self.assertNotEqual(matching_id, chant_with_numerals_in_incipit.id)
 
         # we should only return istartswith results, and not icontains results
-        non_matching_search_term = "1"
+        non_matching_search_term = "2"
         non_matching_response = self.client.get(
             reverse("ajax-search-bar", args=[non_matching_search_term])
         )


### PR DESCRIPTION
This PR makes two improvements to our `test_views` test suite:
- We had two similar `test_chant_with_volpiano_with_no_incipit`s defined within `ChantDetailViewTest`. The second of these has been removed
- `AjaxSearchBarTest.test_cantus_id_search` has been refactored to be deterministic (we had been creating two chants, and only the first had a `cantus_id` specified. When the other chant's `cantus_id` began with a `1` (P=0.1), the test would fail. Now, both chants' Cantus IDs are specified). This fixes #1244.