### PR TITLE
Add link to new "Basic Principles" flat page in "About" menu

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -202,7 +202,7 @@
                                 <a class="dropdown-item" href="/about/faq/">FAQ</a>
                                 <a class="dropdown-item" href="https://www.youtube.com/watch?v=iMmGrUxhPj4" target="_blank">Short Video
                                     Introduction (YouTube)</a>
-                                <a class="dropdown-item" href="/about/principles_of_indexing/">Basic Principles of Indexing</a>
+                                <a class="dropdown-item" href="/about/principles-of-indexing/">Basic Principles of Indexing</a>
                                 {% if request.user.is_authenticated %}
                                     <a class="dropdown-item" href="{% url 'items-count' %}">Items Count</a>
                                 {% endif %}

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -202,6 +202,7 @@
                                 <a class="dropdown-item" href="/about/faq/">FAQ</a>
                                 <a class="dropdown-item" href="https://www.youtube.com/watch?v=iMmGrUxhPj4" target="_blank">Short Video
                                     Introduction (YouTube)</a>
+                                <a class="dropdown-item" href="/about/principles_of_indexing/">Basic Principles of Indexing</a>
                                 {% if request.user.is_authenticated %}
                                     <a class="dropdown-item" href="{% url 'items-count' %}">Items Count</a>
                                 {% endif %}


### PR DESCRIPTION
Debra created a new flatpage at https://cantusdatabase.org/about/principles_of_indexing/. This PR adds the flat page to the "About" dropdown.

**Screenshot with new menu item in "About" dropdown**

![image](https://github.com/DDMAL/CantusDB/assets/11023634/b1622a1a-7ca6-4e40-9791-52877f74d607)
