### PR TITLE
Fixed: Load project environment from settings

### DIFF
--- a/django/cantusdb_project/main_app/context_processors.py
+++ b/django/cantusdb_project/main_app/context_processors.py
@@ -1,18 +1,7 @@
-import os
+from django.conf import settings
 
 
 def determine_project_environment(request):
-    project_environment = os.getenv("PROJECT_ENVIRONMENT", None)
-    if not (
-        project_environment == "DEVELOPMENT"
-        or project_environment == "STAGING"
-        or project_environment == "PRODUCTION"
-    ):
-        raise ValueError(
-            "The PROJECT_ENVIRONMENT environment variable must be either "
-            "DEVELOPMENT, STAGING, or PRODUCTION. "
-            f"Its current value is {project_environment}."
-        )
     return {
-        "PROJECT_ENVIRONMENT": project_environment,
+        "PROJECT_ENVIRONMENT": settings.PROJECT_ENVIRONMENT,
     }


### PR DESCRIPTION
Refactors the context processor to load the PROJECT_ENVIRONMENT variable from the settings file, instead of reading it directly from the environment. (The settings file also reads it from the environment, so it's still the same source, it's just set in one place, not two.)

Refs #1383
Refs #1384