### PR TITLE
Pre-populate office selector on Chant Create page

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2910,30 +2910,50 @@ class ChantCreateViewTest(TestCase):
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
 
     def test_initial_values(self):
+        # create a chant with a known folio, feast, office, c_sequence and image_link
         source: Source = make_fake_source()
+        folio: str = "001r"
+        sequence: int = 1
         feast: Feast = make_fake_feast()
         office: Office = make_fake_office()
-        # create a chant with a known feast and office
+        image_link: str = "https://www.youtube.com/watch?v=9bZkp7q19f0"
         self.client.post(
             reverse("chant-create", args=[source.id]),
             {
-                "manuscript_full_text_std_spelling": "this is a bog standard manuscript spelling textful",
-                "folio": "001r",
-                "c_sequence": "1",
+                "manuscript_full_text_std_spelling": "this is a bog standard manuscript textful spelling",
+                "folio": folio,
+                "c_sequence": str(sequence),
                 "feast": feast.id,
                 "office": office.id,
+                "image_link": image_link,
             },
         )
-        # when we request the page, the same feast and office should be preselected
-        request = self.client.get(
+
+        # when we request the Chant Create page, the same folio, feast, office and image_link should
+        # be preselected, and c_sequence should be incremented by 1.
+        response = self.client.get(
             reverse("chant-create", args=[source.id]),
         )
-        observed_initial_feast: int = request.context["form"].initial["feast"]
-        observed_intitial_office: int = request.context["form"].initial["office"]
+
+        observed_initial_folio: int = response.context["form"].initial["folio"]
+        with self.subTest(subtest="test initial value of folio field"):
+            self.assertEqual(observed_initial_folio, folio)
+
+        observed_initial_feast: int = response.context["form"].initial["feast"]
         with self.subTest(subtest="test initial value of feast feild"):
             self.assertEqual(observed_initial_feast, feast.id)
+
+        observed_initial_office: int = response.context["form"].initial["office"]
         with self.subTest(subtest="test initial value of office field"):
-            self.assertEqual(observed_intitial_office, office.id)
+            self.assertEqual(observed_initial_office, office.id)
+
+        observed_initial_sequence: int = response.context["form"].initial["c_sequence"]
+        with self.subTest(subtest="test initial value of c_sequence field"):
+            self.assertEqual(observed_initial_sequence, sequence + 1)
+
+        observed_initial_image: int = response.context["form"].initial["image_link"]
+        with self.subTest(subtest="test initial value of image_link field"):
+            self.assertEqual(observed_initial_image, image_link)
 
 
 class ChantDeleteViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2909,6 +2909,32 @@ class ChantCreateViewTest(TestCase):
         self.assertEqual(chant_2.volpiano, "abacadaeafagahaja")
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
 
+    def test_initial_values(self):
+        source: Source = make_fake_source()
+        feast: Feast = make_fake_feast()
+        office: Office = make_fake_office()
+        # create a chant with a known feast and office
+        self.client.post(
+            reverse("chant-create", args=[source.id]),
+            {
+                "manuscript_full_text_std_spelling": "this is a bog standard manuscript spelling textful",
+                "folio": "001r",
+                "c_sequence": "1",
+                "feast": feast.id,
+                "office": office.id,
+            },
+        )
+        # when we request the page, the same feast and office should be preselected
+        request = self.client.get(
+            reverse("chant-create", args=[source.id]),
+        )
+        observed_initial_feast: int = request.context["form"].initial["feast"]
+        observed_intitial_office: int = request.context["form"].initial["office"]
+        with self.subTest(subtest="test initial value of feast feild"):
+            self.assertEqual(observed_initial_feast, feast.id)
+        with self.subTest(subtest="test initial value of office field"):
+            self.assertEqual(observed_intitial_office, office.id)
+
 
 class ChantDeleteViewTest(TestCase):
     @classmethod

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -805,6 +805,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             }
         latest_folio = latest_chant.folio if latest_chant.folio else "001r"
         latest_feast = latest_chant.feast.id if latest_chant.feast else ""
+        latest_office = latest_chant.office.id if latest_chant.office else ""
         latest_seq = (
             latest_chant.c_sequence if latest_chant.c_sequence is not None else 0
         )
@@ -812,6 +813,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         return {
             "folio": latest_folio,
             "feast": latest_feast,
+            "office": latest_office,
             "c_sequence": latest_seq + 1,
             "image_link": latest_image,
         }


### PR DESCRIPTION
This PR fixes #915, pre-populating the office selector with the same office as the most recently created chant within the relevant source.

It adds a new test, `ChantCreateViewTest.test_initial_values`, with a subtest for the existing Feast pre-population feature, and a subtest for the new Office pre-population feature.