### PR TITLE
Add `default_server` to nginx development configuration

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf.development
+++ b/config/nginx/conf.d/cantusdb.conf.development
@@ -3,7 +3,7 @@
 # contents of this file.
  
 server {
-    listen 80 default_server;
+    listen 80;
 
     location / {
         proxy_pass http://django:8000;

--- a/config/nginx/conf.d/cantusdb.conf.development
+++ b/config/nginx/conf.d/cantusdb.conf.development
@@ -3,11 +3,7 @@
 # contents of this file.
  
 server {
-    # listen 443 default_server http2 ssl;
     listen 80 default_server;
-	
-    # ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
-    # ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
 
     location / {
         proxy_pass http://django:8000;

--- a/config/nginx/conf.d/cantusdb.conf.development
+++ b/config/nginx/conf.d/cantusdb.conf.development
@@ -1,38 +1,10 @@
 # This file is configured for deployment of the CantusDB project in local development.
 # When building the project locally, replace the contents of cantusdb.conf with the
 # contents of this file.
-
-# server {
-#     listen 80;
-# 
-#     server_tokens off;
-# 
-#     location ^~ /.well-known/acme-challenge/ {
-#         root /var/www/lego;
-#     }
-# 
-#     location / {
-#         return 301 https://$host$request_uri;
-#     }
-# }
- 
-# server {
-#     # Redirect all https traffic for mass.cantusdatabase.org to cantusdatabase.org
-#     listen 443 ssl;
-# 
-#     server_name mass.cantusdatabase.org;
-# 
-#     ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
-#     ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
-# 
-#     location / {
-#         return 301 https://cantusdatabase.org$request_uri;
-#     }
-# }
  
 server {
     # listen 443 default_server http2 ssl;
-    listen 80;
+    listen 80 default_server;
 	
     # ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
     # ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;

--- a/config/nginx/conf.d/cantusdb.conf.production
+++ b/config/nginx/conf.d/cantusdb.conf.production
@@ -79,3 +79,18 @@ server {
         root /;
     }
 }
+
+# Default server to block requests to IP address and non-valid hostnames
+server {
+    access_log off; 
+    server_name _;
+
+    listen 80 default_server;
+    listen 443 default_server;
+    ssl_reject_handshake on;
+
+    # Close connection immediately for requests that don't match a defined
+    # server name
+    return 444;
+}
+

--- a/config/nginx/conf.d/cantusdb.conf.production
+++ b/config/nginx/conf.d/cantusdb.conf.production
@@ -31,10 +31,10 @@ server {
 }
 
 server {
-    listen 443 default_server http2 ssl;
+    listen 443 http2 ssl;
 
     server_name cantusdatabase.org;
-	
+
     ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
 
@@ -56,7 +56,7 @@ server {
         alias /resources/api_cache/concordances.json;
         expires modified +24h;
     }
- 
+
     location = /style.css {
         root /;
     }

--- a/config/nginx/conf.d/cantusdb.conf.staging
+++ b/config/nginx/conf.d/cantusdb.conf.staging
@@ -32,7 +32,7 @@ server {
 }
 
 server {
-    listen 443 default_server http2 ssl;
+    listen 443 http2 ssl;
 
     server_name staging.cantusdatabase.org;
 
@@ -79,4 +79,18 @@ server {
     location = /504.html {
         root /;
     }
+}
+
+# Default server to block requests to IP address and non-valid hostnames
+server {
+    access_log off; 
+    server_name _;
+
+    listen 80 default_server;
+    listen 443 default_server;
+    ssl_reject_handshake on;
+
+    # Close connection immediately for requests that don't match a defined
+    # server name
+    return 444;
 }

--- a/config/nginx/conf.d/cantusdb.conf.staging
+++ b/config/nginx/conf.d/cantusdb.conf.staging
@@ -21,11 +21,8 @@ server {
     # The Staging server's subdomain "staging-alias" is analogous to Production's "mass" subdomain.)
     listen 443 ssl;
 
-    # server_name mass.cantusdatabase.org;
     server_name staging-alias.cantusdatabase.org;
 
-    # ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
-    # ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
     ssl_certificate /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.key;
 
@@ -39,8 +36,6 @@ server {
 
     server_name staging.cantusdatabase.org;
 	
-    # ssl_certificate /etc/nginx/ssl/live/certificates/cantusdatabase.org.crt;
-    # ssl_certificate_key /etc/nginx/ssl/live/certificates/cantusdatabase.org.key;
     ssl_certificate /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.key;
 

--- a/config/nginx/conf.d/cantusdb.conf.staging
+++ b/config/nginx/conf.d/cantusdb.conf.staging
@@ -35,7 +35,7 @@ server {
     listen 443 default_server http2 ssl;
 
     server_name staging.cantusdatabase.org;
-	
+
     ssl_certificate /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.crt;
     ssl_certificate_key /etc/nginx/ssl/live/certificates/staging.cantusdatabase.org.key;
 
@@ -57,7 +57,7 @@ server {
         alias /resources/api_cache/concordances.json;
         expires modified +24h;
     }
- 
+
     location = /style.css {
         root /;
     }


### PR DESCRIPTION
This PR removes existing `default_server`s statements from `cantusdb.conf.staging` and `cantusdb.conf.production`, introducing new server blocks with `default_server` to handle and deny requests not matching a proper hostname. it fixes #1331

This PR also removes commented-out lines from `cantusdb.conf.development` and `cantusdb.conf.staging` - I had initially thought these would be helpful, but `cantusdb.conf.production` has been updated and this change has not been added to the comments in the two other files, and I was finding that the extra commented lines make things difficult to read anyways.