### PR TITLE
Refactor loading of environment variables

### DIFF
--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -38,36 +38,25 @@ SECRET_KEY = os.getenv("CANTUSDB_SECRET_KEY")
 
 PROJECT_ENVIRONMENT: Optional[str] = os.getenv("PROJECT_ENVIRONMENT")
 
-if PROJECT_ENVIRONMENT not in ("DEVELOPMENT", "STAGING", "PRODUCTION"):
+# DEBUG gets set to True below when PROJECT_ENVIRONMENT == "DEVELOPMENT"
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG: bool = False
+if PROJECT_ENVIRONMENT == "DEVELOPMENT":
+    ALLOWED_HOSTS = os.getenv("CANTUSDB_HOSTS_DEVELOPMENT").split(" ")
+    CSRF_TRUSTED_ORIGINS = os.getenv("CANTUSDB_ORIGINS_DEVELOPMENT").split(" ")
+    DEBUG = True
+elif PROJECT_ENVIRONMENT == "STAGING":
+    ALLOWED_HOSTS = os.getenv("CANTUSDB_HOSTS_STAGING").split(" ")
+    CSRF_TRUSTED_ORIGINS = os.getenv("CANTUSDB_ORIGINS_STAGING").split(" ")
+elif PROJECT_ENVIRONMENT == "PRODUCTION":
+    ALLOWED_HOSTS = os.getenv("CANTUSDB_HOSTS_PRODUCTION").split(" ")
+    CSRF_TRUSTED_ORIGINS = os.getenv("CANTUSDB_ORIGINS_PRODUCTION").split(" ")
+else:
     raise ValueError(
         "The PROJECT_ENVIRONMENT environment variable must be either "
         "DEVELOPMENT, STAGING, or PRODUCTION. "
         f"Its current value is {PROJECT_ENVIRONMENT}."
     )
-
-cantusdb_hosts: Optional[str] = os.getenv(f"CANTUSDB_HOSTS_{PROJECT_ENVIRONMENT}")
-cantusdb_origins: Optional[str] = os.getenv(f"CANTUSDB_ORIGINS_{PROJECT_ENVIRONMENT}")
-
-try:
-    ALLOWED_HOSTS: list = cantusdb_hosts.split(" ")
-except AttributeError:  # cantusdb_hosts is None
-    raise ValueError(
-        f"The PROJECT_ENVIRONMENT environment variable is set to {PROJECT_ENVIRONMENT}, "
-        f"yet the CANTUSDB_HOSTS_{PROJECT_ENVIRONMENT} environment variable is not set."
-    )
-
-try:
-    CSRF_TRUSTED_ORIGINS: list = cantusdb_origins.split(" ")
-except AttributeError:  # cantusdb_origins is None
-    raise ValueError(
-        f"The PROJECT_ENVIRONMENT environment variable is set to {PROJECT_ENVIRONMENT}, "
-        f"yet the CANTUSDB_ORIGINS_{PROJECT_ENVIRONMENT} environment variable is not set."
-    )
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
-if PROJECT_ENVIRONMENT == "DEVELOPMENT":
-    DEBUG = True
 
 
 # Application definition

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -25,7 +25,7 @@ MESSAGE_TAGS: dict = {
 }
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR: Optional[str] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 STATIC_ROOT: Optional[str] = os.getenv("CANTUSDB_STATIC_ROOT")
 MEDIA_ROOT: Optional[str] = os.getenv("CANTUSDB_MEDIA_ROOT")

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -16,7 +16,7 @@ from django.contrib.messages import constants as messages
 from typing import Optional
 
 # https://ordinarycoders.com/blog/article/django-messages-framework
-MESSAGE_TAGS = {
+MESSAGE_TAGS: dict = {
     messages.DEBUG: "alert-secondary",
     messages.INFO: "alert-info",
     messages.SUCCESS: "alert-success",
@@ -25,16 +25,16 @@ MESSAGE_TAGS = {
 }
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR: Optional[str] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-STATIC_ROOT = os.getenv("CANTUSDB_STATIC_ROOT")
-MEDIA_ROOT = os.getenv("CANTUSDB_MEDIA_ROOT")
+STATIC_ROOT: Optional[str] = os.getenv("CANTUSDB_STATIC_ROOT")
+MEDIA_ROOT: Optional[str] = os.getenv("CANTUSDB_MEDIA_ROOT")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("CANTUSDB_SECRET_KEY")
+SECRET_KEY: Optional[str] = os.getenv("CANTUSDB_SECRET_KEY")
 
 PROJECT_ENVIRONMENT: Optional[str] = os.getenv("PROJECT_ENVIRONMENT")
 
@@ -61,7 +61,7 @@ else:
 
 # Application definition
 
-INSTALLED_APPS = [
+INSTALLED_APPS: list[str] = [
     "dal",
     "dal_select2",
     "django.contrib.admin",
@@ -82,7 +82,7 @@ INSTALLED_APPS = [
     "users",
 ]
 
-MIDDLEWARE = [
+MIDDLEWARE: list[str] = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -94,9 +94,9 @@ MIDDLEWARE = [
     "reversion.middleware.RevisionMiddleware",
 ]
 
-ROOT_URLCONF = "cantusdb.urls"
+ROOT_URLCONF: str = "cantusdb.urls"
 
-TEMPLATES = [
+TEMPLATES: list[dict] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [os.path.join(BASE_DIR, "templates")],
@@ -113,15 +113,15 @@ TEMPLATES = [
     },
 ]
 
-TEMPLATE_LOADERS = "django.template.loaders.app_directories.load_template_source"
+TEMPLATE_LOADERS: str = "django.template.loaders.app_directories.load_template_source"
 
-WSGI_APPLICATION = "cantusdb.wsgi.application"
+WSGI_APPLICATION: str = "cantusdb.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 
-DATABASES = {
+DATABASES: dict = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": os.getenv("POSTGRES_DB"),
@@ -136,7 +136,7 @@ DATABASES = {
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
 
-AUTH_PASSWORD_VALIDATORS = [
+AUTH_PASSWORD_VALIDATORS: list[dict] = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
@@ -155,46 +155,46 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE: str = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE: str = "UTC"
 
-USE_I18N = True
+USE_I18N: bool = True
 
-USE_L10N = True
+USE_L10N: bool = True
 
-USE_TZ = True
+USE_TZ: bool = True
 
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
-STATIC_URL = "/static/"
+STATIC_URL: str = "/static/"
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+STATICFILES_DIRS: list[str] = [os.path.join(BASE_DIR, "static")]
 
-AUTH_USER_MODEL = "users.User"
-LOGIN_REDIRECT_URL = "/"
-LOGIN_URL = "/login/"
-LOGOUT_REDIRECT_URL = "/login/"
+AUTH_USER_MODEL: str = "users.User"
+LOGIN_REDIRECT_URL: str = "/"
+LOGIN_URL: str = "/login/"
+LOGOUT_REDIRECT_URL: str = "/login/"
 
-SITE_ID = 4
+SITE_ID: int = 4
 
 # New in django 3.2: specify the default type of auto-created primary keys
 # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+DEFAULT_AUTO_FIELD: str = "django.db.models.AutoField"
 
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "email-smtp.us-west-2.amazonaws.com"
-EMAIL_PORT = 587
-EMAIL_HOST_USER = os.getenv("AWS_EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = os.getenv("AWS_EMAIL_HOST_PASSWORD")
-EMAIL_USE_TLS = True
+EMAIL_BACKEND: str = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST: str = "email-smtp.us-west-2.amazonaws.com"
+EMAIL_PORT: int = 587
+EMAIL_HOST_USER: Optional[str] = os.getenv("AWS_EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD: Optional[str] = os.getenv("AWS_EMAIL_HOST_PASSWORD")
+EMAIL_USE_TLS: bool = True
 
-DEFAULT_FROM_EMAIL = "noreply@cantusdatabase.simssa.ca"
+DEFAULT_FROM_EMAIL: str = "noreply@cantusdatabase.simssa.ca"
 
 # automatically disable all panels which user can then manually enable
-DEBUG_TOOLBAR_CONFIG = {
+DEBUG_TOOLBAR_CONFIG: dict = {
     "DISABLE_PANELS": {
         "debug_toolbar.panels.history.HistoryPanel",
         "debug_toolbar.panels.versions.VersionsPanel",
@@ -213,7 +213,7 @@ DEBUG_TOOLBAR_CONFIG = {
     },
 }
 
-INTERNAL_IPS = [
+INTERNAL_IPS: list[str] = [
     "127.0.0.1",
 ]
 

--- a/django/cantusdb_project/main_app/context_processors.py
+++ b/django/cantusdb_project/main_app/context_processors.py
@@ -1,10 +1,18 @@
-import os
+from django.conf import settings
 
 
-def determine_project_environment(request):
-    project_environment: str = os.getenv("PROJECT_ENVIRONMENT")
-    # in cantusdb/settings.py, we've already checked that PROJECT_ENVIRONMENT is
-    # either PRODUCTION, STAGING or DEVELOPMENT
+def determine_project_environment(request) -> str:
+    """_summary_
+
+    Args:
+        request: a request.
+
+    Returns:
+        str: A string indicating the current value of the
+        PROJECT_ENVIRONMENT variable, which is read from an environment
+        variable in settings.py.
+
+    """
     return {
-        "PROJECT_ENVIRONMENT": project_environment,
+        "PROJECT_ENVIRONMENT": settings.PROJECT_ENVIRONMENT,
     }

--- a/django/cantusdb_project/main_app/context_processors.py
+++ b/django/cantusdb_project/main_app/context_processors.py
@@ -2,17 +2,9 @@ import os
 
 
 def determine_project_environment(request):
-    project_environment = os.getenv("PROJECT_ENVIRONMENT", None)
-    if not (
-        project_environment == "DEVELOPMENT"
-        or project_environment == "STAGING"
-        or project_environment == "PRODUCTION"
-    ):
-        raise ValueError(
-            "The PROJECT_ENVIRONMENT environment variable must be either "
-            "DEVELOPMENT, STAGING, or PRODUCTION. "
-            f"Its current value is {project_environment}."
-        )
+    project_environment: str = os.getenv("PROJECT_ENVIRONMENT")
+    # in cantusdb/settings.py, we've already checked that PROJECT_ENVIRONMENT is
+    # either PRODUCTION, STAGING or DEVELOPMENT
     return {
         "PROJECT_ENVIRONMENT": project_environment,
     }

--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -90,7 +90,7 @@ class ChantModelTest(TestCase):
         self.assertEqual(weight_search_term_dict, expected_dict)
 
     def test_get_concordances(self):
-        chant = Chant.objects.get(id=1)
+        chant = Chant.objects.first()
         chant_with_same_cantus_id = Chant.objects.create(
             cantus_id=chant.cantus_id, source=chant.source
         )


### PR DESCRIPTION
This PR reworks how environment variables are read:

- In `settings.py`, we've gotten rid of the series of simple `if` statements checking the value of `PROJECT_ENVIRONMENT`, replacing them with an `if` and a series of `elses`
- in `settings.py`, if `PROJECT_ENVIRONMENT` is not set to something reasonable, an exception with an informative error message is raised.
  - a similar error message used to be generated in `context_processors.py`, but it makes more sense that it be generated in `settings.py`, so it's been removed from the context processors file.
- `context_processors.py` now reads `PROJECT_ENVIRONMENT` from the project settings (as set in `settings.py`), rather than reading it from the environment variables.
- type annotations have been added throughout `settings.py`

In doing the above, it fixes #1383.

It was suggested that in case of misconfiguration, a safe fallback be specified. In talking about this with @dchiller, we both agreed that a misconfiguration should not pass silently, hence the exception that remains.