### PR TITLE
Specify server names in nginx configuration

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf.production
+++ b/config/nginx/conf.d/cantusdb.conf.production
@@ -1,5 +1,8 @@
 server {
+    # Redirect all http traffic to corresponding https page
     listen 80;
+
+    server_name cantusdatabase.org www.cantusdatabase.org mass.cantusdatabase.org;
 
     server_tokens off;
 
@@ -27,8 +30,9 @@ server {
 }
 
 server {
-
     listen 443 default_server http2 ssl;
+
+    server_name cantusdatabase.org www.cantusdatabase.org;
 	
     ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;

--- a/config/nginx/conf.d/cantusdb.conf.production
+++ b/config/nginx/conf.d/cantusdb.conf.production
@@ -16,10 +16,11 @@ server {
 }
 
 server {
-    # Redirect all https traffic for mass.cantusdatabase.org to cantusdatabase.org
+    # Redirect all https traffic for www.cantusdatabase.org and mass.cantusdatabase.org
+    # to cantusdatabase.org
     listen 443 ssl;
 
-    server_name mass.cantusdatabase.org;
+    server_name www.cantusdatabase.org mass.cantusdatabase.org;
 
     ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
@@ -32,7 +33,7 @@ server {
 server {
     listen 443 default_server http2 ssl;
 
-    server_name cantusdatabase.org www.cantusdatabase.org;
+    server_name cantusdatabase.org;
 	
     ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;

--- a/config/nginx/conf.d/cantusdb.conf.staging
+++ b/config/nginx/conf.d/cantusdb.conf.staging
@@ -1,5 +1,8 @@
 server {
+    # redirect all http traffic to corresponding https page
     listen 80;
+
+    server_name staging.cantusdatabase.org staging-alias.cantusdatabase.org;
 
     server_tokens off;
 
@@ -32,8 +35,9 @@ server {
 }
 
 server {
-
     listen 443 default_server http2 ssl;
+
+    server_name staging.cantusdatabase.org;
 	
     # ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
     # ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;


### PR DESCRIPTION
This PR specifies all server names in our staging and production nginx configurations. It fixes #1289.

This is a change I can't really test locally, and different changes have been applied to the production configuration than to the staging configuration, so some real scrutiny of these changes (especially to `cantusdb.conf.production`) would be appreciated.