### PR TITLE
Optimize SourceInventoryView queries

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1047,40 +1047,6 @@ class ChantDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
         return reverse("source-edit-chants", args=[self.object.source.id])
 
 
-class ChantInventoryView(TemplateView):
-    template_name = "full_inventory.html"
-    pk_url_kwarg = "source_id"
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        source_id = self.kwargs.get(self.pk_url_kwarg)
-        source = get_object_or_404(Source, id=source_id)
-
-        display_unpublished = self.request.user.is_authenticated
-        if (not display_unpublished) and (source.published == False):
-            raise PermissionDenied
-
-        # 4064 is the id for the sequence database
-        if source.segment.id == 4064:
-            queryset = (
-                source.sequence_set.annotate(record_type=Value("sequence"))
-                .order_by("s_sequence")
-                .select_related("genre")
-            )
-        else:
-            queryset = (
-                source.chant_set.annotate(record_type=Value("chant"))
-                .order_by("folio", "c_sequence")
-                .select_related("feast", "office", "genre", "diff_db")
-            )
-
-        context["source"] = source
-        context["chants"] = queryset
-
-        return context
-
-
 class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     template_name = "chant_edit.html"
     model = Chant

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -328,7 +328,7 @@ class SourceInventoryView(TemplateView):
             queryset = (
                 source.chant_set.annotate(record_type=Value("chant"))
                 .order_by("folio", "c_sequence")
-                .select_related("feast", "office", "genre")
+                .select_related("feast", "office", "genre", "diff_db")
             )
 
         context["source"] = source


### PR DESCRIPTION
This PR does two things:
- Deletes `ChantInventoryView`, which has been superseded by `SourceInventoryView`
- Applies the `select_related` optimization in our SourceInventoryView that @ahankinson applied in https://github.com/DDMAL/CantusDB/pull/1247

As far as I can tell, the renaming of ChantIndexView -> SourceInventoryView was going on for a period of time. While it was in progress, @ahankinson applied an optimization to the ChantIndexView, whereas the old code had already been copied into the new SourceInventoryView. Once the paths/views in `urls.py` were updated, we switched back to using unoptimized code.

It took me a while to figure out why changes I was making to `ChantInventoryView` were not having any effect on our SQL queries whenever I visited `/source/123627/inventory/` - it will be a good thing to have the old view deleted, to prevent others from going through similar confusion.

I ran `test_views`, and all comprising tests pass.

This PR should properly resolve #1238.