### PR TITLE
Create hook in signals.py to automatically update chants' and sequences' incipits

### DIFF
--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -21,6 +21,8 @@ EXCLUDE = ("json_info",)
 READ_ONLY = (
     "created_by",
     "last_updated_by",
+    "date_created",
+    "date_updated",
 )
 
 
@@ -61,11 +63,7 @@ class ChantAdmin(BaseModelAdmin):
         "id",
     )
 
-    readonly_fields = READ_ONLY + (
-        "date_created",
-        "date_updated",
-        "incipit",
-    )
+    readonly_fields = READ_ONLY + ("incipit",)
 
     list_filter = (
         "genre",

--- a/django/cantusdb_project/main_app/admin.py
+++ b/django/cantusdb_project/main_app/admin.py
@@ -64,6 +64,7 @@ class ChantAdmin(BaseModelAdmin):
     readonly_fields = READ_ONLY + (
         "date_created",
         "date_updated",
+        "incipit",
     )
 
     list_filter = (
@@ -170,6 +171,7 @@ class SequenceAdmin(BaseModelAdmin):
         "source",
         "feast",
     )
+    readonly_fields = READ_ONLY + ("incipit",)
     ordering = ("source__siglum",)
     form = AdminSequenceForm
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -121,7 +121,7 @@ def update_volpiano_fields(instance) -> None:
     )
 
 
-def generate_volpiano_notes(volpiano) -> None:
+def generate_volpiano_notes(volpiano) -> str:
     """
     Populate the ``volpiano_notes`` field of the ``Chant`` model
 
@@ -136,7 +136,7 @@ def generate_volpiano_notes(volpiano) -> None:
     # unwanted_chars are non-note chars, including the clefs, barlines, and accidentals etc.
     # the `searchMelody.js` on old cantus makes no reference to the b-flat accidentals ("y", "i", "z")
     # so put them in unwanted chars for now
-    unwanted_chars = [
+    unwanted_chars: list[str] = [
         "-",
         "1",
         "2",
@@ -153,9 +153,9 @@ def generate_volpiano_notes(volpiano) -> None:
         "z",
     ]
     # convert all charactors to lower-case, upper-case letters stand for liquescent of the same pitch
-    volpiano_lower = volpiano.lower()
+    volpiano_lower: str = volpiano.lower()
     # `)` stands for the lowest `g` note liquescent in volpiano, its 'lower case' is `9`
-    volpiano_notes = volpiano_lower.replace(")", "9")
+    volpiano_notes: str = volpiano_lower.replace(")", "9")
     # remove none-note charactors
     for unwanted_char in unwanted_chars:
         volpiano_notes = volpiano_notes.replace(unwanted_char, "")

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -164,7 +164,7 @@ def generate_volpiano_notes(volpiano) -> str:
     return volpiano_notes
 
 
-def generate_volpiano_intervals(volpiano_notes) -> None:
+def generate_volpiano_intervals(volpiano_notes) -> str:
     """
     Populate the ``volpiano_intervals`` field of the ``Chant`` model
 
@@ -178,24 +178,23 @@ def generate_volpiano_intervals(volpiano_notes) -> None:
         str: A str of digits, recording the intervals between adjacent notes
     """
     # replace '9' (the note G) with the char corresponding to (ASCII(a) - 1), because 'a' denotes the note A
-    volpiano_notes = volpiano_notes.replace("9", chr(ord("a") - 1))
+    volpiano_notes: str = volpiano_notes.replace("9", chr(ord("a") - 1))
     # we model the interval between notes using the difference between the ASCII codes of corresponding letters
     # the letter for the note B is "j" (106), note A is "h" (104), the letter "i" (105) is skipped
     # move all notes above A down by one letter
-    volpiano_notes = list(volpiano_notes)
-    for j, note in enumerate(volpiano_notes):
+    notes_list: list = list(volpiano_notes)
+    for j, note in enumerate(notes_list):
         if ord(note) >= 106:
-            volpiano_notes[j] = chr(ord(note) - 1)
+            notes_list[j] = chr(ord(note) - 1)
 
     # `intervals` records the difference between two adjacent notes.
     # Note that intervals are encoded by counting the number of scale
     # steps between adjacent notes: an ascending second is thus encoded
     # as "1"; a descending third is encoded "-2", and so on.
-    intervals = []
+    intervals: list[int] = []
     for j in range(1, len(volpiano_notes)):
         intervals.append(ord(volpiano_notes[j]) - ord(volpiano_notes[j - 1]))
-    # convert `intervals` to str
-    volpiano_intervals = "".join([str(interval) for interval in intervals])
+    volpiano_intervals: str = "".join([str(interval) for interval in intervals])
     return volpiano_intervals
 
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -18,7 +18,7 @@ from main_app.models import Source
 
 
 @receiver(post_save, sender=Chant)
-def on_chant_save(instance, **kwargs):
+def on_chant_save(instance, **kwargs) -> None:
     update_source_chant_count(instance)
     update_source_melody_count(instance)
 
@@ -28,28 +28,28 @@ def on_chant_save(instance, **kwargs):
 
 
 @receiver(post_delete, sender=Chant)
-def on_chant_delete(instance, **kwargs):
+def on_chant_delete(instance, **kwargs) -> None:
     update_source_chant_count(instance)
     update_source_melody_count(instance)
 
 
 @receiver(post_save, sender=Sequence)
-def on_sequence_save(instance, **kwargs):
+def on_sequence_save(instance, **kwargs) -> None:
     update_source_chant_count(instance)
     update_sequence_incipit_field(instance)
 
 
 @receiver(post_delete, sender=Sequence)
-def on_sequence_delete(instance, **kwargs):
+def on_sequence_delete(instance, **kwargs) -> None:
     update_source_chant_count(instance)
 
 
 @receiver(post_save, sender=Feast)
-def on_feast_save(instance, **kwargs):
+def on_feast_save(instance, **kwargs) -> None:
     update_prefix_field(instance)
 
 
-def update_chant_search_vector(instance):
+def update_chant_search_vector(instance) -> None:
     """When saving an instance of Chant, update its search vector field.
 
     Called in on_chant_save()
@@ -67,7 +67,7 @@ def update_chant_search_vector(instance):
     )
 
 
-def update_source_chant_count(instance):
+def update_source_chant_count(instance) -> None:
     """When saving or deleting a Chant or Sequence, update its Source's number_of_chants field
 
     Called in on_chant_save(), on_chant_delete(), on_sequence_save() and on_sequence_delete()
@@ -83,7 +83,7 @@ def update_source_chant_count(instance):
         source.save()
 
 
-def update_source_melody_count(instance):
+def update_source_melody_count(instance) -> None:
     """When saving or deleting a Chant, update its Source's number_of_melodies field
 
     Called in on_chant_save() and on_chant_delete()
@@ -103,13 +103,13 @@ def update_source_melody_count(instance):
         source.save()
 
 
-def update_volpiano_fields(instance):
+def update_volpiano_fields(instance) -> None:
     """When saving a Chant, make sure the chant's volpiano_notes and volpiano_intervals are up-to-date
 
     Called in on_chant_save()
     """
 
-    def generate_volpiano_notes(volpiano):
+    def generate_volpiano_notes(volpiano) -> None:
         """
         Populate the ``volpiano_notes`` field of the ``Chant`` model
 
@@ -151,7 +151,7 @@ def update_volpiano_fields(instance):
         volpiano_notes = re.sub(r"(.)\1+", r"\1", volpiano_notes)
         return volpiano_notes
 
-    def generate_volpiano_intervals(volpiano_notes):
+    def generate_volpiano_intervals(volpiano_notes) -> None:
         """
         Populate the ``volpiano_intervals`` field of the ``Chant`` model
 
@@ -197,7 +197,7 @@ def update_volpiano_fields(instance):
     )
 
 
-def update_prefix_field(instance):
+def update_prefix_field(instance) -> None:
     pk = instance.pk
 
     if instance.feast_code:
@@ -207,7 +207,7 @@ def update_prefix_field(instance):
         instance.__class__.objects.filter(pk=pk).update(prefix="")
 
 
-def update_chant_incipit_field(chant: Chant):
+def update_chant_incipit_field(chant: Chant) -> None:
     """Update the incipit field of the specified Chant to be the first
     several words of the chant's standardized-spelling fulltext
 
@@ -223,7 +223,7 @@ def update_chant_incipit_field(chant: Chant):
         Chant.objects.filter(id=chant.id).update(incipit=new_incipit)
 
 
-def update_sequence_incipit_field(sequence: Sequence):
+def update_sequence_incipit_field(sequence: Sequence) -> None:
     """Update the incipit field of the specified Sequence to be the first
     several words of the sequence's standardized-spelling fulltext
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -192,8 +192,8 @@ def generate_volpiano_intervals(volpiano_notes) -> str:
     # steps between adjacent notes: an ascending second is thus encoded
     # as "1"; a descending third is encoded "-2", and so on.
     intervals: list[int] = []
-    for j in range(1, len(volpiano_notes)):
-        intervals.append(ord(volpiano_notes[j]) - ord(volpiano_notes[j - 1]))
+    for j in range(1, len(notes_list)):
+        intervals.append(ord(notes_list[j]) - ord(notes_list[j - 1]))
     volpiano_intervals: str = "".join([str(interval) for interval in intervals])
     return volpiano_intervals
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -234,8 +234,9 @@ def update_sequence_incipit_field(sequence: Sequence) -> None:
         field is to be updated
     """
     title: Optional[str] = sequence.title
-    if title:  # As of late Feb 2024, most (all?) sequences in the database have no
-        # fulltext, but every sequence has a title
+    if title:  # As of late Feb 2024, no sequences in the database have
+        # fulltext, but every sequence has a title, and the value stored in
+        # the title field is an incipit.
         incipit: str = title
         Sequence.objects.filter(id=sequence.id).update(incipit=incipit)
 

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -109,82 +109,6 @@ def update_volpiano_fields(instance) -> None:
     Called in on_chant_save()
     """
 
-    def generate_volpiano_notes(volpiano) -> None:
-        """
-        Populate the ``volpiano_notes`` field of the ``Chant`` model
-
-        This field is used for melody search
-
-        Args:
-            volpiano (str): The content of ``chant.volpiano``
-
-        Returns:
-            str: Volpiano str with non-note chars and duplicate consecutive notes removed
-        """
-        # unwanted_chars are non-note chars, including the clefs, barlines, and accidentals etc.
-        # the `searchMelody.js` on old cantus makes no reference to the b-flat accidentals ("y", "i", "z")
-        # so put them in unwanted chars for now
-        unwanted_chars = [
-            "-",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "?",
-            ".",
-            " ",
-            "y",
-            "i",
-            "z",
-        ]
-        # convert all charactors to lower-case, upper-case letters stand for liquescent of the same pitch
-        volpiano_lower = volpiano.lower()
-        # `)` stands for the lowest `g` note liquescent in volpiano, its 'lower case' is `9`
-        volpiano_notes = volpiano_lower.replace(")", "9")
-        # remove none-note charactors
-        for unwanted_char in unwanted_chars:
-            volpiano_notes = volpiano_notes.replace(unwanted_char, "")
-        # remove duplicate consecutive chars
-        volpiano_notes = re.sub(r"(.)\1+", r"\1", volpiano_notes)
-        return volpiano_notes
-
-    def generate_volpiano_intervals(volpiano_notes) -> None:
-        """
-        Populate the ``volpiano_intervals`` field of the ``Chant`` model
-
-        This field is used for melody search when searching for transpositions
-
-        Args:
-            volpiano_notes (str): The content of ``chant.volpiano_notes``,
-            populated by the ``generate_volpiano_notes`` function
-
-        Returns:
-            str: A str of digits, recording the intervals between adjacent notes
-        """
-        # replace '9' (the note G) with the char corresponding to (ASCII(a) - 1), because 'a' denotes the note A
-        volpiano_notes = volpiano_notes.replace("9", chr(ord("a") - 1))
-        # we model the interval between notes using the difference between the ASCII codes of corresponding letters
-        # the letter for the note B is "j" (106), note A is "h" (104), the letter "i" (105) is skipped
-        # move all notes above A down by one letter
-        volpiano_notes = list(volpiano_notes)
-        for j, note in enumerate(volpiano_notes):
-            if ord(note) >= 106:
-                volpiano_notes[j] = chr(ord(note) - 1)
-
-        # `intervals` records the difference between two adjacent notes.
-        # Note that intervals are encoded by counting the number of scale
-        # steps between adjacent notes: an ascending second is thus encoded
-        # as "1"; a descending third is encoded "-2", and so on.
-        intervals = []
-        for j in range(1, len(volpiano_notes)):
-            intervals.append(ord(volpiano_notes[j]) - ord(volpiano_notes[j - 1]))
-        # convert `intervals` to str
-        volpiano_intervals = "".join([str(interval) for interval in intervals])
-        return volpiano_intervals
-
     if instance.volpiano is None:
         return
 
@@ -195,6 +119,84 @@ def update_volpiano_fields(instance) -> None:
         volpiano_notes=volpiano_notes,
         volpiano_intervals=volpiano_intervals,
     )
+
+
+def generate_volpiano_notes(volpiano) -> None:
+    """
+    Populate the ``volpiano_notes`` field of the ``Chant`` model
+
+    This field is used for melody search
+
+    Args:
+        volpiano (str): The content of ``chant.volpiano``
+
+    Returns:
+        str: Volpiano str with non-note chars and duplicate consecutive notes removed
+    """
+    # unwanted_chars are non-note chars, including the clefs, barlines, and accidentals etc.
+    # the `searchMelody.js` on old cantus makes no reference to the b-flat accidentals ("y", "i", "z")
+    # so put them in unwanted chars for now
+    unwanted_chars = [
+        "-",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "?",
+        ".",
+        " ",
+        "y",
+        "i",
+        "z",
+    ]
+    # convert all charactors to lower-case, upper-case letters stand for liquescent of the same pitch
+    volpiano_lower = volpiano.lower()
+    # `)` stands for the lowest `g` note liquescent in volpiano, its 'lower case' is `9`
+    volpiano_notes = volpiano_lower.replace(")", "9")
+    # remove none-note charactors
+    for unwanted_char in unwanted_chars:
+        volpiano_notes = volpiano_notes.replace(unwanted_char, "")
+    # remove duplicate consecutive chars
+    volpiano_notes = re.sub(r"(.)\1+", r"\1", volpiano_notes)
+    return volpiano_notes
+
+
+def generate_volpiano_intervals(volpiano_notes) -> None:
+    """
+    Populate the ``volpiano_intervals`` field of the ``Chant`` model
+
+    This field is used for melody search when searching for transpositions
+
+    Args:
+        volpiano_notes (str): The content of ``chant.volpiano_notes``,
+        populated by the ``generate_volpiano_notes`` function
+
+    Returns:
+        str: A str of digits, recording the intervals between adjacent notes
+    """
+    # replace '9' (the note G) with the char corresponding to (ASCII(a) - 1), because 'a' denotes the note A
+    volpiano_notes = volpiano_notes.replace("9", chr(ord("a") - 1))
+    # we model the interval between notes using the difference between the ASCII codes of corresponding letters
+    # the letter for the note B is "j" (106), note A is "h" (104), the letter "i" (105) is skipped
+    # move all notes above A down by one letter
+    volpiano_notes = list(volpiano_notes)
+    for j, note in enumerate(volpiano_notes):
+        if ord(note) >= 106:
+            volpiano_notes[j] = chr(ord(note) - 1)
+
+    # `intervals` records the difference between two adjacent notes.
+    # Note that intervals are encoded by counting the number of scale
+    # steps between adjacent notes: an ascending second is thus encoded
+    # as "1"; a descending third is encoded "-2", and so on.
+    intervals = []
+    for j in range(1, len(volpiano_notes)):
+        intervals.append(ord(volpiano_notes[j]) - ord(volpiano_notes[j - 1]))
+    # convert `intervals` to str
+    volpiano_intervals = "".join([str(interval) for interval in intervals])
+    return volpiano_intervals
 
 
 def update_prefix_field(instance) -> None:

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -233,23 +233,12 @@ def update_sequence_incipit_field(sequence: Sequence) -> None:
         sequence (Sequence): The sequence from the database whose `incipit`
         field is to be updated
     """
-    fulltext: Optional[str] = ""
-    std_fulltext: Optional[str] = sequence.manuscript_full_text_std_spelling
-    ms_fulltext: Optional[str] = sequence.manuscript_full_text
     title: Optional[str] = sequence.title
     if title:  # most (all?) sequences in the database have no
         # fulltext, so we should expect to have to use the value
         # in the title field most of the time (most sequences have at least a title)
-        fulltext = title
-    if ms_fulltext:  # if there's an MS-spelling fulltext, use it
-        fulltext = ms_fulltext
-    if (
-        std_fulltext
-    ):  # but we should default to the standard-spelling fulltext if available
-        fulltext = std_fulltext
-    if fulltext:
-        new_incipit: str = generate_incipit(fulltext)
-        Sequence.objects.filter(id=sequence.id).update(incipit=new_incipit)
+        incipit: str = title
+        Sequence.objects.filter(id=sequence.id).update(incipit=incipit)
 
 
 def generate_incipit(fulltext: str) -> str:

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -234,11 +234,16 @@ def update_sequence_incipit_field(sequence: Sequence):
     fulltext: Optional[str] = ""
     std_fulltext: Optional[str] = sequence.manuscript_full_text_std_spelling
     ms_fulltext: Optional[str] = sequence.manuscript_full_text
-    if ms_fulltext:  # most (all?) sequences in the database have no
-        # standard-spelling fulltext, so we should expect to have to use the
-        # MS-spelling fulltext most of the time.
+    title: Optional[str] = sequence.title
+    if title:  # most (all?) sequences in the database have no
+        # fulltext, so we should expect to have to use the value
+        # in the title field most of the time (most sequences have at least a title)
+        fulltext = title
+    if ms_fulltext:  # if there's an MS-spelling fulltext, use it
         fulltext = ms_fulltext
-    if std_fulltext:  # but we should use standard-spelling fulltext if available
+    if (
+        std_fulltext
+    ):  # but we should default to the standard-spelling fulltext if available
         fulltext = std_fulltext
     if fulltext:
         new_incipit: str = generate_incipit(fulltext)

--- a/django/cantusdb_project/main_app/signals.py
+++ b/django/cantusdb_project/main_app/signals.py
@@ -234,9 +234,8 @@ def update_sequence_incipit_field(sequence: Sequence) -> None:
         field is to be updated
     """
     title: Optional[str] = sequence.title
-    if title:  # most (all?) sequences in the database have no
-        # fulltext, so we should expect to have to use the value
-        # in the title field most of the time (most sequences have at least a title)
+    if title:  # As of late Feb 2024, most (all?) sequences in the database have no
+        # fulltext, but every sequence has a title
         incipit: str = title
         Sequence.objects.filter(id=sequence.id).update(incipit=incipit)
 

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -313,9 +313,6 @@ def make_fake_sequence(source=None, title=None, cantus_id=None) -> Sequence:
         cantus_id = make_random_string(6, "0123456789")
     sequence = Sequence.objects.create(
         title=title,
-        # most sequences in the database have no standard-spelling fulltext,
-        # but they do have MS-spelling fulltext.
-        manuscript_full_text=faker.sentence(),
         siglum=make_random_string(6),
         # folio in the form of two digits and one letter
         folio=faker.bothify("##?"),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -20,9 +20,6 @@ from typing import Optional, List
 # Max positive integer accepted by Django's positive integer field
 MAX_SEQUENCE_NUMBER = 2147483647
 
-# The incipit will be up to 100 characters of the full text
-INCIPIT_LENGTH = 100
-
 # Create a Faker instance with locale set to Latin
 faker = Faker("la")
 
@@ -146,7 +143,6 @@ def make_fake_chant(
     feast=None,
     mode=None,
     manuscript_full_text_std_spelling=None,
-    incipit=None,
     manuscript_full_text_std_proofread=None,
     manuscript_full_text=None,
     volpiano=None,
@@ -180,8 +176,6 @@ def make_fake_chant(
         mode = make_random_string(1, "0123456789*?")
     if manuscript_full_text_std_spelling is None:
         manuscript_full_text_std_spelling = faker.sentence()
-    if incipit is None:
-        incipit = manuscript_full_text_std_spelling[0:INCIPIT_LENGTH]
     if manuscript_full_text_std_proofread is None:
         manuscript_full_text_std_proofread = False
     if manuscript_full_text is None:
@@ -214,7 +208,6 @@ def make_fake_chant(
         ),  # chant_range is of the form "1-x-y-4", x, y are volpiano notes
         addendum=make_random_string(3, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
         manuscript_full_text_std_spelling=manuscript_full_text_std_spelling,
-        incipit=incipit,
         manuscript_full_text_std_proofread=manuscript_full_text_std_proofread,
         manuscript_full_text=manuscript_full_text,
         manuscript_full_text_proofread=faker.boolean(),
@@ -310,22 +303,17 @@ def make_fake_segment(name: str = None, id: int = None) -> Segment:
     return segment
 
 
-def make_fake_sequence(
-    source=None, title=None, incipit=None, cantus_id=None
-) -> Sequence:
+def make_fake_sequence(source=None, title=None, cantus_id=None) -> Sequence:
     """Generates a fake Sequence object."""
     if source is None:
         source = make_fake_source(segment_name="Bower Sequence Database")
     if title is None:
         title = faker.sentence()
-    if incipit is None:
-        incipit = title[:INCIPIT_LENGTH]
     if cantus_id is None:
         cantus_id = make_random_string(6, "0123456789")
     sequence = Sequence.objects.create(
         title=title,
         siglum=make_random_string(6),
-        incipit=incipit,
         # folio in the form of two digits and one letter
         folio=faker.bothify("##?"),
         s_sequence=make_random_string(2, "0123456789"),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -313,6 +313,9 @@ def make_fake_sequence(source=None, title=None, cantus_id=None) -> Sequence:
         cantus_id = make_random_string(6, "0123456789")
     sequence = Sequence.objects.create(
         title=title,
+        # most sequences in the database have no standard-spelling fulltext,
+        # but they do have MS-spelling fulltext.
+        manuscript_full_text=faker.sentence(),
         siglum=make_random_string(6),
         # folio in the form of two digits and one letter
         folio=faker.bothify("##?"),

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -223,6 +223,9 @@ def make_fake_chant(
         json_info=None,
         next_chant=next_chant,
     )
+    chant.refresh_from_db()  # several fields (e.g., incipit) are calculated automatically
+    # upon chant save. By refreshing from db before returning, we ensure all the chant's fields
+    # are up-to-date. For more information, refer to main_app/signals.py
     return chant
 
 
@@ -329,6 +332,9 @@ def make_fake_sequence(source=None, title=None, cantus_id=None) -> Sequence:
         cantus_id=cantus_id,
         image_link=faker.image_url(),
     )
+    sequence.refresh_from_db()  # several fields (e.g., incipit) are calculated automatically
+    # upon sequence save. By refreshing from db before returning, we ensure all the sequence's fields
+    # are up-to-date. For more information, refer to main_app/signals.py
     return sequence
 
 

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -17,6 +17,8 @@ from django.contrib.auth import get_user_model
 
 from typing import Optional, List
 
+User = get_user_model()
+
 # Max positive integer accepted by Django's positive integer field
 MAX_SEQUENCE_NUMBER = 2147483647
 
@@ -249,9 +251,9 @@ def make_fake_genre(name=None) -> Genre:
     return genre
 
 
-def make_fake_user(is_indexer=True) -> get_user_model():
+def make_fake_user(is_indexer=True) -> User:
     """Generates a fake User object."""
-    user = get_user_model().objects.create(
+    user = User.objects.create(
         full_name=f"{faker.first_name()} {faker.last_name()}",
         institution=faker.company(),
         city=faker.city(),

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -83,13 +83,13 @@ class UpdateCachedConcordancesCommandTest(TestCase):
         published_chant: Chant = make_fake_chant(
             source=published_source,
             cantus_id="123456",
-            incipit="chant in a published source",
+            manuscript_full_text_std_spelling="chant in a published source",
         )
         unpublished_source: Source = make_fake_source(published=False)
         unpublished_chant: Chant = make_fake_chant(
             source=unpublished_source,
             cantus_id="123456",
-            incipit="chant in an unpublished source",
+            manuscript_full_text_std_spelling="chant in an unpublished source",
         )
 
         concordances: dict = update_cached_concordances.get_concordances()
@@ -97,6 +97,9 @@ class UpdateCachedConcordancesCommandTest(TestCase):
         self.assertEqual(len(concordances), 1)
 
         single_concordance: dict = concordances_for_single_id[0]
+        published_chant.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
         expected_incipit: str = published_chant.incipit
         observed_incipit: str = single_concordance["incipit"]
         self.assertEqual(expected_incipit, observed_incipit)

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -9,6 +9,7 @@ from main_app.tests.make_fakes import (
     make_fake_source,
 )
 from main_app.management.commands import update_cached_concordances
+from main_app.signals import generate_incipit
 
 # run with `python -Wa manage.py test main_app.tests.test_functions`
 # the -Wa flag tells Python to display deprecation warnings
@@ -131,3 +132,20 @@ class UpdateCachedConcordancesCommandTest(TestCase):
             observed_value: Union[str, int, None] = single_concordance[key]
             with self.subTest(key=key):
                 self.assertEqual(observed_value, value)
+
+
+class IncipitSignalTest(TestCase):
+    # testing an edge case in generate_incipit, within main_app/signals.py.
+    # Some other tests involving this function can be found
+    # in ChantModelTest and SequenceModelTest.
+    def test_generate_incipit(self):
+        complete_fulltext: str = "one two three four five six seven"
+        expected_incipit_1: str = "one two three four five"
+        observed_incipit_1: str = generate_incipit(complete_fulltext)
+        with self.subTest(test="full-length fulltext"):
+            self.assertEqual(observed_incipit_1, expected_incipit_1)
+        short_fulltext: str = "one*"
+        expected_incipit_2 = "one*"
+        observed_incipit_2 = generate_incipit(short_fulltext)
+        with self.subTest(test="fulltext that's already a short incipit"):
+            self.assertEqual(observed_incipit_2, expected_incipit_2)

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -106,6 +106,9 @@ class UpdateCachedConcordancesCommandTest(TestCase):
 
     def test_concordances_values(self):
         chant: Chant = make_fake_chant()
+        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
         cantus_id: str = chant.cantus_id
 
         concordances: dict = update_cached_concordances.get_concordances()

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -237,14 +237,8 @@ class ChantModelTest(TestCase):
         full_text: str = "Incipit should be five words sheep headphones bongoes"
         expected_incipit: str = "Incipit should be five words"
         chant.manuscript_full_text_std_spelling = full_text
-        print(
-            f"before refresh\n  {chant.manuscript_full_text_std_spelling=}\n  {chant.incipit=}"
-        )
         chant.save()
         chant.refresh_from_db()
-        print(
-            f"refreshed:\n  {chant.manuscript_full_text_std_spelling=}\n  {chant.incipit=}"
-        )
         observed_incipit: str = chant.incipit
         self.assertEqual(observed_incipit, expected_incipit)
 

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -231,6 +231,23 @@ class ChantModelTest(TestCase):
         self.assertEqual(chant1.get_next_chant(), lacuna)
         self.assertEqual(lacuna.get_next_chant(), chant3)
 
+    def test_incipit_signal(self):
+        """Test whether a chant's incipit is updated to reflect its fulltext upon save"""
+        chant: Chant = make_fake_chant()
+        full_text: str = "Incipit should be five words sheep headphones bongoes"
+        expected_incipit: str = "Incipit should be five words"
+        chant.manuscript_full_text_std_spelling = full_text
+        print(
+            f"before refresh\n  {chant.manuscript_full_text_std_spelling=}\n  {chant.incipit=}"
+        )
+        chant.save()
+        chant.refresh_from_db()
+        print(
+            f"refreshed:\n  {chant.manuscript_full_text_std_spelling=}\n  {chant.incipit=}"
+        )
+        observed_incipit: str = chant.incipit
+        self.assertEqual(observed_incipit, expected_incipit)
+
 
 class FeastModelTest(TestCase):
     @classmethod
@@ -348,6 +365,19 @@ class SequenceModelTest(TestCase):
         chant_fields = Chant.get_fields_and_properties()
         seq_fields = Sequence.get_fields_and_properties()
         self.assertEqual(chant_fields, seq_fields)
+
+    def test_incipit_signal(self):
+        """Test whether a sequence's incipit is updated to reflect its fulltext upon save"""
+        sequence: Sequence = make_fake_sequence()
+        full_text: str = (
+            "Incipit debet esse quinque verba bombus equus armadillo macropus"
+        )
+        expected_incipit: str = "Incipit debet esse quinque verba"
+        sequence.manuscript_full_text_std_spelling = full_text
+        sequence.save()
+        sequence.refresh_from_db()
+        observed_incipit: str = sequence.incipit
+        self.assertEqual(observed_incipit, expected_incipit)
 
 
 class SourceModelTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -361,13 +361,11 @@ class SequenceModelTest(TestCase):
         self.assertEqual(chant_fields, seq_fields)
 
     def test_incipit_signal(self):
-        """Test whether a sequence's incipit is updated to reflect its fulltext upon save"""
+        """Test whether a sequence's incipit is updated to reflect its title upon save"""
         sequence: Sequence = make_fake_sequence()
-        full_text: str = (
-            "Incipit debet esse quinque verba bombus equus armadillo macropus"
-        )
-        expected_incipit: str = "Incipit debet esse quinque verba"
-        sequence.manuscript_full_text_std_spelling = full_text
+        title: str = "Incipit titulus esse debet"
+        expected_incipit: str = title
+        sequence.title = title
         sequence.save()
         sequence.refresh_from_db()
         observed_incipit: str = sequence.incipit

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2020,30 +2020,50 @@ class ChantSearchMSViewTest(TestCase):
         includes_search_term = "brevity is the soul of wit"
         doesnt_include_search_term = "longevity is the soul of wit"
         source = make_fake_source()
+
+        # For all the chants below: incipit is automatically calculated
+        # based on fulltext every time a chant is saved. In order to set
+        # the incipit, we need to create the chant (.save() is called
+        # at the end of make_fake_chant()), and then update the incipit
+        # to ensure the proper value is stored in the database for when
+        # we make the request for the page.
+
         chant_incipit = make_fake_chant(
             source=source,
-            incipit=includes_search_term,  # <==
             manuscript_full_text=doesnt_include_search_term,
             manuscript_full_text_std_spelling=doesnt_include_search_term,
         )
+        Chant.objects.filter(id=chant_incipit.id).update(
+            incipit=includes_search_term  # <==
+        )
+
         chant_ms_spelling = make_fake_chant(
             source=source,
-            incipit=doesnt_include_search_term,
             manuscript_full_text=includes_search_term,  # <==
             manuscript_full_text_std_spelling=doesnt_include_search_term,
         )
+        Chant.objects.filter(id=chant_ms_spelling.id).update(
+            incipit=doesnt_include_search_term
+        )
+
         chant_std_spelling = make_fake_chant(
             source=source,
-            incipit=doesnt_include_search_term,
             manuscript_full_text=doesnt_include_search_term,
             manuscript_full_text_std_spelling=includes_search_term,  # <==
         )
+        Chant.objects.filter(id=chant_std_spelling.id).update(
+            incipit=doesnt_include_search_term
+        )
+
         chant_without_search_term = make_fake_chant(
             source=source,
-            incipit=doesnt_include_search_term,
             manuscript_full_text=doesnt_include_search_term,
             manuscript_full_text_std_spelling=doesnt_include_search_term,
         )
+        Chant.objects.filter(id=chant_without_search_term.id).update(
+            incipit=doesnt_include_search_term
+        )
+
         response_starts_with = self.client.get(
             reverse("chant-search-ms", args=[source.id]),
             {"keyword": search_term, "op": "starts_with"},

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1081,9 +1081,17 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_siglum(self):
         source_1 = make_fake_source(published=True, siglum="sigl-1")
-        chant_1 = make_fake_chant(incipit="thing 1", source=source_1)
+        chant_1 = make_fake_chant(
+            manuscript_full_text_std_spelling="thing 1", source=source_1
+        )
         source_2 = make_fake_source(published=True, siglum="sigl-2")
-        chant_2 = make_fake_chant(incipit="thing 2", source=source_2)
+        chant_2 = make_fake_chant(
+            manuscript_full_text_std_spelling="thing 2", source=source_2
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "thing"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1500,12 +1500,11 @@ class ChantSearchViewTest(TestCase):
     def test_column_header_links(self):
         # these are the 9 column headers users can order by:
         siglum = "glum-01"
-        incipit = "so it begins"
+        fulltext = "so it begins"
         office = make_fake_office()
         genre = make_fake_genre()
         cantus_id = make_random_string(6, "0123456789")
         mode = make_random_string(1, "0123456789*?")
-        ms_ft = faker.sentence()
         mel = make_fake_volpiano()
         image = faker.image_url()
 
@@ -1515,12 +1514,11 @@ class ChantSearchViewTest(TestCase):
         feast = make_fake_feast()
         position = make_random_string(1)
         chant = make_fake_chant(
-            incipit=incipit,
+            manuscript_full_text_std_spelling=fulltext,
             office=office,
             genre=genre,
             cantus_id=cantus_id,
             mode=mode,
-            manuscript_full_text_std_spelling=ms_ft,
             volpiano=mel,
             image_link=image,
             source=source,

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1288,13 +1288,17 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_mode(self):
         chant_1 = make_fake_chant(
-            incipit="For first he looks upon his forepaws to see if they are clean",
+            manuscript_full_text_std_spelling="For first he looks upon his forepaws to see if they are clean",
             mode="1",
         )
         chant_2 = make_fake_chant(
-            incipit="For secondly he kicks up behind to clear away there",
+            manuscript_full_text_std_spelling="For secondly he kicks up behind to clear away there",
             mode="2",
         )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "for"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4409,6 +4409,9 @@ class SourceInventoryViewTest(TestCase):
         bower_segment = Segment.objects.create(id=4064, name="Bower Sequence Database")
         source = make_fake_source(published=True, segment=bower_segment)
         sequence = make_fake_sequence(source=source)
+        sequence.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on sequence save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
         incipit = sequence.incipit
         url = reverse("sequence-detail", args=[sequence.id])
         response = self.client.get(reverse("source-inventory", args=[source.id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1984,29 +1984,10 @@ class ChantSearchMSViewTest(TestCase):
         doesnt_include_search_term = "longevity is the soul of wit"
         source = make_fake_source()
 
-        # For all the chants below: incipit is automatically calculated
-        # based on fulltext every time a chant is saved. In order to set
-        # the incipit, we need to create the chant (.save() is called
-        # at the end of make_fake_chant()), and then update the incipit
-        # to ensure the proper value is stored in the database for when
-        # we make the request for the page.
-
-        chant_incipit = make_fake_chant(
-            source=source,
-            manuscript_full_text=doesnt_include_search_term,
-            manuscript_full_text_std_spelling=doesnt_include_search_term,
-        )
-        Chant.objects.filter(id=chant_incipit.id).update(
-            incipit=includes_search_term  # <==
-        )
-
         chant_ms_spelling = make_fake_chant(
             source=source,
-            manuscript_full_text=includes_search_term,  # <==
+            manuscript_full_text=includes_search_term,  # <== includes_search_term
             manuscript_full_text_std_spelling=doesnt_include_search_term,
-        )
-        Chant.objects.filter(id=chant_ms_spelling.id).update(
-            incipit=doesnt_include_search_term
         )
 
         chant_std_spelling = make_fake_chant(
@@ -2014,17 +1995,22 @@ class ChantSearchMSViewTest(TestCase):
             manuscript_full_text=doesnt_include_search_term,
             manuscript_full_text_std_spelling=includes_search_term,  # <==
         )
-        Chant.objects.filter(id=chant_std_spelling.id).update(
-            incipit=doesnt_include_search_term
+
+        # some chants inherited from OldCantus have an incipit but no full-text -
+        # we need to ensure these chants appear in the results
+        chant_incipit = make_fake_chant(
+            source=source,
+        )
+        Chant.objects.filter(id=chant_incipit.id).update(
+            incipit=includes_search_term,  # <==
+            manuscript_full_text=None,
+            manuscript_full_text_std_spelling=None,
         )
 
         chant_without_search_term = make_fake_chant(
             source=source,
             manuscript_full_text=doesnt_include_search_term,
             manuscript_full_text_std_spelling=doesnt_include_search_term,
-        )
-        Chant.objects.filter(id=chant_without_search_term.id).update(
-            incipit=doesnt_include_search_term
         )
 
         response_starts_with = self.client.get(

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2222,15 +2222,19 @@ class ChantSearchMSViewTest(TestCase):
     def test_order_by_mode(self):
         source = make_fake_source()
         chant_1 = make_fake_chant(
-            incipit="For thirdly he works it upon stretch with the forepaws extended",
+            manuscript_full_text_std_spelling="For thirdly he works it upon stretch with the forepaws extended",
             mode="1",
             source=source,
         )
         chant_2 = make_fake_chant(
-            incipit="For fourthly he sharpens his paws by wood",
+            manuscript_full_text_std_spelling="For fourthly he sharpens his paws by wood",
             mode="2",
             source=source,
         )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "for"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5586,15 +5586,17 @@ class AjaxSearchBarTest(TestCase):
 
     def test_incipit_search(self):
         unremarkable_chant = make_fake_chant(
-            incipit=(
-                "The incipit contains no "
+            manuscript_full_text_std_spelling=(
+                "The fulltext contains no "
                 "numbers no asterisks and no punctuation "
                 "and is thus completely normal"
             )
         )
-        chant_with_asterisk = make_fake_chant(incipit="few words*")
+        chant_with_asterisk = make_fake_chant(
+            manuscript_full_text_std_spelling="few words*"
+        )
 
-        istartswith_search_term = "the incipit"
+        istartswith_search_term = "the fulltext"
         istartswith_response = self.client.get(
             reverse("ajax-search-bar", args=[istartswith_search_term])
         )

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4393,6 +4393,9 @@ class SourceInventoryViewTest(TestCase):
     def test_incipit_column_for_chant_source(self):
         source = make_fake_source(published=True)
         chant = make_fake_chant(source=source)
+        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
         incipit = chant.incipit
         url = reverse("chant-detail", args=[chant.id])
         response = self.client.get(reverse("source-inventory", args=[source.id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1357,14 +1357,18 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_volpiano(self):
         chant_1 = make_fake_chant(
-            incipit="this is a chant with volpiano",
+            manuscript_full_text_std_spelling="this is a chant with volpiano",
             volpiano="1---d---d---a--a---a---e--f--e---d---4",
         )
         chant_2 = make_fake_chant(
-            incipit="this is a chant about parsley",
+            manuscript_full_text_std_spelling="this is a chant about parsley",
         )
         chant_2.volpiano = None
         chant_2.save()
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "s is a ch"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2306,15 +2306,19 @@ class ChantSearchMSViewTest(TestCase):
         source = make_fake_source()
         chant_1 = make_fake_chant(
             source=source,
-            incipit="this is a chant with volpiano",
+            manuscript_full_text_std_spelling="this is a chant with volpiano",
             volpiano="1---d---d---a--a---a---e--f--e---d---4",
         )
         chant_2 = make_fake_chant(
             source=source,
-            incipit="this is a chant about parsley",
+            manuscript_full_text_std_spelling="this is a chant about parsley",
         )
         chant_2.volpiano = None
         chant_2.save()
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "s is a ch"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -825,7 +825,6 @@ class ChantDetailViewTest(TestCase):
         chant = make_fake_chant(
             source=source,
             volpiano="1---c--g--e---e---d---c---c---f---e---e--d---d---c",
-            incipit="somebody",
         )
         chant.manuscript_full_text = None
         chant.manuscript_full_text_std_spelling = None

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2396,12 +2396,12 @@ class ChantSearchMSViewTest(TestCase):
     def test_column_header_links(self):
         # these are the 9 column headers users can order by:
         siglum = "glum-01"
-        incipit = "so it begins"
+        full_text = "this is a full text that begins with the search term"
+        search_term = "this is a fu"
         office = make_fake_office()
         genre = make_fake_genre()
         cantus_id = make_random_string(6, "0123456789")
         mode = make_random_string(1, "0123456789*?")
-        ms_ft = faker.sentence()
         mel = make_fake_volpiano()
         image = faker.image_url()
 
@@ -2415,18 +2415,13 @@ class ChantSearchMSViewTest(TestCase):
             genre=genre,
             cantus_id=cantus_id,
             mode=mode,
-            manuscript_full_text_std_spelling=ms_ft,
+            manuscript_full_text_std_spelling=full_text,
             volpiano=mel,
             image_link=image,
             source=source,
             feast=feast,
             position=position,
         )
-        # incipit is automatically calculated from fulltext
-        # on chant save, so we need to set the incipit this way.
-        Chant.objects.filter(id=chant.id).update(incipit=incipit)
-        search_term = "so it be"
-
         response_1 = self.client.get(
             reverse("chant-search-ms", args=[source.id]),
             {

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1223,8 +1223,16 @@ class ChantSearchViewTest(TestCase):
         genre_1 = make_fake_genre()
         genre_2 = make_fake_genre()
         assert genre_1.id < genre_2.id
-        chant_1 = make_fake_chant(genre=genre_1, incipit="hocus")
-        chant_2 = make_fake_chant(genre=genre_2, incipit="pocus")
+        chant_1 = make_fake_chant(
+            genre=genre_1, manuscript_full_text_std_spelling="hocus"
+        )
+        chant_2 = make_fake_chant(
+            genre=genre_2, manuscript_full_text_std_spelling="focus"
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "ocu"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1267,8 +1267,16 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_order_by_cantus_id(self):
-        chant_1 = make_fake_chant(incipit="isaac", cantus_id="121393")
-        chant_2 = make_fake_chant(incipit="baal", cantus_id="196418")
+        chant_1 = make_fake_chant(
+            manuscript_full_text_std_spelling="isaac", cantus_id="121393"
+        )
+        chant_2 = make_fake_chant(
+            manuscript_full_text_std_spelling="baal", cantus_id="196418"
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "aa"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2057,8 +2057,16 @@ class ChantSearchMSViewTest(TestCase):
 
     def test_order_by_incipit(self):
         source = make_fake_source(published=True)
-        chant_1 = make_fake_chant(source=source, incipit="higgledy")
-        chant_2 = make_fake_chant(source=source, incipit="piggledy")
+        chant_1 = make_fake_chant(
+            source=source, manuscript_full_text_std_spelling="higgledy"
+        )
+        chant_2 = make_fake_chant(
+            source=source, manuscript_full_text_std_spelling="piggledy"
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "iggl"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2200,8 +2200,16 @@ class ChantSearchMSViewTest(TestCase):
 
     def test_order_by_cantus_id(self):
         source = make_fake_source()
-        chant_1 = make_fake_chant(incipit="isaac", cantus_id="121393", source=source)
-        chant_2 = make_fake_chant(incipit="baal", cantus_id="196418", source=source)
+        chant_1 = make_fake_chant(
+            manuscript_full_text_std_spelling="isaac", cantus_id="121393", source=source
+        )
+        chant_2 = make_fake_chant(
+            manuscript_full_text_std_spelling="baal", cantus_id="196418", source=source
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "aa"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1330,14 +1330,18 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_ms_fulltext(self):
         chant_1 = make_fake_chant(
-            incipit="this is a chant with",
             manuscript_full_text="this is a chant with a MS spelling fylltexte",
+            manuscript_full_text_std_spelling="this is a chant with a MS spelling fulltext",
         )
         chant_2 = make_fake_chant(
-            incipit="this is a chant without",
+            manuscript_full_text_std_spelling="this is a chant without a MS spelling fulltext",
         )
         chant_2.manuscript_full_text = None
         chant_2.save()
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "s is a ch"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2267,16 +2267,20 @@ class ChantSearchMSViewTest(TestCase):
     def test_order_by_ms_fulltext(self):
         source = make_fake_source()
         chant_1 = make_fake_chant(
-            incipit="this is a chant with a MS spelling fulltext",
+            manuscript_full_text_std_spelling="this is a chant with a MS spelling fulltext",
             manuscript_full_text="this is a chant with a MS spelling fylltexte",
             source=source,
         )
         chant_2 = make_fake_chant(
-            incipit="this is a chant without",
+            manuscript_full_text_std_spelling="this is a chant without",
             source=source,
         )
         chant_2.manuscript_full_text = None
         chant_2.save()
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "s is a ch"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2155,8 +2155,16 @@ class ChantSearchMSViewTest(TestCase):
         genre_1 = make_fake_genre()
         genre_2 = make_fake_genre()
         assert genre_1.id < genre_2.id
-        chant_1 = make_fake_chant(genre=genre_1, incipit="hocus", source=source)
-        chant_2 = make_fake_chant(genre=genre_2, incipit="pocus", source=source)
+        chant_1 = make_fake_chant(
+            genre=genre_1, manuscript_full_text_std_spelling="hocus", source=source
+        )
+        chant_2 = make_fake_chant(
+            genre=genre_2, manuscript_full_text_std_spelling="pocus", source=source
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "ocu"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2098,8 +2098,16 @@ class ChantSearchMSViewTest(TestCase):
         office_1 = make_fake_office()
         office_2 = make_fake_office()
         assert office_1.id < office_2.id
-        chant_1 = make_fake_chant(office=office_1, incipit="hocus", source=source)
-        chant_2 = make_fake_chant(office=office_2, incipit="pocus", source=source)
+        chant_1 = make_fake_chant(
+            office=office_1, manuscript_full_text_std_spelling="hocus", source=source
+        )
+        chant_2 = make_fake_chant(
+            office=office_2, manuscript_full_text_std_spelling="pocus", source=source
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "ocu"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5632,11 +5632,11 @@ class AjaxSearchBarTest(TestCase):
     def test_cantus_id_search(self):
         chant_with_normal_cantus_id = make_fake_chant(
             cantus_id="012345",
-            incipit="This incipit contains no numerals",
+            manuscript_full_text_std_spelling="This fulltext contains no numerals",
         )
         chant_with_numerals_in_incipit = make_fake_chant(
             cantus_id="123456",
-            incipit="0 me! 0 my! This is unexpected!",
+            manuscript_full_text_std_spelling="0 me! 0 my! This is unexpected!",
         )
 
         # for search terms that contain numerals, we should only return

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5069,6 +5069,10 @@ class JsonCidTest(TestCase):
 
     def test_values(self):
         chant = make_fake_chant(cantus_id="100000")
+        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
+
         expected_values = {
             "siglum": chant.source.siglum,
             "srclink": f"http://testserver/source/{chant.source.id}",

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3026,9 +3026,7 @@ class SourceEditChantsViewTest(TestCase):
     def test_chant_with_volpiano_with_no_fulltext(self):
         # in the past, a Chant Edit page will error rather than loading properly when the chant has volpiano but no fulltext
         source = make_fake_source()
-        chant = make_fake_chant(
-            source=source, volpiano="1---f--e---f--d---e--c---d--d", incipit="dies irae"
-        )
+        chant = make_fake_chant(source=source, volpiano="1---f--e---f--d---e--c---d--d")
         chant.manuscript_full_text = None
         chant.manuscript_full_text_std_spelling = None
         chant.save()

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5465,7 +5465,7 @@ class ContentOverviewTest(TestCase):
 
     def test_source_selected_model(self):
         source = make_fake_source(title="Test Source")
-        chant = make_fake_chant(incipit="Test Chant")
+        chant = make_fake_chant()
         response = self.client.get(reverse("content-overview"), {"model": "sources"})
         self.assertContains(response, f"<b>Sources</b>", html=True)
         self.assertContains(

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1314,7 +1314,7 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_ms_fulltext(self):
         chant_1 = make_fake_chant(
-            incipit="this is a chant with a MS spelling fulltext",
+            incipit="this is a chant with",
             manuscript_full_text="this is a chant with a MS spelling fylltexte",
         )
         chant_2 = make_fake_chant(
@@ -5553,6 +5553,9 @@ class AutocompleteViewsTest(TestCase):
 class AjaxSearchBarTest(TestCase):
     def test_response(self):
         chant = make_fake_chant()
+        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
         cantus_id = chant.cantus_id
 
         response = self.client.get(reverse("ajax-search-bar", args=[cantus_id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2478,7 +2478,6 @@ class ChantSearchMSViewTest(TestCase):
         feast = make_fake_feast()
         position = make_random_string(1)
         chant = make_fake_chant(
-            incipit=incipit,
             office=office,
             genre=genre,
             cantus_id=cantus_id,
@@ -2490,6 +2489,9 @@ class ChantSearchMSViewTest(TestCase):
             feast=feast,
             position=position,
         )
+        # incipit is automatically calculated from fulltext
+        # on chant save, so we need to set the incipit this way.
+        Chant.objects.filter(id=chant.id).update(incipit=incipit)
         search_term = "so it be"
 
         response_1 = self.client.get(

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3736,7 +3736,7 @@ class SequenceEditViewTest(TestCase):
         self.assertTemplateUsed(response, "404.html")
 
     def test_update_sequence(self):
-        sequence = make_fake_sequence(incipit="test_update_sequence")
+        sequence = make_fake_sequence()
         sequence_id = str(sequence.id)
         response = self.client.post(
             reverse("sequence-edit", args=[sequence_id]),

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1167,8 +1167,16 @@ class ChantSearchViewTest(TestCase):
         office_1 = make_fake_office()
         office_2 = make_fake_office()
         assert office_1.id < office_2.id
-        chant_1 = make_fake_chant(office=office_1, incipit="hocus")
-        chant_2 = make_fake_chant(office=office_2, incipit="pocus")
+        chant_1 = make_fake_chant(
+            office=office_1, manuscript_full_text_std_spelling="hocus"
+        )
+        chant_2 = make_fake_chant(
+            office=office_2, manuscript_full_text_std_spelling="pocus"
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "ocu"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1087,10 +1087,6 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="thing 2", source=source_2
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "thing"
 
@@ -1132,10 +1128,6 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             source=source, manuscript_full_text_std_spelling="piggledy"
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "iggl"
 
@@ -1180,10 +1172,6 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             office=office_2, manuscript_full_text_std_spelling="pocus"
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "ocu"
 
@@ -1228,10 +1216,6 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             genre=genre_2, manuscript_full_text_std_spelling="focus"
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "ocu"
 
@@ -1272,10 +1256,6 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="baal", cantus_id="196418"
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "aa"
 
@@ -1318,10 +1298,6 @@ class ChantSearchViewTest(TestCase):
             manuscript_full_text_std_spelling="For secondly he kicks up behind to clear away there",
             mode="2",
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "for"
 
@@ -1361,16 +1337,12 @@ class ChantSearchViewTest(TestCase):
             manuscript_full_text_std_spelling="this is a chant with a MS spelling fulltext",
         )
         chant_2 = make_fake_chant(
-            manuscript_full_text_std_spelling="this is a chant without a MS spelling fulltext",
+            manuscript_full_text_std_spelling="this will become a chant without a MS spelling fulltext",
         )
         chant_2.manuscript_full_text = None
         chant_2.save()
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
-        search_term = "s is a ch"
+        search_term = "a chant wit"
 
         response_ascending = self.client.get(
             reverse("chant-search"),
@@ -1412,10 +1384,6 @@ class ChantSearchViewTest(TestCase):
         )
         chant_2.volpiano = None
         chant_2.save()
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "s is a ch"
 
@@ -1459,10 +1427,6 @@ class ChantSearchViewTest(TestCase):
         )
         chant_2.image_link = None
         chant_2.save()
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "a chant with"
 
@@ -2082,10 +2046,6 @@ class ChantSearchMSViewTest(TestCase):
         chant_2 = make_fake_chant(
             source=source, manuscript_full_text_std_spelling="piggledy"
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "iggl"
 
@@ -2131,10 +2091,6 @@ class ChantSearchMSViewTest(TestCase):
         chant_2 = make_fake_chant(
             office=office_2, manuscript_full_text_std_spelling="pocus", source=source
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "ocu"
 
@@ -2180,10 +2136,6 @@ class ChantSearchMSViewTest(TestCase):
         chant_2 = make_fake_chant(
             genre=genre_2, manuscript_full_text_std_spelling="pocus", source=source
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "ocu"
 
@@ -2225,10 +2177,6 @@ class ChantSearchMSViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="baal", cantus_id="196418", source=source
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "aa"
 
@@ -2274,10 +2222,6 @@ class ChantSearchMSViewTest(TestCase):
             mode="2",
             source=source,
         )
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "for"
 
@@ -2324,10 +2268,6 @@ class ChantSearchMSViewTest(TestCase):
         )
         chant_2.manuscript_full_text = None
         chant_2.save()
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "s is a ch"
 
@@ -2374,10 +2314,6 @@ class ChantSearchMSViewTest(TestCase):
         )
         chant_2.volpiano = None
         chant_2.save()
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         search_term = "s is a ch"
 
@@ -2424,8 +2360,6 @@ class ChantSearchMSViewTest(TestCase):
         )
         chant_2.image_link = None
         chant_2.save()
-        chant_1.refresh_from_db()
-        chant_2.refresh_from_db()
 
         search_term = "a chant with"
 
@@ -3131,6 +3065,8 @@ class SourceEditChantsViewTest(TestCase):
             folio="001r",
             c_sequence=2,
         )
+        expected_volpiano: str = "abacadaeafagahaja"
+        expected_intervals: str = "1-12-23-34-45-56-67-78-8"
         self.client.post(
             reverse("source-edit-chants", args=[source.id]),
             {
@@ -3141,8 +3077,8 @@ class SourceEditChantsViewTest(TestCase):
             },
         )
         chant_2 = Chant.objects.get(manuscript_full_text_std_spelling="resonare foobaz")
-        self.assertEqual(chant_2.volpiano, "abacadaeafagahaja")
-        self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
+        self.assertEqual(chant_2.volpiano, expected_volpiano)
+        self.assertEqual(chant_2.volpiano_intervals, expected_intervals)
 
     def test_chant_with_volpiano_with_no_fulltext(self):
         # in the past, a Chant Edit page will error rather than loading properly when the chant has volpiano but no fulltext
@@ -3231,7 +3167,7 @@ class ChantEditSyllabificationViewTest(TestCase):
 
     def test_edit_syllabification(self):
         chant = make_fake_chant(manuscript_syllabized_full_text="lorem ipsum")
-        self.assertIs(chant.manuscript_syllabized_full_text, "lorem ipsum")
+        self.assertEqual(chant.manuscript_syllabized_full_text, "lorem ipsum")
         response = self.client.post(
             f"/edit-syllabification/{chant.id}",
             {"manuscript_syllabized_full_text": "lo-rem ip-sum"},
@@ -4512,9 +4448,6 @@ class SourceInventoryViewTest(TestCase):
     def test_incipit_column_for_chant_source(self):
         source = make_fake_source(published=True)
         chant = make_fake_chant(source=source)
-        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
         incipit = chant.incipit
         url = reverse("chant-detail", args=[chant.id])
         response = self.client.get(reverse("source-inventory", args=[source.id]))
@@ -4528,9 +4461,6 @@ class SourceInventoryViewTest(TestCase):
         bower_segment = Segment.objects.create(id=4064, name="Bower Sequence Database")
         source = make_fake_source(published=True, segment=bower_segment)
         sequence = make_fake_sequence(source=source)
-        sequence.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on sequence save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
         incipit = sequence.incipit
         url = reverse("sequence-detail", args=[sequence.id])
         response = self.client.get(reverse("source-inventory", args=[source.id]))
@@ -5191,9 +5121,6 @@ class JsonCidTest(TestCase):
 
     def test_values(self):
         chant = make_fake_chant(cantus_id="100000")
-        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
 
         expected_values = {
             "siglum": chant.source.siglum,
@@ -5675,9 +5602,6 @@ class AutocompleteViewsTest(TestCase):
 class AjaxSearchBarTest(TestCase):
     def test_response(self):
         chant = make_fake_chant()
-        chant.refresh_from_db()  # incipit is automatically calculated from fulltext
-        # on chant save; refreshing from DB allows us to compare the value to what we see in
-        # the results.
         cantus_id = chant.cantus_id
 
         response = self.client.get(reverse("ajax-search-bar", args=[cantus_id]))

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1127,8 +1127,16 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_incipit(self):
         source = make_fake_source(published=True)
-        chant_1 = make_fake_chant(source=source, incipit="higgledy")
-        chant_2 = make_fake_chant(source=source, incipit="piggledy")
+        chant_1 = make_fake_chant(
+            source=source, manuscript_full_text_std_spelling="higgledy"
+        )
+        chant_2 = make_fake_chant(
+            source=source, manuscript_full_text_std_spelling="piggledy"
+        )
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "iggl"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2380,15 +2380,17 @@ class ChantSearchMSViewTest(TestCase):
         source = make_fake_source()
         chant_1 = make_fake_chant(
             source=source,
-            incipit="this is a chant with a link",
+            manuscript_full_text_std_spelling="this is a chant with a link",
             image_link="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         )
         chant_2 = make_fake_chant(
             source=source,
-            incipit="this is a chant without",
+            manuscript_full_text_std_spelling="this is a chant without",
         )
         chant_2.image_link = None
         chant_2.save()
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()
 
         search_term = "a chant with"
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -1436,14 +1436,18 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_image_link(self):
         chant_1 = make_fake_chant(
-            incipit="this is a chant with a link",
+            manuscript_full_text_std_spelling="this is a chant with a link",
             image_link="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         )
         chant_2 = make_fake_chant(
-            incipit="this is a chant without",
+            manuscript_full_text_std_spelling="this is a chant without",
         )
         chant_2.image_link = None
         chant_2.save()
+        chant_1.refresh_from_db()
+        chant_2.refresh_from_db()  # incipit is automatically calculated from fulltext
+        # on chant save; refreshing from DB allows us to compare the value to what we see in
+        # the results.
 
         search_term = "a chant with"
 


### PR DESCRIPTION
This PR adds several functions in `signals.py` that automatically keep chants' and sequences' incipits up-to-date. In doing so, it will resolve #1187.

While working in `signals.py`, return annotations were added to all functions. Also, several functions that were declared within other functions have be un-nested, which should make the code simpler/clearer to read.

In the admin area, it sets the `incipit` field for Chants and Sequences to be read-only.

It also updates a great many tests in the test suite, as we had been using incipits in many places to, e.g., test that the expected chant was being returned among a set of results. 