### PR TITLE
Fix layout for flatpages, articles templates

### DIFF
--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -4,7 +4,7 @@
 <div class="container">
     <title>{{ article.title }} | Cantus Manuscript Database</title>
     <div class="row">
-        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+        <div class="p-3 col-lg-8 bg-white rounded main-content">
             <h3>
                 {{ article.title }}
             </h3>
@@ -22,7 +22,7 @@
             </div>
         </div>
         <div class="col p-0 sidebar">
-            <div class="search-bar">
+            <div class="search-bar mb-3">
                 {% include "global_search_bar.html" %}
             </div>
             <div class="card mt-3 w-100">

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -4,7 +4,7 @@
 <div class="container">
     <title>What's New | Cantus Manuscript Database</title>
     <div class="row">
-        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+        <div class="p-3 col-lg-8 bg-white rounded main-content">
             <h3>What's New</h3>
             {% for article in articles %}
             <div class="row">
@@ -25,7 +25,7 @@
             <br>
         </div>
         <div class="col p-0 sidebar">
-            <div class="search-bar">
+            <div class="search-bar mb-3">
                 {% include "global_search_bar.html" %}
             </div>
 

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -4,13 +4,13 @@
 <div class="container">
     <title>{{ flatpage.title }} | Cantus Manuscript Database</title>
     <div class="row">
-        <div class="mr-3 p-3 col-lg-8 bg-white rounded">
+        <div class="p-3 col-lg-8 bg-white rounded main-content">
             <h2>{{ flatpage.title }}</h2>
             {{ flatpage.content }}
         </div>
         
         <div class="col p-0 sidebar">
-            <div class="search-bar">
+            <div class="search-bar mb-3">
                 {% include "global_search_bar.html" %}
             </div>
 
@@ -26,7 +26,7 @@
                 </div>
 
                 <script>
-                    function jumpSource() {
+                    function jumpSource() { 
                         sourceLink = document.getElementById("source-select").options[document.getElementById("source-select").selectedIndex].value;
                         fullLink = window.location.origin + '/' + sourceLink;
                         window.location.assign(fullLink);


### PR DESCRIPTION
Fixes #1342

- Article List and Article Detail page both have one card in the sidebar; I applied the same changes as in `user_source_list.html` in #1332.
- Flatpages `default.html` has three cards in sidebar; I applied the same changes as in `source_detail.html`.