### PR TITLE
Change how postgres finds postgres.conf, which contains modified configurations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     restart: always
-    command: -c 'config_file=/etc/postgresql/postgresql.conf'
+    command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     restart: always
+    command: -c 'config_file=/etc/postgresql/postgresql.conf'
 
 volumes:
   postgres_data:

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
 FROM postgres:14-alpine
-COPY postgresql.conf /var/lib/postgresql/data/postgresql.conf
+COPY postgresql.conf /etc/postgresql/postgresql.conf
 COPY postgres_backup.sh /usr/local/bin/postgres_backup.sh
 RUN chmod +x /usr/local/bin/postgres_backup.sh


### PR DESCRIPTION
Previously, the postgres configuration file was added to the /var/lib/postgresql/data directory which was overwritten by the already-existing named data volume (`postgres_data`), causing the modified configurations not to be picked up. When initializing a database, the placement of the configuration file in /var/lib/postgresql/data caused an error that the "PGDATA was not empty."

This commit fixes this issue by placing the configuration file in a different location (/etc/postgresql) and then running the Dockerfile entrypoint with the path to the config file.

Closes #1283 