### PR TITLE
Add postgres command with path to config file to docker-compose staging

### DIFF
--- a/docker-compose.yml.development
+++ b/docker-compose.yml.development
@@ -43,6 +43,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     restart: always
+    command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
 
 volumes:
   postgres_data:

--- a/docker-compose.yml.staging
+++ b/docker-compose.yml.staging
@@ -37,6 +37,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     restart: always
+    command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Simultaneous work on #1286 and #1293 meant the staging and production versions of `docker-compose.yml` had different commands. This fixes the command in the staging version with an argument pointing to the location of the `postgres.conf` file in the `postgres` container. 