### PR TITLE
Update volpiano-display-utilities to v1.1.2

### DIFF
--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -39,5 +39,5 @@ typed-ast==1.4.1
 typing-extensions==3.10.0.0
 ujson==5.9.0
 urllib3==1.26.18
-volpiano-display-utilities @ git+https://github.com/DDMAL/volpiano-display-utilities.git@v1.1.1
+volpiano-display-utilities @ git+https://github.com/DDMAL/volpiano-display-utilities.git@v1.1.2
 wrapt==1.12.1


### PR DESCRIPTION
Update volpiano-display-utilities dependency. 


See https://github.com/DDMAL/volpiano-display-utilities/releases/tag/v1.1.2 for release details