### PR TITLE
Source Detail: Hide folio/feast dropdowns in sidebar for Bower sources

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -185,24 +185,28 @@
                 </div>
                 <div class="card-body">
                     <small>
-                        <!--a small selector of all folios of this source-->
-                        <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
-                            <option value="">Select a folio:</option>
-                            {% for folio in folios %}
-                                <option value="{{ folio }}">{{ folio }}</option>
-                            {% endfor %}
-                        </select>                              
-
-                        <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
-                            <option value="">Select a feast:</option>
-                            {% for folio, feast in feasts_with_folios %}
-                                <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
-                            {% endfor %}
-                        </select>
-
-                        <br>
                         {% if source.segment.id == 4063 %}
-                            {# only display this link for sources in the CANTUS segment #}
+                            {# all of the following are different ways to link to the Chant List page #}
+                            {# Since sources in the Bower segment contain no chants, the Chant List page #}
+                            {# is currently set up to raise a 404 if you try to access it for a source in #}
+                            {# the Bower segment. So, we need to display this section only for sources in #}
+                            {# the CANTUS segment #}
+                            <!--a small selector of all folios of this source-->
+                            <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
+                                <option value="">Select a folio:</option>
+                                {% for folio in folios %}
+                                    <option value="{{ folio }}">{{ folio }}</option>
+                                {% endfor %}
+                            </select>                              
+
+                            <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                                <option value="">Select a feast:</option>
+                                {% for folio, feast in feasts_with_folios %}
+                                    <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
+                                {% endfor %}
+                            </select>
+
+                            <br>
                             <a href="{% url "chant-list" source.id %}" class="guillemet" target="_blank">View all chants</a>
                         {% endif %}
                         <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>


### PR DESCRIPTION
Fixes #1049, as discussed in https://github.com/DDMAL/CantusDB/issues/1049#issuecomment-1991967697 and the comments following. This PR finishes work that was meant to have been done as part of #785, where we hid the "View all chants" link so as to prevent users from being able to access the Chant List page for sources in the Bower segment. But I missed that the dropdowns also link to this same page.

Before:
![Screenshot 2024-03-12 at 1 34 27 PM](https://github.com/DDMAL/CantusDB/assets/58090591/26191a15-c15e-4278-8b06-19f5384f96c0)

After:
![Screenshot 2024-03-12 at 1 31 01 PM](https://github.com/DDMAL/CantusDB/assets/58090591/0ebf51bd-ad9d-4b8a-bbf9-17cf3972e592)
