### PR TITLE
Update update_cached_concordances command to comply with new spec

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -6,9 +6,11 @@ from django.db.models.query import QuerySet
 from django.core.management.base import BaseCommand
 from main_app.models import Chant
 
-
 # Usage: `python manage.py update_cached_concordances`
 # or `python manage.py update_cached_concordances -d "/path/to/directory/in/which/to/save/concordances"`
+
+# Used for creating URIs for chant and source detail pages
+CANTUSDB_DOMAIN: str = "https://cantusdatabase.org"
 
 
 class Command(BaseCommand):
@@ -97,11 +99,10 @@ def make_chant_dict(chant: dict) -> dict:
         dict: A dictionary representing a chant, with several values standardized
             (e.g., `siglum`) and several values calculated (e.g., `srclink`)
     """
-    DOMAIN: str = "https://cantusdatabase.org"
     source_id: int = chant["source_id"]
-    source_uri: str = f"{DOMAIN}/source/{source_id}/"
+    source_uri: str = f"{CANTUSDB_DOMAIN}/source/{source_id}/"
     chant_id: int = chant["id"]
-    chant_uri: str = f"{DOMAIN}/chant/{chant_id}/"
+    chant_uri: str = f"{CANTUSDB_DOMAIN}/chant/{chant_id}/"
     processed_chant: dict = {
         "siglum": chant["source__siglum"],
         "srclink": source_uri,

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -122,36 +122,3 @@ def make_chant_dict(chant: dict) -> dict:
     }
 
     return processed_chant
-
-    # stdout.write("Processing chants\n")
-    # concordances: defaultdict = defaultdict(list)
-    # for chant in values:
-    #     source_id: int = chant["source_id"]
-    #     source_absolute_url: str = f"{DOMAIN}/source/{source_id}/"
-    #     chant_id: int = chant["id"]
-    #     chant_absolute_url: str = f"{DOMAIN}/chant/{chant_id}/"
-
-    #     concordances[chant["cantus_id"]].append(
-    #         {
-    #             "siglum": chant["source__siglum"],
-    #             "srclink": source_absolute_url,
-    #             "chantlink": chant_absolute_url,
-    #             "folio": chant["folio"],
-    #             "sequence": chant["c_sequence"],
-    #             "incipit": chant["incipit"],
-    #             "feast": chant["feast__name"],
-    #             "genre": chant["genre__name"],
-    #             "office": chant["office__name"],
-    #             "position": chant["position"],
-    #             "cantus_id": chant["cantus_id"],
-    #             "image": chant["image_link"],
-    #             "mode": chant["mode"],
-    #             "full_text": chant["manuscript_full_text_std_spelling"],
-    #             "melody": chant["volpiano"],
-    #             "db": "CD",
-    #         }
-    #     )
-
-    # stdout.write(f"All chants processed - found {len(concordances)} Cantus IDs\n")
-
-    # return dict(concordances)

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -45,13 +45,13 @@ class Command(BaseCommand):
         )
 
 
-def get_concordances() -> dict:
-    """Fetch all published chants in the database, group them by Cantus ID, and return
-    a dictionary containing information on each of these chants.
+def get_concordances() -> list[dict]:
+    """Fetch all published chants in the database, and return a list
+    of dictionaries containing information on these chants.
 
     Returns:
-        dict: A dictionary where each key is a Cantus ID and each value is a list all
-          published chants in the database with that Cantus ID.
+        list[dict]: A list of dictionaries, each representing a single chant
+            from the database
     """
 
     stdout.write("Querying database for published chants\n")

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -1,9 +1,7 @@
 import ujson
 import os
 from sys import stdout
-from typing import Optional
 from datetime import datetime
-from collections import defaultdict
 from django.db.models.query import QuerySet
 from django.core.management.base import BaseCommand
 from main_app.models import Chant

--- a/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
+++ b/django/cantusdb_project/main_app/management/commands/update_cached_concordances.py
@@ -32,13 +32,6 @@ class Command(BaseCommand):
         stdout.write(f"Running update_cached_concordances at {start_time}.\n")
         concordances: dict = get_concordances()
         write_time: str = datetime.now().isoformat()
-        metadata: dict = {
-            "last_updated": write_time,
-        }
-        data_and_metadata: dict = {
-            "data": concordances,
-            "metadata": metadata,
-        }
         stdout.write(f"Attempting to make directory at {cache_dir} to hold cache: ")
         try:
             os.mkdir(cache_dir)
@@ -47,7 +40,7 @@ class Command(BaseCommand):
             stdout.write(f"directory at {cache_dir} already exists.\n")
         stdout.write(f"Writing concordances to {filepath} at {write_time}.\n")
         with open(filepath, "w") as json_file:
-            ujson.dump(data_and_metadata, json_file)
+            ujson.dump(concordances, json_file)
         end_time = datetime.now().isoformat()
         stdout.write(
             f"Concordances successfully written to {filepath} at {end_time}.\n\n"
@@ -62,7 +55,6 @@ def get_concordances() -> dict:
         dict: A dictionary where each key is a Cantus ID and each value is a list all
           published chants in the database with that Cantus ID.
     """
-    DOMAIN: str = "https://cantusdatabase.org"
 
     stdout.write("Querying database for published chants\n")
     published_chants: QuerySet[Chant] = Chant.objects.filter(source__published=True)
@@ -89,35 +81,79 @@ def get_concordances() -> dict:
         "volpiano",
     )
 
-    stdout.write("Processing chants\n")
-    concordances: defaultdict = defaultdict(list)
-    for chant in values:
-        source_id: int = chant["source_id"]
-        source_absolute_url: str = f"{DOMAIN}/source/{source_id}/"
-        chant_id: int = chant["id"]
-        chant_absolute_url: str = f"{DOMAIN}/chant/{chant_id}/"
+    concordances: list[dict] = [make_chant_dict(chant) for chant in values]
+    return concordances
 
-        concordances[chant["cantus_id"]].append(
-            {
-                "siglum": chant["source__siglum"],
-                "srclink": source_absolute_url,
-                "chantlink": chant_absolute_url,
-                "folio": chant["folio"],
-                "sequence": chant["c_sequence"],
-                "incipit": chant["incipit"],
-                "feast": chant["feast__name"],
-                "genre": chant["genre__name"],
-                "office": chant["office__name"],
-                "position": chant["position"],
-                "cantus_id": chant["cantus_id"],
-                "image": chant["image_link"],
-                "mode": chant["mode"],
-                "full_text": chant["manuscript_full_text_std_spelling"],
-                "melody": chant["volpiano"],
-                "db": "CD",
-            }
-        )
 
-    stdout.write(f"All chants processed - found {len(concordances)} Cantus IDs\n")
+def make_chant_dict(chant: dict) -> dict:
+    """Given a dictionary representing a chant from the database,
+    return a chant with the keys specified at
+    https://github.com/DDMAL/CantusDB/wiki/APIs#concordances
 
-    return dict(concordances)
+    Args:
+        chant (dict): A dictionary representing a chant from the database,
+            from a QuerySet.values() call, with several non-standardized
+            keys from database traversals (e.g., `source__siglum`)
+
+    Returns:
+        dict: A dictionary representing a chant, with several values standardized
+            (e.g., `siglum`) and several values calculated (e.g., `srclink`)
+    """
+    DOMAIN: str = "https://cantusdatabase.org"
+    source_id: int = chant["source_id"]
+    source_uri: str = f"{DOMAIN}/source/{source_id}/"
+    chant_id: int = chant["id"]
+    chant_uri: str = f"{DOMAIN}/chant/{chant_id}/"
+    processed_chant: dict = {
+        "siglum": chant["source__siglum"],
+        "srclink": source_uri,
+        "chantlink": chant_uri,
+        "folio": chant["folio"],
+        "sequence": chant["c_sequence"],
+        "incipit": chant["incipit"],
+        "feast": chant["feast__name"],
+        "genre": chant["genre__name"],
+        "office": chant["office__name"],
+        "position": chant["position"],
+        "cantus_id": chant["cantus_id"],
+        "image": chant["image_link"],
+        "mode": chant["mode"],
+        "full_text": chant["manuscript_full_text_std_spelling"],
+        "melody": chant["volpiano"],
+        "db": "CD",
+    }
+
+    return processed_chant
+
+    # stdout.write("Processing chants\n")
+    # concordances: defaultdict = defaultdict(list)
+    # for chant in values:
+    #     source_id: int = chant["source_id"]
+    #     source_absolute_url: str = f"{DOMAIN}/source/{source_id}/"
+    #     chant_id: int = chant["id"]
+    #     chant_absolute_url: str = f"{DOMAIN}/chant/{chant_id}/"
+
+    #     concordances[chant["cantus_id"]].append(
+    #         {
+    #             "siglum": chant["source__siglum"],
+    #             "srclink": source_absolute_url,
+    #             "chantlink": chant_absolute_url,
+    #             "folio": chant["folio"],
+    #             "sequence": chant["c_sequence"],
+    #             "incipit": chant["incipit"],
+    #             "feast": chant["feast__name"],
+    #             "genre": chant["genre__name"],
+    #             "office": chant["office__name"],
+    #             "position": chant["position"],
+    #             "cantus_id": chant["cantus_id"],
+    #             "image": chant["image_link"],
+    #             "mode": chant["mode"],
+    #             "full_text": chant["manuscript_full_text_std_spelling"],
+    #             "melody": chant["volpiano"],
+    #             "db": "CD",
+    #         }
+    #     )
+
+    # stdout.write(f"All chants processed - found {len(concordances)} Cantus IDs\n")
+
+    # return dict(concordances)

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -17,18 +17,13 @@ from main_app.management.commands import update_cached_concordances
 class UpdateCachedConcordancesCommandTest(TestCase):
     def test_concordances_structure(self):
         chant: Chant = make_fake_chant(cantus_id="123456")
-        concordances: dict = update_cached_concordances.get_concordances()
+        concordances: list = update_cached_concordances.get_concordances()
 
-        with self.subTest(test="Ensure get_concordances returns dict"):
-            self.assertIsInstance(concordances, dict)
+        with self.subTest(test="Ensure get_concordances returns list"):
+            self.assertIsInstance(concordances, list)
 
-        concordances_for_single_cantus_id: list = concordances["123456"]
-        with self.subTest(test="Ensure values are lists"):
-            self.assertIsInstance(concordances_for_single_cantus_id, list)
-
-        single_concordance = concordances_for_single_cantus_id[0]
+        single_concordance = concordances[0]
         with self.subTest(test="Ensure each concordance is a dict"):
-            single_concordance: dict = concordances_for_single_cantus_id[0]
             self.assertIsInstance(single_concordance, dict)
 
         expected_keys = (
@@ -56,57 +51,33 @@ class UpdateCachedConcordancesCommandTest(TestCase):
         with self.subTest(test="Ensure no unexpected keys present"):
             self.assertEqual(len(concordance_keys), len(expected_keys))
 
-    def test_number_of_concordances_returned(self):
-        cantus_ids: tuple[tuple[str, int]] = (
-            ("000002", 2),
-            ("000003", 3),
-            ("000005", 5),
-            ("000007", 7),
-            ("000011", 11),
-        )
-        for cantus_id, n in cantus_ids:
-            for _ in range(n):
-                make_fake_chant(cantus_id=cantus_id)
-
-        concordances: dict = update_cached_concordances.get_concordances()
-        with self.subTest(test="Test all Cantus IDs present"):
-            self.assertEqual(len(concordances), len(cantus_ids))
-
-        for cantus_id, n in cantus_ids:
-            concordances_for_id: list = concordances[cantus_id]
-            with self.subTest(n=n):
-                self.assertEqual(len(concordances_for_id), n)
-
     def test_published_vs_unpublished(self):
         published_source: Source = make_fake_source(published=True)
         published_chant: Chant = make_fake_chant(
             source=published_source,
-            cantus_id="123456",
-            incipit="chant in a published source",
+            manuscript_full_text_std_spelling="chant in a published source",
         )
         unpublished_source: Source = make_fake_source(published=False)
         unpublished_chant: Chant = make_fake_chant(
             source=unpublished_source,
-            cantus_id="123456",
-            incipit="chant in an unpublished source",
+            manuscript_full_text_std_spelling="chant in an unpublished source",
         )
 
-        concordances: dict = update_cached_concordances.get_concordances()
-        concordances_for_single_id: list = concordances["123456"]
+        concordances: list = update_cached_concordances.get_concordances()
         self.assertEqual(len(concordances), 1)
 
-        single_concordance: dict = concordances_for_single_id[0]
-        expected_incipit: str = published_chant.incipit
+        single_concordance: dict = concordances[0]
+        # since the fulltext, specified above, contains <= 5 words,
+        # incipit should be the same as the fulltext
+        expected_incipit: str = published_chant.manuscript_full_text_std_spelling
         observed_incipit: str = single_concordance["incipit"]
         self.assertEqual(expected_incipit, observed_incipit)
 
     def test_concordances_values(self):
         chant: Chant = make_fake_chant()
-        cantus_id: str = chant.cantus_id
 
-        concordances: dict = update_cached_concordances.get_concordances()
-        concordances_for_single_id: list = concordances[cantus_id]
-        single_concordance: dict = concordances_for_single_id[0]
+        concordances: list = update_cached_concordances.get_concordances()
+        single_concordance: dict = concordances[0]
 
         expected_items: tuple = (
             ("siglum", chant.source.siglum),

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -67,11 +67,9 @@ class UpdateCachedConcordancesCommandTest(TestCase):
         self.assertEqual(len(concordances), 1)
 
         single_concordance: dict = concordances[0]
-        # since the fulltext, specified above, contains <= 5 words,
-        # incipit should be the same as the fulltext
-        expected_incipit: str = published_chant.manuscript_full_text_std_spelling
-        observed_incipit: str = single_concordance["incipit"]
-        self.assertEqual(expected_incipit, observed_incipit)
+        expected_fulltext: str = published_chant.manuscript_full_text_std_spelling
+        observed_fulltext: str = single_concordance["full_text"]
+        self.assertEqual(expected_fulltext, observed_fulltext)
 
     def test_concordances_values(self):
         chant: Chant = make_fake_chant()


### PR DESCRIPTION
This PR updates our `update_cached_concordances` command to output a file matching the updated specification (see #1323). In doing so, it fixes #1323.

The tests have also been updated to reflect the new spec.