### PR TITLE
Redirect http traffic directly to https://cantusdatabase.org

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf.production
+++ b/config/nginx/conf.d/cantusdb.conf.production
@@ -1,5 +1,5 @@
 server {
-    # Redirect all http traffic to corresponding https page
+    # Redirect all http traffic to corresponding canonical https page
     listen 80;
 
     server_name cantusdatabase.org www.cantusdatabase.org mass.cantusdatabase.org;
@@ -11,7 +11,7 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://cantusdatabase.org$request_uri;
     }
 }
 

--- a/config/nginx/conf.d/cantusdb.conf.staging
+++ b/config/nginx/conf.d/cantusdb.conf.staging
@@ -1,5 +1,5 @@
 server {
-    # redirect all http traffic to corresponding https page
+    # redirect all http traffic to corresponding canonical https page
     listen 80;
 
     server_name staging.cantusdatabase.org staging-alias.cantusdatabase.org;
@@ -11,7 +11,7 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://staging.cantusdatabase.org$request_uri;
     }
 }
 


### PR DESCRIPTION
This PR updates our production and staging Nginx configuration to redirect http traffic from alternate subdomains to the canonical https subdomain, rather than redirecting it to the same https subdomain and then redirecting from there to the canonical subdomain, as we had been doing previously.