### PR TITLE
Remove Query Parameters from Links to Homepage

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -166,7 +166,7 @@
         <!-- Navbar -->
         <div class="container p-0">
             <nav class="navbar navbar-expand-lg navbar-light bg-white border-top col-12">
-                <a class="navbar-brand" href="/?ref=navbar_logo">
+                <a class="navbar-brand" href="/">
                     <img src="{% static "CantusLogoSmall.gif" %}" alt="Cantus Database home" title="Cantus Database Home" loading="lazy">
                 </a>
 
@@ -186,7 +186,7 @@
                                 ABOUT
                             </a>
                             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                                <a class="dropdown-item" href="/?ref=navbar_about">Home</a>
+                                <a class="dropdown-item" href="/">Home</a>
                                 <a class="dropdown-item" href="{% url 'article-list' %}">News</a>
                                 <a class="dropdown-item" href="{% url 'indexer-list' %}">Contributors</a>
                                 <a class="dropdown-item" href="/about/id-numbers/">ID Numbers: A History and


### PR DESCRIPTION
This PR removes query parameters from the 2 links to the home page in the NavBar.  It fixes #1399. 