### PR TITLE
Update csv-export view to use chants' sources' sigla

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5215,11 +5215,15 @@ class CsvExportTest(TestCase):
             "node_id",
         ]
         for t in expected_column_titles:
-            self.assertIn(t, header)
-
-        self.assertEqual(len(rows), NUM_CHANTS)
-        for row in rows:
-            self.assertEqual(len(header), len(row))
+            with self.subTest(expected_column=t):
+                self.assertIn(t, header)
+        with self.subTest(subtest="ensure a row exists for each chant"):
+            self.assertEqual(len(rows), NUM_CHANTS)
+        with self.subTest(
+            subtest="ensure all rows have the same number of columns as the header"
+        ):
+            for row in rows:
+                self.assertEqual(len(header), len(row))
 
     def test_published_vs_unpublished(self):
         published_source = make_fake_source(published=True)
@@ -5245,12 +5249,18 @@ class CsvExportTest(TestCase):
         split_content = list(csv.reader(content.splitlines(), delimiter=","))
         header, rows = split_content[0], split_content[1:]
 
-        self.assertEqual(len(rows), NUM_SEQUENCES)
-        for row in rows:
-            self.assertEqual(len(header), len(row))
-            self.assertNotEqual(
-                row[3], ""
-            )  # ensure that the .s_sequence field is being written to the "sequence" column
+        with self.subTest(subtest="ensure a row exists for each sequence"):
+            self.assertEqual(len(rows), NUM_SEQUENCES)
+        with self.subTest(
+            subtest="ensure all rows have the same number of columns as the header"
+        ):
+            for row in rows:
+                self.assertEqual(len(header), len(row))
+        with self.subTest(
+            subtest="ensure .s_sequence field is being written to the 'sequence' column"
+        ):
+            for row in rows:
+                self.assertNotEqual(row[3], "")
 
 
 class ChangePasswordViewTest(TestCase):

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -236,6 +236,7 @@ def csv_export(request, source_id):
         ]
     )
     for entry in entries:
+        siglum = entry.source.siglum if entry.source else ""
         feast = entry.feast.name if entry.feast else ""
         office = entry.office.name if entry.office else ""
         genre = entry.genre.name if entry.genre else ""
@@ -243,7 +244,7 @@ def csv_export(request, source_id):
 
         writer.writerow(
             [
-                entry.siglum,
+                siglum,
                 entry.marginalia,
                 entry.folio,
                 # if entry has a c_sequence, it's a Chant. If it doesn't, it's a Sequence, so write its s_sequence

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -235,8 +235,8 @@ def csv_export(request, source_id):
             "node_id",
         ]
     )
+    siglum = source.siglum
     for entry in entries:
-        siglum = entry.source.siglum if entry.source else ""
         feast = entry.feast.name if entry.feast else ""
         office = entry.office.name if entry.office else ""
         genre = entry.genre.name if entry.genre else ""


### PR DESCRIPTION
This PR updates our `csv-export` view, ensuring that we display chants' sources' sigla rather than the chants' sigla (which are legacy data which is sometimes out-of-date, and should never be displayed). This PR thus fixes #1365.

As part of this PR,
- CsvExportTest was updated to check for this change.
- I reworked CsvExportTest a bit, mostly adding subtests to annotate the various `assert`ions we were making.