### PR TITLE
Merge staging into production, 2024 Apr 04 edition

### DIFF
--- a/django/cantusdb_project/cantusdb/urls.py
+++ b/django/cantusdb_project/cantusdb/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 from django.urls import include

--- a/django/cantusdb_project/main_app/models/base_model.py
+++ b/django/cantusdb_project/main_app/models/base_model.py
@@ -1,4 +1,5 @@
 """Defines a BaseModel to be extended by all other models"""
+
 from typing import List
 from django.db import models
 from django.urls import reverse

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -1,4 +1,5 @@
 """Functions to make fake objects to be used for testing"""
+
 import random
 from faker import Faker
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2910,30 +2910,50 @@ class ChantCreateViewTest(TestCase):
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
 
     def test_initial_values(self):
+        # create a chant with a known folio, feast, office, c_sequence and image_link
         source: Source = make_fake_source()
+        folio: str = "001r"
+        sequence: int = 1
         feast: Feast = make_fake_feast()
         office: Office = make_fake_office()
-        # create a chant with a known feast and office
+        image_link: str = "https://www.youtube.com/watch?v=9bZkp7q19f0"
         self.client.post(
             reverse("chant-create", args=[source.id]),
             {
-                "manuscript_full_text_std_spelling": "this is a bog standard manuscript spelling textful",
-                "folio": "001r",
-                "c_sequence": "1",
+                "manuscript_full_text_std_spelling": "this is a bog standard manuscript textful spelling",
+                "folio": folio,
+                "c_sequence": str(sequence),
                 "feast": feast.id,
                 "office": office.id,
+                "image_link": image_link,
             },
         )
-        # when we request the page, the same feast and office should be preselected
-        request = self.client.get(
+
+        # when we request the Chant Create page, the same folio, feast, office and image_link should
+        # be preselected, and c_sequence should be incremented by 1.
+        response = self.client.get(
             reverse("chant-create", args=[source.id]),
         )
-        observed_initial_feast: int = request.context["form"].initial["feast"]
-        observed_intitial_office: int = request.context["form"].initial["office"]
+
+        observed_initial_folio: int = response.context["form"].initial["folio"]
+        with self.subTest(subtest="test initial value of folio field"):
+            self.assertEqual(observed_initial_folio, folio)
+
+        observed_initial_feast: int = response.context["form"].initial["feast"]
         with self.subTest(subtest="test initial value of feast feild"):
             self.assertEqual(observed_initial_feast, feast.id)
+
+        observed_initial_office: int = response.context["form"].initial["office"]
         with self.subTest(subtest="test initial value of office field"):
-            self.assertEqual(observed_intitial_office, office.id)
+            self.assertEqual(observed_initial_office, office.id)
+
+        observed_initial_sequence: int = response.context["form"].initial["c_sequence"]
+        with self.subTest(subtest="test initial value of c_sequence field"):
+            self.assertEqual(observed_initial_sequence, sequence + 1)
+
+        observed_initial_image: int = response.context["form"].initial["image_link"]
+        with self.subTest(subtest="test initial value of image_link field"):
+            self.assertEqual(observed_initial_image, image_link)
 
 
 class ChantDeleteViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2886,7 +2886,7 @@ class ChantCreateViewTest(TestCase):
                 "c_sequence": "1",
                 # liquescents, to be converted to lowercase
                 #                    vv v v v v v v
-                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"
+                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz",
                 #                      ^ ^ ^ ^ ^ ^ ^^^^^^^^
                 # clefs, accidentals, etc., to be deleted
             },
@@ -3033,7 +3033,7 @@ class SourceEditChantsViewTest(TestCase):
                 "c_sequence": "1",
                 # liquescents, to be converted to lowercase
                 #                    vv v v v v v v
-                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz"
+                "volpiano": "9abcdefg)A-B1C2D3E4F5G67?. yiz",
                 #                      ^ ^ ^ ^ ^ ^ ^^^^^^^^
                 # clefs, accidentals, etc., to be deleted
             },
@@ -4510,7 +4510,9 @@ class SourceInventoryViewTest(TestCase):
         response = self.client.get(reverse("source-inventory", args=[source.id]))
         html: str = str(response.content)
         self.assertIn(diff_id, html)
-        expected_html_substring: str = f'<a href="https://differentiaedatabase.ca/differentia/{diff_id}" target="_blank">'
+        expected_html_substring: str = (
+            f'<a href="https://differentiaedatabase.ca/differentia/{diff_id}" target="_blank">'
+        )
         self.assertIn(expected_html_substring, html)
 
     def test_redirect_with_source_parameter(self):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -5215,11 +5215,15 @@ class CsvExportTest(TestCase):
             "node_id",
         ]
         for t in expected_column_titles:
-            self.assertIn(t, header)
-
-        self.assertEqual(len(rows), NUM_CHANTS)
-        for row in rows:
-            self.assertEqual(len(header), len(row))
+            with self.subTest(expected_column=t):
+                self.assertIn(t, header)
+        with self.subTest(subtest="ensure a row exists for each chant"):
+            self.assertEqual(len(rows), NUM_CHANTS)
+        with self.subTest(
+            subtest="ensure all rows have the same number of columns as the header"
+        ):
+            for row in rows:
+                self.assertEqual(len(header), len(row))
 
     def test_published_vs_unpublished(self):
         published_source = make_fake_source(published=True)
@@ -5245,12 +5249,18 @@ class CsvExportTest(TestCase):
         split_content = list(csv.reader(content.splitlines(), delimiter=","))
         header, rows = split_content[0], split_content[1:]
 
-        self.assertEqual(len(rows), NUM_SEQUENCES)
-        for row in rows:
-            self.assertEqual(len(header), len(row))
-            self.assertNotEqual(
-                row[3], ""
-            )  # ensure that the .s_sequence field is being written to the "sequence" column
+        with self.subTest(subtest="ensure a row exists for each sequence"):
+            self.assertEqual(len(rows), NUM_SEQUENCES)
+        with self.subTest(
+            subtest="ensure all rows have the same number of columns as the header"
+        ):
+            for row in rows:
+                self.assertEqual(len(header), len(row))
+        with self.subTest(
+            subtest="ensure .s_sequence field is being written to the 'sequence' column"
+        ):
+            for row in rows:
+                self.assertNotEqual(row[3], "")
 
 
 class ChangePasswordViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2909,6 +2909,32 @@ class ChantCreateViewTest(TestCase):
         self.assertEqual(chant_2.volpiano, "abacadaeafagahaja")
         self.assertEqual(chant_2.volpiano_intervals, "1-12-23-34-45-56-67-78-8")
 
+    def test_initial_values(self):
+        source: Source = make_fake_source()
+        feast: Feast = make_fake_feast()
+        office: Office = make_fake_office()
+        # create a chant with a known feast and office
+        self.client.post(
+            reverse("chant-create", args=[source.id]),
+            {
+                "manuscript_full_text_std_spelling": "this is a bog standard manuscript spelling textful",
+                "folio": "001r",
+                "c_sequence": "1",
+                "feast": feast.id,
+                "office": office.id,
+            },
+        )
+        # when we request the page, the same feast and office should be preselected
+        request = self.client.get(
+            reverse("chant-create", args=[source.id]),
+        )
+        observed_initial_feast: int = request.context["form"].initial["feast"]
+        observed_intitial_office: int = request.context["form"].initial["office"]
+        with self.subTest(subtest="test initial value of feast feild"):
+            self.assertEqual(observed_initial_feast, feast.id)
+        with self.subTest(subtest="test initial value of office field"):
+            self.assertEqual(observed_intitial_office, office.id)
+
 
 class ChantDeleteViewTest(TestCase):
     @classmethod

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -391,11 +391,6 @@ urlpatterns = [
         views.csv_export_redirect_from_old_path,
         name="csv-export-old-path",
     ),
-    path(
-        "ajax/concordance/<str:cantus_id>",
-        views.ajax_concordance_list,
-        name="ajax-concordance",
-    ),
     # content overview (for project managers)
     path(
         "content-overview/",

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -805,6 +805,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             }
         latest_folio = latest_chant.folio if latest_chant.folio else "001r"
         latest_feast = latest_chant.feast.id if latest_chant.feast else ""
+        latest_office = latest_chant.office.id if latest_chant.office else ""
         latest_seq = (
             latest_chant.c_sequence if latest_chant.c_sequence is not None else 0
         )
@@ -812,6 +813,7 @@ class ChantCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         return {
             "folio": latest_folio,
             "feast": latest_feast,
+            "office": latest_office,
             "c_sequence": latest_seq + 1,
             "image_link": latest_image,
         }

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -69,61 +69,6 @@ def items_count(request):
     return render(request, "items_count.html", context)
 
 
-def ajax_concordance_list(request, cantus_id):
-    """
-    Function-based view responding to the AJAX call for concordance list on the chant detail page,
-    accessed with ``chants/<int:pk>``, click on "Display concordances of this chant"
-
-    Args:
-        cantus_id (str): The Cantus ID of the requested concordances group
-
-    Returns:
-        JsonResponse: A response to the AJAX call, to be unpacked by the frontend js code
-    """
-    chants = Chant.objects.filter(cantus_id=cantus_id)
-    seqs = Sequence.objects.filter(cantus_id=cantus_id)
-
-    display_unpublished = request.user.is_authenticated
-    if not display_unpublished:
-        chants = chants.filter(source__published=True)
-        seqs = seqs.filter(source__published=True)
-
-    if seqs:
-        chants = chants.union(seqs).order_by("siglum", "folio")
-    else:
-        chants = chants.order_by("siglum", "folio")
-    # queryset(list of dictionaries)
-    concordance_values = chants.values(
-        "siglum",
-        "folio",
-        "incipit",
-        "office__name",
-        "genre__name",
-        "position",
-        "feast__name",
-        "mode",
-        "image_link",
-    )
-
-    concordances = list(concordance_values)
-    for i, concordance in enumerate(concordances):
-        # some chants do not have a source
-        # for those chants, do not return source link
-        if chants[i].source:
-            concordance["source_link"] = chants[i].source.get_absolute_url()
-        if chants[i].search_vector:
-            concordance["chant_link"] = chants[i].get_absolute_url()
-        else:
-            concordance["chant_link"] = reverse("sequence-detail", args=[chants[i].id])
-        concordance["db"] = "CD"
-
-    concordance_count = len(concordances)
-    return JsonResponse(
-        {"concordances": concordances, "concordance_count": concordance_count},
-        safe=True,
-    )
-
-
 def ajax_melody_list(request, cantus_id) -> JsonResponse:
     """
     Function-based view responding to the AJAX call for melody list on the chant detail page,

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -236,6 +236,7 @@ def csv_export(request, source_id):
         ]
     )
     for entry in entries:
+        siglum = entry.source.siglum if entry.source else ""
         feast = entry.feast.name if entry.feast else ""
         office = entry.office.name if entry.office else ""
         genre = entry.genre.name if entry.genre else ""
@@ -243,7 +244,7 @@ def csv_export(request, source_id):
 
         writer.writerow(
             [
-                entry.siglum,
+                siglum,
                 entry.marginalia,
                 entry.folio,
                 # if entry has a c_sequence, it's a Chant. If it doesn't, it's a Sequence, so write its s_sequence

--- a/django/cantusdb_project/main_app/views/views.py
+++ b/django/cantusdb_project/main_app/views/views.py
@@ -235,8 +235,8 @@ def csv_export(request, source_id):
             "node_id",
         ]
     )
+    siglum = source.siglum
     for entry in entries:
-        siglum = entry.source.siglum if entry.source else ""
         feast = entry.feast.name if entry.feast else ""
         office = entry.office.name if entry.office else ""
         genre = entry.genre.name if entry.genre else ""

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -3,7 +3,7 @@ asgiref==3.6.0
 astroid==2.4.2
 attrs==19.3.0
 backports.zoneinfo==0.2.1
-black==21.10b0
+black==24.3.0
 certifi==2023.7.22
 chardet==3.0.4
 charset-normalizer==2.0.12

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -36,7 +36,7 @@ sqlparse==0.4.4
 text-unidecode==1.3
 toml==0.10.1
 typed-ast==1.4.1
-typing-extensions==3.10.0.0
+typing-extensions==4.0.1
 ujson==5.9.0
 urllib3==1.26.18
 volpiano-display-utilities @ git+https://github.com/DDMAL/volpiano-display-utilities.git@v1.1.2

--- a/django/cantusdb_project/requirements.txt
+++ b/django/cantusdb_project/requirements.txt
@@ -7,7 +7,7 @@ black==24.3.0
 certifi==2023.7.22
 chardet==3.0.4
 charset-normalizer==2.0.12
-click==7.1.2
+click==8.0.0
 coverage==5.3.1
 Django==4.2.11
 django-autocomplete-light==3.9.4

--- a/scripts/parse_link_checker_output.py
+++ b/scripts/parse_link_checker_output.py
@@ -1,4 +1,5 @@
 """Modules"""
+
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
Changes:

- Dependencies:
  - black bumped from 21.10b0 to 24.3.0
  - typing-extensions bumped from 3.10.0.0 to 4.0.1
  - click bumped from 7.1.2 to 8.0.0
- Tests
  - `main_app.tests.test_views.CsvExportTest` updated to use subtests
  - `main_app.tests.test_views.ChantCreateViewTest` had several tests added to ensure the `get_initial` method works as expected
- Ajax Concordance List - view removed
- [x] Chant Create
  - we now pre-populate the form's "Office" field using the same office as the most recently modified chant in the same source (should work the same way as the "Feast" field)
- [x] CSV Export
  - We now display the source's siglum in the "siglum" column, rather than each chant's individual siglum
