### PR TITLE
Fix layout of pages that were missed earlier

### DIFF
--- a/django/cantusdb_project/main_app/templates/400.html
+++ b/django/cantusdb_project/main_app/templates/400.html
@@ -29,6 +29,7 @@
                 <h3>400</h3>
                 <h5>Bad Request</h5>
                 <br>
+                <p>Your request couldn't be understood by the server.</p>
             </div>
         </div>
     </div>

--- a/django/cantusdb_project/main_app/templates/400.html
+++ b/django/cantusdb_project/main_app/templates/400.html
@@ -25,7 +25,7 @@
     {% block content %}
     <div class="container">
         <div class="row">
-            <div class="mr-3 p-3 col-md-8 bg-white rounded">
+            <div class="p-3 col-12 bg-white rounded">
                 <h3>400</h3>
                 <h5>Bad Request</h5>
                 <br>

--- a/django/cantusdb_project/main_app/templates/403.html
+++ b/django/cantusdb_project/main_app/templates/403.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-8 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             <h3>403</h3>
             <h5>Access denied</h5>
             <br>

--- a/django/cantusdb_project/main_app/templates/404.html
+++ b/django/cantusdb_project/main_app/templates/404.html
@@ -6,9 +6,9 @@
             <h3>404</h3>
             <h5>Page not found</h5>
             <br>
-            <dl>
-                <dd>{{ exception }}</dd>
-            </dl> 
+            <p>
+                We couldn't find a page at this address.
+            </p>
         </div>
     </div>
 </div>

--- a/django/cantusdb_project/main_app/templates/404.html
+++ b/django/cantusdb_project/main_app/templates/404.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-8 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             <h3>404</h3>
             <h5>Page not found</h5>
             <br>

--- a/django/cantusdb_project/main_app/templates/chant_delete.html
+++ b/django/cantusdb_project/main_app/templates/chant_delete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <title>Delete Chant | Cantus Manuscript Database</title>
-<div class="mr-3 p-3 col-md-8 bg-white rounded">
+<div class="p-3 col-md-12 bg-white rounded">
     <form method="post">{% csrf_token %}
         <p>
             <span class="text-danger">

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -3,7 +3,7 @@
 {% block content %}
 <title>Content Overview | Cantus Manuscript Database</title>
 
-<div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
+<div class="p-3 col-12 mx-auto bg-white rounded">
     <h3>Content Overview</h3>
 
     <div class="row justify-content-center">
@@ -19,80 +19,82 @@
     </div>
     <div style="height:10px;"></div>
     {% if selected_model_name %}
-        <table class="table table-sm small table-bordered">
-            <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
-                {{ selected_model_name|capfirst }}</b></small>
-            <thead>
-                <tr>
-                    <th scope="col" class="text-wrap" style="text-align:center">Title / Incipit / Name</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Type</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Creation Date</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Creator</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Last Updated Date</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Last Updated By</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Operations</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for object in page_obj %}
+        <div class="table-responsive">
+            <table class="table table-sm small table-bordered">
+                <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}
+                    {{ selected_model_name|capfirst }}</b></small>
+                <thead>
                     <tr>
-                        {% if object.title %}
+                        <th scope="col" class="text-wrap" style="text-align:center">Title / Incipit / Name</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Type</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Creation Date</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Creator</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Last Updated Date</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Last Updated By</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Operations</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for object in page_obj %}
+                        <tr>
+                            {% if object.title %}
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
+                                </td>
+                            {% elif object.incipit %}
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{{ object.get_absolute_url }}"><b>{{ object.incipit|truncatechars:30 }}</b></a>
+                                </td>
+                            {% elif object.name %}
+                                <td class="text-wrap" style="text-align:center">
+                                    {% if object|classname == "Notation" or object|classname == "Segment" or object|classname == "RismSiglum" %}
+                                        <b>{{ object.name|truncatechars:30 }}
+                                    {% else %}
+                                        <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                    {% endif %}
+                                </td>
+                            {% elif object.full_name %}
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
+                                </td>
+                            {% else %}
+                                <td class="text-wrap" style="text-align:center">
+                                    <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
+                                </td>
+                            {% endif %}
+                            <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
+                            <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object.title|truncatechars:30 }}</b></a>
-                            </td>
-                        {% elif object.incipit %}
-                            <td class="text-wrap" style="text-align:center">
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object.incipit|truncatechars:30 }}</b></a>
-                            </td>
-                        {% elif object.name %}
-                            <td class="text-wrap" style="text-align:center">
-                                {% if object|classname == "Notation" or object|classname == "Segment" or object|classname == "RismSiglum" %}
-                                    <b>{{ object.name|truncatechars:30 }}
+                                {% if object.created_by is None %}
+                                    {{ object.created_by }}
                                 {% else %}
-                                    <a href="{{ object.get_absolute_url }}"><b>{{ object.name|truncatechars:30 }}</b></a>
+                                    <a href="{% url 'admin:users_user_change' object.created_by.id %}">
+                                        {{ object.created_by }}
+                                    </a>
                                 {% endif %}
                             </td>
-                        {% elif object.full_name %}
+                            <td class="text-wrap" style="text-align:center">{{ object.date_updated|date:'Y-m-d H:i' }}</td>
                             <td class="text-wrap" style="text-align:center">
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object.full_name }}</b></a>
-                            </td>
-                        {% else %}
-                            <td class="text-wrap" style="text-align:center">
-                                <a href="{{ object.get_absolute_url }}"><b>{{ object|classname }} Object</b></a>
-                            </td>
-                        {% endif %}
-                        <td class="text-wrap" style="text-align:center">{{ object|classname }}</td>
-                        <td class="text-wrap" style="text-align:center">{{ object.date_created|date:'Y-m-d H:i' }}</td>
-                        <td class="text-wrap" style="text-align:center">
-                            {% if object.created_by is None %}
-                                {{ object.created_by }}
-                            {% else %}
-                                <a href="{% url 'admin:users_user_change' object.created_by.id %}">
-                                    {{ object.created_by }}
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td class="text-wrap" style="text-align:center">{{ object.date_updated|date:'Y-m-d H:i' }}</td>
-                        <td class="text-wrap" style="text-align:center">
-                            {% if object.last_updated_by is None %}
-                                {{ object.last_updated_by }}
-                            {% else %}
-                                <a href="{% url 'admin:users_user_change' object.last_updated_by.id %}">
+                                {% if object.last_updated_by is None %}
                                     {{ object.last_updated_by }}
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td class="text-wrap" style="text-align:center">
-                            {% with class=object|classname %}
-                                <a href={% url class|admin_url_name:"change" object.id %}><b>Edit</b></a>
-                                |
-                                <a href={% url class|admin_url_name:"delete" object.id %}><b>Delete</b></a>
-                            {% endwith %}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                                {% else %}
+                                    <a href="{% url 'admin:users_user_change' object.last_updated_by.id %}">
+                                        {{ object.last_updated_by }}
+                                    </a>
+                                {% endif %}
+                            </td>
+                            <td class="text-wrap" style="text-align:center">
+                                {% with class=object|classname %}
+                                    <a href={% url class|admin_url_name:"change" object.id %}><b>Edit</b></a>
+                                    |
+                                    <a href={% url class|admin_url_name:"delete" object.id %}><b>Delete</b></a>
+                                {% endwith %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "pagination.html" %}
     {% else %}
         <div style="height:10px;"></div>

--- a/django/cantusdb_project/main_app/templates/registration/change_password.html
+++ b/django/cantusdb_project/main_app/templates/registration/change_password.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-12 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             
             <!--Display messages -->
             {% for message in messages %}

--- a/django/cantusdb_project/main_app/templates/registration/login.html
+++ b/django/cantusdb_project/main_app/templates/registration/login.html
@@ -3,7 +3,7 @@
 <title>Log in | Cantus Manuscript Database</title>
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-8 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             <!--Display "submit success" message -->
             {% if messages %}
             <div class="alert alert-success alert-dismissible">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password.html
@@ -4,7 +4,7 @@
 <title>Request Password Reset | Cantus Manuscript Database</title>
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-12 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             
             <!--Display messages -->
             {% for message in messages %}

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_complete.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_complete.html
@@ -4,7 +4,7 @@
 <title>Reset Password Complete | Cantus Manuscript Database</title>
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-12 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             <p>Your password has been set.  You may go ahead and log in now.</p>
 
             <p><a href="{{ login_url }}">Log in</a></p>

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_confirm.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_confirm.html
@@ -4,7 +4,7 @@
 <title>Reset Password | Cantus Manuscript Database</title>
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-12 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             {% if validlink %}
                 <p>Please enter your new password twice so we can verify you typed it in correctly.</p>
                 <form method="post">{% csrf_token %}

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_sent.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_sent.html
@@ -4,7 +4,7 @@
 <title>Password Reset Email Sent | Cantus Manuscript Database</title>
 <div class="container">
     <div class="row">
-        <div class="mr-3 p-3 col-md-12 bg-white rounded">
+        <div class="p-3 col-12 bg-white rounded">
             <h5>Password Reset Email Sent</h5>
             <p>We’ve emailed you instructions for resetting your password, if an account exists with the email you entered. You should receive them shortly.</p>
 

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -28,58 +28,60 @@
         </div>
     </form>
     {% if sequences %}
-        <table class="table table-bordered table-sm small">
-            <thead>
-                <tr>
-                    <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">AH</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for sequence in sequences %}
-                    <tr style="text-align:center">
-                        <td class="text-wrap">
-                            {% if sequence.source %}
-                                <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}">
-                                    <b>{{ sequence.source.siglum }}</b><br>
-                                </a>
-                            {% endif %}
-                            <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}
-                        </td>
-                        <td class="text-wrap">
-                            <a href="{% url 'sequence-detail' sequence.id %}">
-                                {{ sequence.incipit|default:"" }}
-                            </a>
-                        </td>
-                        <td class="text-wrap">
-                            {{ sequence.rubrics|default:"" }}
-                        </td>
-                        <td class="text-wrap">
-                            {{ sequence.analecta_hymnica|default:"" }}
-                        </td>
-                        <td class="text-wrap">
-                            {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
-                            <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
-                        </td>
-                        <td class="text-wrap">
-                            {{ sequence.col1 |default:"" }}
-                        </td>
-                        <td class="text-wrap">
-                            {{ sequence.col2 |default:"" }}
-                        </td>
-                        <td class="text-wrap">
-                            {{ sequence.col3 |default:"" }}
-                        </td>
+        <div class="table-responsive">
+            <table class="table table-bordered table-sm small">
+                <thead>
+                    <tr>
+                        <th scope="col" class="text-wrap" style="text-align:center">Siglum</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Text incipit</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Rubrics</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">AH</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Cantus ID</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Notes:1</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Notes:2</th>
+                        <th scope="col" class="text-wrap" style="text-align:center">Notes:3</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for sequence in sequences %}
+                        <tr style="text-align:center">
+                            <td class="text-wrap">
+                                {% if sequence.source %}
+                                    <a href="{% url 'source-detail' sequence.source.id %}" title="{{ sequence.source.title }}">
+                                        <b>{{ sequence.source.siglum }}</b><br>
+                                    </a>
+                                {% endif %}
+                                <b>{{ sequence.folio|default:"" }}</b> {{ sequence.s_sequence|default:"" }}
+                            </td>
+                            <td class="text-wrap">
+                                <a href="{% url 'sequence-detail' sequence.id %}">
+                                    {{ sequence.incipit|default:"" }}
+                                </a>
+                            </td>
+                            <td class="text-wrap">
+                                {{ sequence.rubrics|default:"" }}
+                            </td>
+                            <td class="text-wrap">
+                                {{ sequence.analecta_hymnica|default:"" }}
+                            </td>
+                            <td class="text-wrap">
+                                {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
+                                <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
+                            </td>
+                            <td class="text-wrap">
+                                {{ sequence.col1 |default:"" }}
+                            </td>
+                            <td class="text-wrap">
+                                {{ sequence.col2 |default:"" }}
+                            </td>
+                            <td class="text-wrap">
+                                {{ sequence.col3 |default:"" }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% else %}
         No sequences found.
     {% endif %}

--- a/django/cantusdb_project/main_app/templates/source_delete.html
+++ b/django/cantusdb_project/main_app/templates/source_delete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <title>Delete Source | Cantus Manuscript Database</title>
-<div class="mr-3 p-3 col-md-8 bg-white rounded">
+<div class="p-3 col-12 bg-white rounded">
     <form method="post">{% csrf_token %}
         <p>
             <span class="text-danger">


### PR DESCRIPTION
This PR updates the formatting of a handful of pages that were missed in #1332 and #1343. Unless otherwise specified, all these pages have been updated to take up `col-12` at all breakpoints, and not have an awkward gap on the right at the narrowest breakpoint:

- Error pages (`400.html`, `403.html`, `404.html`) have had their formatting updated
  - Also, a simple error message was added to `400.html`
  - and the error message on `404.html` was tweaked. It's still not Debra-approved, but at least it no longer says "Resolver404"
- the formatting of various registration pages (`change_password.html`, `login.html`, `reset_password_complese.html`, `reset_password_confirm.html`, `reset_password_sent.html` and `reset_password.html`) has been updated
- `chant_delete.html` and `source_delete.html` have had their formatting updated
- `sequence_list.html` - the table has been wrapped in a div with `class="table-responsive"`
- `content_overview.html` - the table has been wrapped in a div with `class="table-responsive"`

This PR thus fixes #1347 and #1349