### PR TITLE
Rename Office -> Service in public-facing views

### DIFF
--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -62,7 +62,7 @@
                             <th scope="col" class="text-wrap" title="Sequence"></th>
                             <th scope="col" class="text-wrap" title="Incipit / Full text">Incipit / Full text</th>
                             <th scope="col" class="text-wrap" title="Feast">Feast</th>
-                            <th scope="col" class="text-wrap" title="Office"></th>
+                            <th scope="col" class="text-wrap" title="Service"></th>
                             <th scope="col" class="text-wrap" title="Genre"></th>
                             <th scope="col" class="text-wrap" title="Position"></th>
                             <th scope="col" class="text-wrap" title="Cantus ID">CantusID</th>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -61,7 +61,7 @@
 
                 <div class="form-row">
                     <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.office.id_for_label }}"><small>Office/Mass:</small></label>
+                        <label for="{{ form.office.id_for_label }}"><small>Service:</small></label>
                         <br>{{ form.office }}
                         <a href="/description/#Office"><small>?</small></a>
                     </div>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -71,7 +71,7 @@
                 
                     {% if chant.office %}
                         <div class="form-group col-lg-2 col-sm-6 col-6">
-                            <dt>Office/Mass</dt>
+                            <dt>Service</dt>
                             <dd>
                                 <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                             </dd>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -68,7 +68,7 @@
 
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-3">
-                            <small>{{ form.office.label_tag }}</small>
+                            <label for="{{ form.office.id_for_label }}"><small>Service:</small></label>
                             <br>{{ form.office }}
                         </div>
                     </div>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -48,7 +48,7 @@
         </div>
         <div class="form-row align-items-end">
             <div class="form-group m-1 col-lg-3 col-sm-6">
-                <label for="officeFilter"><small>Office/Mass</small></label>
+                <label for="officeFilter"><small>Service</small></label>
                 <select id="officeFilter" name="office" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>
                     {% for office in offices %}
@@ -132,15 +132,15 @@
                             <th scope="col" class="text-wrap" style="text-align:center" title="Feast">
                                 Feast
                             </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Office">
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Service">
                                 {% if order == "office" %}
                                     {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a> ▼
+                                        <a href="{{ url_with_search_params }}&order=office&sort=asc">Service</a> ▼
                                     {% else %}
-                                        <a href="{{ url_with_search_params }}&order=office&sort=desc">Office<br>/Mass</a> ▲
+                                        <a href="{{ url_with_search_params }}&order=office&sort=desc">Service</a> ▲
                                     {% endif %}
                                 {% else %}
-                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Office<br>/Mass</a>
+                                    <a href="{{ url_with_search_params }}&order=office&sort=asc">Service</a>
                                 {% endif %}
                             </th>
                             <th scope="col" class="text-wrap" style="text-align:center" title="Genre">

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -19,7 +19,7 @@
                     <th scope="col" class="text-wrap" title="Source">Source</th>
                     <th scope="col" class="text-wrap" title="Folio">Folio</th>
                     <th scope="col" class="text-wrap" title="Title">Title</th>
-                    <th scope="col" class="text-wrap" title="Office">Office </th>
+                    <th scope="col" class="text-wrap" title="Service">Service</th>
                     <th scope="col" class="text-wrap" title="Genre">Genre </th>
                     <th scope="col" class="text-wrap" title="Position">Position</th>
                     <th scope="col" class="text-wrap" title="Feast">Feast</th>

--- a/django/cantusdb_project/main_app/templates/full_inventory.html
+++ b/django/cantusdb_project/main_app/templates/full_inventory.html
@@ -31,7 +31,7 @@
                 <th width="30" title="Folio">Folio</th>
                 <th width="30" title="Sequence">Seq</th>
                 <th width="80" title="Feast">Feast</th>
-                <th width="30" title="Office">Office</th>
+                <th width="30" title="Service">Service</th>
                 <th width="30" title="Genre">Genre</th>
                 <th width="30" title="Position">Pos</th>
                 <th width="200" title="Incipit">Incipit</th>

--- a/django/cantusdb_project/main_app/templates/office_list.html
+++ b/django/cantusdb_project/main_app/templates/office_list.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Office/Mass Abbreviations | Cantus Manuscript Database</title>
+<title>Service Abbreviations | Cantus Manuscript Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}
     </object>
-    <h3>Office/Mass Abbreviations</h3>
+    <h3>Service Abbreviations</h3>
     <small>Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }}</small>
     <table class="table table-bordered table-sm small">
         <thead>
             <tr>
-                <th scope="col" class="text-wrap">Office</th>
-                <th scope="col" class="text-wrap">Description</th>
+                <th scope="col" class="text-wrap" title="Service">Service</th>
+                <th scope="col" class="text-wrap" title="Description">Description</th>
             </tr>
         </thead>
         <tbody>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -252,7 +252,7 @@
                             </a>
                             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                                 <a class="dropdown-item" href="{% url 'genre-list' %}">Genre abbreviations</a>
-                                <a class="dropdown-item" href="{% url 'office-list' %}">Office/Mass abbreviations</a>
+                                <a class="dropdown-item" href="{% url 'office-list' %}">Service abbreviations</a>
                                 <a class="dropdown-item" href="/description/">Fields</a>
                             </div>
                         </li>


### PR DESCRIPTION
This PR replaces "Office" and "Office/Mass" in outward-facing views with "Service". In doing so, it fixes #1367.

Note that in a couple of parts of the site, "Office/Mass" appears in the specific sense of indicating whether a particular Genre is "performed" during an Office or during a Mass (e.g., see https://cantusdatabase.org/genres/). Such instances are unchanged.

This PR does not attempt to change any URL paths or change how "service" objects are represented in the codebase (i.e., variable names, the name of the Office model, etc.). I'll open two new issues so that these things might be addressed.