### PR TITLE
Bump Black to 24.3.0

### DIFF
--- a/django/cantusdb_project/cantusdb/urls.py
+++ b/django/cantusdb_project/cantusdb/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 from django.urls import include

--- a/django/cantusdb_project/main_app/models/base_model.py
+++ b/django/cantusdb_project/main_app/models/base_model.py
@@ -1,4 +1,5 @@
 """Defines a BaseModel to be extended by all other models"""
+
 from typing import List
 from django.db import models
 from django.urls import reverse

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -1,4 +1,5 @@
 """Functions to make fake objects to be used for testing"""
+
 import random
 from faker import Faker
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2886,7 +2886,7 @@ class ChantCreateViewTest(TestCase):
                 "c_sequence": "1",
                 # liquescents, to be converted to lowercase
                 #                    vv v v v v v v
-                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"
+                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz",
                 #                      ^ ^ ^ ^ ^ ^ ^^^^^^^^
                 # clefs, accidentals, etc., to be deleted
             },
@@ -3033,7 +3033,7 @@ class SourceEditChantsViewTest(TestCase):
                 "c_sequence": "1",
                 # liquescents, to be converted to lowercase
                 #                    vv v v v v v v
-                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"
+                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz",
                 #                      ^ ^ ^ ^ ^ ^ ^^^^^^^^
                 # clefs, accidentals, etc., to be deleted
             },
@@ -4510,7 +4510,9 @@ class SourceInventoryViewTest(TestCase):
         response = self.client.get(reverse("source-inventory", args=[source.id]))
         html: str = str(response.content)
         self.assertIn(diff_id, html)
-        expected_html_substring: str = f'<a href="https://differentiaedatabase.ca/differentia/{diff_id}" target="_blank">'
+        expected_html_substring: str = (
+            f'<a href="https://differentiaedatabase.ca/differentia/{diff_id}" target="_blank">'
+        )
         self.assertIn(expected_html_substring, html)
 
     def test_redirect_with_source_parameter(self):

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -3,7 +3,7 @@ asgiref==3.6.0
 astroid==2.4.2
 attrs==19.3.0
 backports.zoneinfo==0.2.1
-black==21.10b0
+black==24.3.0
 certifi==2023.7.22
 chardet==3.0.4
 charset-normalizer==2.0.12

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -36,7 +36,7 @@ sqlparse==0.4.4
 text-unidecode==1.3
 toml==0.10.1
 typed-ast==1.4.1
-typing-extensions==3.10.0.0
+typing-extensions==4.0.1
 ujson==5.9.0
 urllib3==1.26.18
 volpiano-display-utilities @ git+https://github.com/DDMAL/volpiano-display-utilities.git@v1.1.2

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -7,7 +7,7 @@ black==24.3.0
 certifi==2023.7.22
 chardet==3.0.4
 charset-normalizer==2.0.12
-click==7.1.2
+click==8.0.0
 coverage==5.3.1
 Django==4.2.11
 django-autocomplete-light==3.9.4

--- a/scripts/parse_link_checker_output.py
+++ b/scripts/parse_link_checker_output.py
@@ -1,4 +1,5 @@
 """Modules"""
+
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
I tried updating `black` from 21.10b0 to 24.3.0 as proposed by dependabot in #1381 and rebuilding, and it turns out that `black` 24.3.0 requires updated versions of `typing-extensions` and `click` as well.

This PR:
- bumps black from 21.10b0 to 24.3.0
- bumps typing-extensions from 3.10.0.0 to 4.0.1
- bumps click from 7.1.2 to 8.0.0
- updates several of our files to comply with the updated Black style
- in doing so, this PR replaces dependabot's - once this is merged, we should close #1381.

The container builds fine, and all tests pass.