### PR TITLE
Configure nginx to serve cached concordances

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -1,37 +1,6 @@
 server {
+
     listen 80;
-
-    server_tokens off;
-
-    location ^~ /.well-known/acme-challenge/ {
-        root /var/www/lego;
-    }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    # Redirect all https traffic for mass.cantusdatabase.org to cantusdatabase.org
-    listen 443 ssl;
-
-    server_name mass.cantusdatabase.org;
-
-    ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
-    ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
-
-    location / {
-        return 301 https://cantusdatabase.org$request_uri;
-    }
-}
-
-server {
-
-    listen 443 default_server http2 ssl;
-	
-    ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
-    ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
 
     location / {
         proxy_pass http://django:8000;
@@ -49,6 +18,7 @@ server {
 
     location /concordances {
         alias /resources/api_cache/concordances.json;
+        expires 6h;
     }
  
     location = /style.css {

--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -49,7 +49,7 @@ server {
 
     location /concordances {
         alias /resources/api_cache/concordances.json;
-        expires 6h;
+        expires modified +24h;
     }
  
     location = /style.css {

--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -46,7 +46,11 @@ server {
     location /media {
         alias /resources/media/;
     }
-    
+
+    location /concordances {
+        alias /resources/api_cache/concordances.json;
+    }
+ 
     location = /style.css {
         root /;
     }

--- a/config/nginx/conf.d/cantusdb.conf
+++ b/config/nginx/conf.d/cantusdb.conf
@@ -1,6 +1,37 @@
 server {
-
     listen 80;
+
+    server_tokens off;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/lego;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    # Redirect all https traffic for mass.cantusdatabase.org to cantusdatabase.org
+    listen 443 ssl;
+
+    server_name mass.cantusdatabase.org;
+
+    ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
+    ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
+
+    location / {
+        return 301 https://cantusdatabase.org$request_uri;
+    }
+}
+
+server {
+
+    listen 443 default_server http2 ssl;
+	
+    ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
+    ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
 
     location / {
         proxy_pass http://django:8000;

--- a/cron/cron.txt
+++ b/cron/cron.txt
@@ -6,5 +6,6 @@
 
 # min   hour    day     month   weekday command
 0       4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/postgres/db_backup.sh
+10      4       *       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh update_cached_concordances
 40      4       1       *       *       bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_next_chant_fields; bash /home/ubuntu/code/CantusDB/cron/management/manage.sh populate_is_last_chant_in_feast
 50      4       *       *       7       /usr/local/bin/docker-compose -f /home/ubuntu/code/CantusDB/docker-compose.yml exec -T nginx lego --path /etc/nginx/ssl/live -d cantusdatabase.org -d www.cantusdatabase.org -d mass.cantusdatabase.org -m updateme@example.com --http --http.webroot /var/www/lego/ renew --days 45 --renew-hook "nginx -s reload" 

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -10,7 +10,7 @@ from main_app.models import Chant
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
-        CACHE_DIR: str = "api_cache"
+        CACHE_DIR: str = "/resources/api_cache"
         FILEPATH: str = f"{CACHE_DIR}/concordances.json"
         start_time: str = datetime.now().isoformat()
         stdout.write(f"Running update_cached_concordances at {start_time}.\n")

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -1,6 +1,7 @@
 import ujson
 import os
 from sys import stdout
+from typing import Optional
 from datetime import datetime
 from collections import defaultdict
 from django.db.models.query import QuerySet
@@ -9,9 +10,20 @@ from main_app.models import Chant
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-d",
+            "--directory",
+            help="Optional filepath specifying a directory to output concordances",
+            type=str,
+        )
+
     def handle(self, *args, **kwargs) -> None:
-        CACHE_DIR: str = "/resources/api_cache"
-        FILEPATH: str = f"{CACHE_DIR}/concordances.json"
+        cache_dir: Optional[str] = kwargs["directory"]
+        if not cache_dir:
+            cache_dir = "/resources/api_cache"
+
+        filepath: str = f"{cache_dir}/concordances.json"
         start_time: str = datetime.now().isoformat()
         stdout.write(f"Running update_cached_concordances at {start_time}.\n")
         concordances: dict = get_concordances()
@@ -23,18 +35,18 @@ class Command(BaseCommand):
             "data": concordances,
             "metadata": metadata,
         }
-        stdout.write(f"Attempting to make directory at {CACHE_DIR} to hold cache: ")
+        stdout.write(f"Attempting to make directory at {cache_dir} to hold cache: ")
         try:
-            os.mkdir(CACHE_DIR)
-            stdout.write(f"successfully created directory at {CACHE_DIR}.\n")
+            os.mkdir(cache_dir)
+            stdout.write(f"successfully created directory at {cache_dir}.\n")
         except FileExistsError:
-            stdout.write(f"directory at {CACHE_DIR} already exists.\n")
-        stdout.write(f"Writing concordances to {FILEPATH} at {write_time}.\n")
-        with open(FILEPATH, "w") as json_file:
+            stdout.write(f"directory at {cache_dir} already exists.\n")
+        stdout.write(f"Writing concordances to {filepath} at {write_time}.\n")
+        with open(filepath, "w") as json_file:
             ujson.dump(data_and_metadata, json_file)
         end_time = datetime.now().isoformat()
         stdout.write(
-            f"Concordances successfully written to {FILEPATH} at {end_time}.\n\n"
+            f"Concordances successfully written to {filepath} at {end_time}.\n\n"
         )
 
 

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -9,6 +9,10 @@ from django.core.management.base import BaseCommand
 from main_app.models import Chant
 
 
+# Usage: `python manage.py update_cached_concordances`
+# or `python manage.py update_cached_concordances -d "/path/to/directory/in/which/to/save/concordances"`
+
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
@@ -21,6 +25,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
         cache_dir: Optional[str] = kwargs["directory"]
         if not cache_dir:
+            # this default directory should match the value in docker-compose.yml,
+            # at services:django:volumes:api_cache_volume
             cache_dir = "/resources/api_cache"
 
         filepath: str = f"{cache_dir}/concordances.json"
@@ -51,6 +57,13 @@ class Command(BaseCommand):
 
 
 def get_concordances() -> dict:
+    """Fetch all published chants in the database, group them by Cantus ID, and return
+    a dictionary containing information on each of these chants.
+
+    Returns:
+        dict: A dictionary where each key is a Cantus ID and each value is a list all
+          published chants in the database with that Cantus ID.
+    """
     DOMAIN: str = "https://cantusdatabase.org"
 
     stdout.write("Querying database for published chants\n")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./:/code/
       - static_volume:/resources/static
       - media_volume:/resources/media
+      - api_cache_volume:/resources/api_cache
     env_file: ./config/envs/dev_env
     ports:
       - 3000:3000
@@ -25,6 +26,7 @@ services:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
       - media_volume:/resources/media
+      - api_cache_volume:/resources/api_cache
       - ./certificates:/etc/nginx/ssl/live
     restart: always
     depends_on:
@@ -42,3 +44,4 @@ volumes:
   postgres_data:
   static_volume:
   media_volume:
+  api_cache_volume:


### PR DESCRIPTION
This PR updates our nginx configuration to serve cached concordances created by our `update_cached_concordances` command. It fixes #1209. 

- A new docker volume, `api_cache`, has been created. `update_cached_concordances` now writes its output to this volume, and the nginx container has access to this volume too, in order to be able to serve the concordances
- nginx has been configured to return the cached concordances when it receives a request at `/concordances`
- `cron.txt` has been updated to run `update_cached_concordances` once per day

The cron changes haven't been tested - we can do this once these changes have made their way to the staging server.

After making the last commit implicated in this PR, I
- followed the steps in https://github.com/DDMAL/CantusDB/wiki/Getting-Started-with-Development, and rebuilt and restarted the docker containers
- navigated to localhost/concordances in my browser, and successfully downloaded a bunch of concordances in .json format that had been created yesterday
- ran `python manage.py update_cached_concordances`
- navigated to localhost/concordances again, downloaded a new batch of concordances, and saw that the timestamp had been updated
- in short, this is behaving exactly as expected and as hoped-for!