### PR TITLE
Change `user_can_edit_sequences` permissions

### DIFF
--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -36,7 +36,7 @@ class SequenceDetailView(DetailView):
             .select_related("source")
             .order_by("siglum")
         )
-        context["user_can_edit_sequence"] = user_can_edit_sequences(user)
+        context["user_can_edit_sequence"] = user_can_edit_sequences(user, sequence)
         return context
 
 
@@ -86,4 +86,5 @@ class SequenceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
     def test_func(self):
         user = self.request.user
-        return user_can_edit_sequences(user)
+        sequence = self.get_object()
+        return user_can_edit_sequences(user, sequence)


### PR DESCRIPTION
This PR modifies `permissions.py` so that an editor or contributor who is assigned to a source in the bower segment may edit sequences in that source. Previously, only project managers had this permission.

`user_can_edit_sequences` was modified to mirror the functionality of `user_can_edit_chants_in_source`, which has the same permissions that are needed. 

Resolves #1294 