### PR TITLE
Chant Create: Reimplement Suggested Chants feature

### DIFF
--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -119,7 +119,7 @@ def get_json_from_ci_api(
     try:
         response: requests.Response = requests.get(uri, timeout=timeout)
     except requests.exceptions.Timeout:
-        return {}
+        return None
 
     response.encoding = "utf-8-sig"
     return response.json()

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -33,7 +33,7 @@ def get_suggested_chants(
     if not isinstance(first_suggestion, dict):
         return None
 
-    sort_by_occurrences: function = lambda suggestion: int(suggestion["count"])
+    sort_by_occurrences: Callable[[dict], int] = lambda suggestion: int(suggestion["count"])
     sorted_suggestions: list = sorted(
         all_suggestions, key=sort_by_occurrences, reverse=True
     )

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -76,11 +76,11 @@ def get_suggested_chant(
         return None
 
     fulltext: str = json["info"]["field_full_text"]
-    incipit = " ".join(fulltext.split(" ")[:5])
+    incipit: str = " ".join(fulltext.split(" ")[:5])
     genre_name: str = json["info"]["field_genre"]
     genre_id: Optional[int] = None
     try:
-        genre_id: Optional[Genre] = Genre.objects.get(name=genre_name).id
+        genre_id = Genre.objects.get(name=genre_name).id
     except Genre.DoesNotExist:
         pass
 

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -9,7 +9,7 @@ from main_app.models import Genre
 
 CANTUS_INDEX_DOMAIN: str = "https://cantusindex.uwaterloo.ca"
 DEFAULT_TIMEOUT: float = 2  # seconds
-NUMBER_OF_SUGGESTED_CHANTS: int = 5  # this number can't be too large,
+NUMBER_OF_SUGGESTED_CHANTS: int = 3  # this number can't be too large,
 # since for each suggested chant, we make a request to Cantus Index.
 # We haven't yet parallelized this process, so setting this number
 # too high will cause the Chant Create page to take a very long time

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -22,8 +22,11 @@ def get_suggested_chants(
 ) -> Optional[list[dict]]:
     endpoint_path: str = f"/json-nextchants/{cantus_id}"
     all_suggestions: Optional[list] = get_json_from_ci_api(endpoint_path)
+
     if not all_suggestions:
-        return None  # get_json_from_ci_api timed out
+        # get_json_from_ci_api timed out
+        # or CI returned a response with no suggestions.
+        return None
 
     # when Cantus ID doesn't exist within CI, CI's api returns a 200 response with `['Cantus ID is not valid']`
     first_suggestion = all_suggestions[0]
@@ -138,4 +141,10 @@ def get_json_from_ci_api(
         return None  # /json-cid/Non-existentCantusId returns a 500 page
 
     response.encoding = "utf-8-sig"
+
+    if not response.text.strip():
+        # /json-nextchants returns a response with text='\r\n' in situations where
+        # there are no suggested chants
+        return None
+
     return response.json()

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -4,7 +4,7 @@ Cantus Index's (CI's) various APIs.
 """
 
 import requests
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 from main_app.models import Genre
 
 CANTUS_INDEX_DOMAIN: str = "https://cantusindex.uwaterloo.ca"
@@ -33,7 +33,9 @@ def get_suggested_chants(
     if not isinstance(first_suggestion, dict):
         return None
 
-    sort_by_occurrences: Callable[[dict], int] = lambda suggestion: int(suggestion["count"])
+    sort_by_occurrences: Callable[[dict], int] = lambda suggestion: int(
+        suggestion["count"]
+    )
     sorted_suggestions: list = sorted(
         all_suggestions, key=sort_by_occurrences, reverse=True
     )

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -19,12 +19,17 @@ NUMBER_OF_SUGGESTED_CHANTS: int = 5  # this number can't be too large,
 
 def get_suggested_chants(
     cantus_id: str, number_of_suggestions: int = NUMBER_OF_SUGGESTED_CHANTS
-) -> list[dict]:
+) -> Optional[list[dict]]:
     endpoint_path: str = f"/json-nextchants/{cantus_id}"
-    all_suggestions: list = get_json_from_ci_api(endpoint_path)
+    all_suggestions: Optional[list] = get_json_from_ci_api(endpoint_path)
+    if not all_suggestions:
+        return None  # get_json_from_ci_api timed out
+
     sort_by_occurrences: function = lambda suggestion: int(suggestion["count"])
-    sorted_suggestions = sorted(all_suggestions, key=sort_by_occurrences, reverse=True)
-    trimmed_suggestions = sorted_suggestions[:number_of_suggestions]
+    sorted_suggestions: list = sorted(
+        all_suggestions, key=sort_by_occurrences, reverse=True
+    )
+    trimmed_suggestions: list = sorted_suggestions[:number_of_suggestions]
 
     suggested_chants: list[dict] = []
     for suggestion in trimmed_suggestions:

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -110,7 +110,7 @@ def get_suggested_chant(
 
 
 def get_json_from_ci_api(
-    path: str, timeout: int = DEFAULT_TIMEOUT
+    path: str, timeout: float = DEFAULT_TIMEOUT
 ) -> Union[dict, list, None]:
     """Given a path, send a request to Cantus Index at that path,
     decode the response to remove its Byte Order Marker, parse it,

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -21,9 +21,9 @@ def get_suggested_chants(
     cantus_id: str, number_of_suggestions: int = NUMBER_OF_SUGGESTED_CHANTS
 ) -> Optional[list[dict]]:
     endpoint_path: str = f"/json-nextchants/{cantus_id}"
-    all_suggestions: Optional[list] = get_json_from_ci_api(endpoint_path)
+    all_suggestions: Union[list, dict, None] = get_json_from_ci_api(endpoint_path)
 
-    if not all_suggestions:
+    if not isinstance(all_suggestions, list):
         # get_json_from_ci_api timed out
         # or CI returned a response with no suggestions.
         return None

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -84,9 +84,10 @@ def get_suggested_chant(
             ...but if get_json_from_ci_api timed out, returns None instead
     """
     endpoint_path: str = f"/json-cid/{cantus_id}"
-    json: dict = get_json_from_ci_api(endpoint_path, timeout=timeout)
+    json: Union[dict, list, None] = get_json_from_ci_api(endpoint_path, timeout=timeout)
 
-    if not json:  # mostly, in case of a timeout within get_json_from_ci_api
+    if not isinstance(json, dict):
+        # mostly, in case of a timeout within get_json_from_ci_api
         return None
 
     fulltext: str = json["info"]["field_full_text"]

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -4,7 +4,6 @@ Cantus Index's (CI's) various APIs.
 """
 
 import requests
-from codecs import decode
 from typing import Optional, Union
 from main_app.models import Genre
 

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -41,7 +41,7 @@ def get_suggested_chants(
     )
     trimmed_suggestions: list = sorted_suggestions[:number_of_suggestions]
 
-    suggested_chants: list[dict] = []
+    suggested_chants: list[Optional[dict]] = []
     for suggestion in trimmed_suggestions:
         cantus_id: str = suggestion["cid"]
         occurrences: int = int(suggestion["count"])

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -1,0 +1,118 @@
+"""
+A collection of functions for fetching data from
+Cantus Index's (CI's) various APIs.
+"""
+
+import requests
+from codecs import decode
+from typing import Optional, Union
+from main_app.models import Genre
+
+CANTUS_INDEX_DOMAIN = "https://cantusindex.uwaterloo.ca"
+DEFAULT_TIMEOUT = 2  # seconds
+NUMBER_OF_SUGGESTED_CHANTS = 5  # this number can't be too large,
+# since for each suggested chant, we make a request to Cantus Index.
+# We haven't yet parallelized this process, so setting this number
+# too high will cause the Chant Create page to take a very long time
+# to load. If/when we parallelize this process, we want to limit
+# the size of the burst of requests sent to CantusIndex.
+
+
+def get_suggested_chants(
+    cantus_id: str, number_of_suggestions: int = NUMBER_OF_SUGGESTED_CHANTS
+) -> list[dict]:
+    endpoint_path: str = f"/json-nextchants/{cantus_id}"
+    all_suggestions: list = get_json_from_ci_api(endpoint_path)
+    sort_by_occurrences: function = lambda suggestion: int(suggestion["count"])
+    sorted_suggestions = sorted(all_suggestions, key=sort_by_occurrences, reverse=True)
+    trimmed_suggestions = sorted_suggestions[:number_of_suggestions]
+
+    suggested_chants: list[dict] = []
+    for suggestion in trimmed_suggestions:
+        cantus_id = suggestion["cid"]
+        occurrences = suggestion["count"]
+        suggested_chants.append(get_suggested_chant(cantus_id, occurrences))
+
+    # filter out Cantus IDs where get_suggested_chant timed out
+    filtered_suggestions = [sugg for sugg in suggested_chants if sugg is not None]
+
+    return filtered_suggestions
+
+
+def get_suggested_chant(cantus_id: str, occurrences: int) -> Optional[dict]:
+    """Given a Cantus ID and a number of occurrences, query one of Cantus Index's
+    APIs for information on that Cantus ID and return a dictionary
+    containing a full text, an incipit, the ID of that Cantus ID's genre, and
+    the number of occurrences for that Cantus ID
+
+    (Number of occurrences: this function is used on the Chant Create page,
+    to suggest Cantus IDs of chants that might follow a chant with the Cantus ID
+    of the most recently created chant within the current source. Number of occurrences
+    is provided by Cantus Index's /nextchants API, based on which chants follow which
+    other chants in existing manuscripts)
+
+    Args:
+        cantus_id (str): a Cantus ID
+        occurrences (int): the number of times chants with this Cantus ID follow chants
+            with the Cantus ID of the most recently created chant.
+
+    Returns:
+        Optional[dict]: A dictionary with the following keys:
+            - "cantus_id"
+            - "occurrences"
+            - "fulltext"
+            - "incipit"
+            - "genre_id"
+            ...but if get_json_from_ci_api timed out, returns None instead
+    """
+    endpoint_path: str = f"/json-cid/{cantus_id}"
+    json: dict = get_json_from_ci_api(endpoint_path)
+
+    if not json:  # mostly, in case of a timeout within get_json_from_ci_api
+        return None
+
+    fulltext: str = json["info"]["field_full_text"]
+    incipit = " ".join(fulltext.split(" ")[:5])
+    genre_name: str = json["info"]["field_genre"]
+    genre: Genre = Genre.objects.get(name=genre_name)
+    genre_id: int = genre.id
+
+    return {
+        "cantus_id": cantus_id,
+        "occurrences": occurrences,
+        "fulltext": fulltext,
+        "incipit": incipit,
+        "genre_id": genre_id,
+    }
+
+
+def get_json_from_ci_api(
+    path: str, timeout: int = DEFAULT_TIMEOUT
+) -> Union[dict, list, None]:
+    """Given a path, send a request to Cantus Index at that path,
+    decode the response to remove its Byte Order Marker, parse it,
+    and return it as a dictionary or list.
+
+    Args:
+        path (str): The path of the Cantus Index endpoint, including a leading "/"
+        timeout (int): how long to wait for a response before giving
+            up and returning None.
+
+    Returns:
+        Union[dict, list, None]:
+            If the JSON returned from Cantus Index is a JSON object, returns a dict.
+            If the JSON returned is a JSON array, returns a list.
+            In case the request times out, returns None.
+    """
+
+    if not path.startswith("/"):
+        raise ValueError('path must begin with "/"')
+
+    uri = f"{CANTUS_INDEX_DOMAIN}{path}"
+    try:
+        response: requests.Response = requests.get(uri, timeout=timeout)
+    except requests.exceptions.Timeout:
+        return {}
+
+    response.encoding = "utf-8-sig"
+    return response.json()

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -277,32 +277,19 @@
                             </div>
                         {% if suggested_chants %}
                             {% for suggestion in suggested_chants %}
-                                <input type="button" style="width: 80px" value="{{ suggestion.cantus_id }}" onclick="autoFill{{ suggestion.clean_cantus_id }}()" title="{{ suggestion.cantus_id }}"></input>
+                                <input
+                                    type="button"
+                                    style="width: 80px"
+                                    value="{{ suggestion.cantus_id }}"
+                                    title="{{ suggestion.cantus_id }}"
+                                    onclick='autoFillSuggestedChant(
+                                        "{{suggestion.genre_name}}",
+                                        {{suggestion.genre_id | default_if_none:"null"}},
+                                        "{{suggestion.cantus_id}}",
+                                        "{{suggestion.fulltext}}"
+                                    )'
+                                >
                                 <strong>{{ suggestion.genre_name }}</strong> - <span title="{{ suggestion.fulltext }}">{{ suggestion.incipit }}</span> (<strong>{{ suggestion.occurrences }}x</strong>)<br>
-                                <script>
-                                    function autoFill{{ suggestion.clean_cantus_id }}() {
-                                        document.getElementById('id_cantus_id').value = "{{ suggestion.cantus_id }}";
-                                        document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ suggestion.fulltext }}";
-                                        var genre_id = {{ suggestion.genre_id | default_if_none:"null" }};
-                                        var genre_name = "{{ suggestion.genre_name }}";
-
-                                        // in case suggestion.genre_id is None, don't try to change the #id_genre selector
-                                        if (genre_id === null) {
-                                            return
-                                        }
-                                        // Since we're using a django-autocomplete-light widget for the Genre selector,
-                                        // we need to follow a special process in selecting a value from the widget:
-                                        // Set the value, creating a new option if necessary
-                                        if ($('#id_genre').find("option[value='" + genre_id + "']").length) {
-                                            $('#id_genre').val(genre_id).trigger('change');
-                                        } else { 
-                                            // Create a DOM Option and pre-select by default
-                                            var newOption = new Option(genre_name, genre_id, true, true);
-                                            // Append it to the select
-                                            $('#id_genre').append(newOption).trigger('change');
-                                        };
-                                    }
-                                </script>
                             {% endfor %}
                         {% else %}
                             Sorry! No suggestions found.<br>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -288,6 +288,8 @@
                                         if (genre_id === null) {
                                             return
                                         }
+                                        // Since we're using a django-autocomplete-light widget for the Genre selector,
+                                        // we need to follow a special process in selecting a value from the widget:
                                         // Set the value, creating a new option if necessary
                                         if ($('#id_genre').find("option[value='" + genre_id + "']").length) {
                                             $('#id_genre').val(genre_id).trigger('change');

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -280,7 +280,6 @@
                                 <script>
                                     function autoFill{{ suggestion.clean_cantus_id }}() {
                                         document.getElementById('id_cantus_id').value = "{{ suggestion.cantus_id }}";
-                                        {% comment %} document.getElementById('id_genre').value = {{ suggestion.genre_id }}; {% endcomment %}
                                         document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ suggestion.fulltext }}";
                                         var genre_id = {{ suggestion.genre_id | default_if_none:"null" }};
                                         var genre_name = "{{ suggestion.genre_name }}";

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -282,9 +282,13 @@
                                         document.getElementById('id_cantus_id').value = "{{ suggestion.cantus_id }}";
                                         {% comment %} document.getElementById('id_genre').value = {{ suggestion.genre_id }}; {% endcomment %}
                                         document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ suggestion.fulltext }}";
-                                        var genre_id = {{ suggestion.genre_id }};
+                                        var genre_id = {{ suggestion.genre_id | default_if_none:"null" }};
                                         var genre_name = "{{ suggestion.genre_name }}";
 
+                                        // in case suggestion.genre_id is None, don't try to change the #id_genre selector
+                                        if (genre_id == null) {
+                                            return
+                                        }
                                         // Set the value, creating a new option if necessary
                                         if ($('#id_genre').find("option[value='" + genre_id + "']").length) {
                                             $('#id_genre').val(genre_id).trigger('change');

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -255,11 +255,55 @@
             <div class="search-bar mb-3">
                 {% include "global_search_bar.html" %}
             </div>
-            <div class="card w-100">
+
+            <div class="card w-100 mb-3">
                 <div class="card-header">
-                    <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.title }}</a></h5>
+                    <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h5>
                 </div>
             </div>
+
+            {% if previous_chant %}
+                <div class="card w-100">
+                    <div class="card-body">
+                        <small>
+                            <b>Suggestions based on previous chant:</b><br>
+                            <div>
+                                {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{% url 'chant-detail' previous_chant.id %}" target="_blank">{{ previous_chant.incipit }}</a><br>
+                                {% if previous_chant.cantus_id %}
+                                    (Cantus ID: <b><a href="https://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a></b>)
+                                {% endif %}
+                            </div>
+                        {% if suggested_chants %}
+                            {% for suggestion in suggested_chants %}
+                                <input type="button" style="width: 80px" value="{{ suggestion.cantus_id }}" onclick="autoFill{{ suggestion.clean_cantus_id }}()" title="{{ suggestion.cantus_id }}"></input>
+                                <strong>{{ suggestion.genre_name }}</strong> - <span title="{{ suggestion.fulltext }}">{{ suggestion.incipit }}</span> (<strong>{{ suggestion.occurrences }}x</strong>)<br>
+                                <script>
+                                    function autoFill{{ suggestion.clean_cantus_id }}() {
+                                        document.getElementById('id_cantus_id').value = "{{ suggestion.cantus_id }}";
+                                        {% comment %} document.getElementById('id_genre').value = {{ suggestion.genre_id }}; {% endcomment %}
+                                        document.getElementById('id_manuscript_full_text_std_spelling').value = "{{ suggestion.fulltext }}";
+                                        var genre_id = {{ suggestion.genre_id }};
+                                        var genre_name = "{{ suggestion.genre_name }}";
+
+                                        // Set the value, creating a new option if necessary
+                                        if ($('#id_genre').find("option[value='" + genre_id + "']").length) {
+                                            $('#id_genre').val(genre_id).trigger('change');
+                                        } else { 
+                                            // Create a DOM Option and pre-select by default
+                                            var newOption = new Option(genre_name, genre_id, true, true);
+                                            // Append it to the select
+                                            $('#id_genre').append(newOption).trigger('change');
+                                        };
+                                    }
+                                </script>
+                            {% endfor %}
+                        {% else %}
+                            Sorry! No suggestions found.<br>
+                        {% endif %}
+                        </small>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -100,25 +100,7 @@
                         {% if previous_chant %}
                             Feasts that follow:
                                {% for feast, count in suggested_feasts.items %}
-                                    <a href="javascript:" onclick="autoFillFeast{{ feast.id }}();">{{ feast.name }}</a> ({{ count }}x) |
-                                    <script>
-                                        function autoFillFeast{{ feast.id }}() {
-                                            var feast_id = {{ feast.id }};
-                                            var feast_name = "{{ feast.name }}";
-
-                                            // Since we're using a django-autocomplete-light widget for the Genre selector,
-                                            // we need to follow a special process in selecting a value from the widget:
-                                            // Set the value, creating a new option if necessary
-                                            if ($('#id_feast').find("option[value='" + feast_id + "']").length) {
-                                                $('#id_feast').val(feast_id).trigger('change');
-                                            } else { 
-                                                // Create a DOM Option and pre-select by default
-                                                var newOption = new Option(feast_name, feast_id, true, true);
-                                                // Append it to the select
-                                                $('#id_feast').append(newOption).trigger('change');
-                                            };
-                                        }
-                                    </script>
+                                    <a href="javascript:" onclick='autoFillFeast("{{ feast.name }}", {{ feast.id }});'>{{ feast.name }}</a> ({{ count }}x) |
                                {% endfor %}                                                                                                      
                             
                             <!-- eventually, perhaps: implement a "Reverse Changes" button -->

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -265,10 +265,10 @@
                                     value="{{ suggestion.cantus_id }}"
                                     title="{{ suggestion.cantus_id }}"
                                     onclick='autoFillSuggestedChant(
-                                        "{{suggestion.genre_name}}",
-                                        {{suggestion.genre_id | default_if_none:"null"}},
-                                        "{{suggestion.cantus_id}}",
-                                        "{{suggestion.fulltext}}"
+                                        "{{ suggestion.genre_name }}",
+                                        {{ suggestion.genre_id | default_if_none:"null" }},
+                                        "{{ suggestion.cantus_id }}",
+                                        "{{ suggestion.fulltext }}"
                                     )'
                                 >
                                 <strong>{{ suggestion.genre_name }}</strong> - <span title="{{ suggestion.fulltext }}">{{ suggestion.incipit }}</span> (<strong>{{ suggestion.occurrences }}x</strong>)<br>

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -286,7 +286,7 @@
                                         var genre_name = "{{ suggestion.genre_name }}";
 
                                         // in case suggestion.genre_id is None, don't try to change the #id_genre selector
-                                        if (genre_id == null) {
+                                        if (genre_id === null) {
                                             return
                                         }
                                         // Set the value, creating a new option if necessary

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -106,6 +106,8 @@
                                             var feast_id = {{ feast.id }};
                                             var feast_name = "{{ feast.name }}";
 
+                                            // Since we're using a django-autocomplete-light widget for the Genre selector,
+                                            // we need to follow a special process in selecting a value from the widget:
                                             // Set the value, creating a new option if necessary
                                             if ($('#id_feast').find("option[value='" + feast_id + "']").length) {
                                                 $('#id_feast').val(feast_id).trigger('change');

--- a/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
+++ b/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
@@ -200,7 +200,7 @@ mock_json_cid_006928_content: bytes = bytes(
     mock_json_cid_006928_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_008349_json: dict = {
+mock_json_cid_006928_json: dict = {
     "info": {
         "field_ah_item": None,
         "field_ah_volume": None,

--- a/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
+++ b/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
@@ -1,3 +1,5 @@
+import ujson
+
 #######################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010") ###
 #######################################################################################
@@ -11,26 +13,26 @@ mock_json_nextchants_001010_text: str = """
     {"cid":"007713","count":"2"},
     {"cid":"909030","count":"1"}
 ]
-"""  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").text
+"""
+# should be equivalent to:
+# >>> requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").text
 # this doesn't include the BOM which we expect to see beginning response.text
 # CI seems to present these, sorted by "count", in descending order.
 # Here, they have been switched around so we can ensure that our own
 # sorting by number of occurrences is working properly
+
 mock_json_nextchants_001010_content: bytes = bytes(
     mock_json_nextchants_001010_text,
     encoding="utf-8-sig",
 )  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").content
-# we expect request.content to be encoded in signed utf-8
-mock_json_nextchants_001010_json: list[dict] = [
-    {"cid": "008349", "count": "12"},
-    {"cid": "006928", "count": "17"},
-    {"cid": "008411c", "count": "4"},
-    {"cid": "008390", "count": "3"},
-    {"cid": "007713", "count": "2"},
-    {"cid": "909030", "count": "1"},
-]  # request = requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010")
-# request.encoding = "utf-8-sig"
-# request.json
+# we expect request.content to be encoded in signed utf-8. I.e., this step adds the BOM
+mock_json_nextchants_001010_json: list[dict] = ujson.loads(
+    mock_json_nextchants_001010_text
+)
+# should be equivalent to:
+# >>> request = requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010")
+# >>> request.encoding = "utf-8-sig"
+# >>> request.json()
 
 
 #######################################################################################
@@ -59,7 +61,7 @@ mock_json_cid_008349_text: str = """
         "field_fulltext_source": null,
         "field_genre": "H",
         "field_language": null,
-        "field_notes": "The 1632 Urban VIII hymn revision is nearly identical to this version and so shares this Cantus ID.  Note the following differences: \"voci concordi\" (Urban VIII) instead of \"viribus totis\" in stanza 1 and \"perennem\" instead of \"beatam\" in stanza 2.",
+        "field_notes": null,
         "field_related_chant_id": null,
         "field_similar_chant_id": null,
         "field_troped_chant_id": null
@@ -106,59 +108,7 @@ mock_json_cid_008349_content: bytes = bytes(
     mock_json_cid_008349_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_008349_json: dict = {
-    "info": {
-        "field_ah_item": None,
-        "field_ah_volume": None,
-        "field_cao": "8349",
-        "field_cao_concordances": "S",
-        "field_feast": "Dominica in estate",
-        "field_full_text": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
-        "field_fulltext_source": None,
-        "field_genre": "H",
-        "field_language": None,
-        "field_notes": 'The 1632 Urban VIII hymn revision is nearly identical to this version and so shares this Cantus ID.  Note the following differences: "voci concordi" (Urban VIII) instead of "viribus totis" in stanza 1 and "perennem" instead of "beatam" in stanza 2.',
-        "field_related_chant_id": None,
-        "field_similar_chant_id": None,
-        "field_troped_chant_id": None,
-    },
-    "chants": {
-        "0": {
-            "siglum": "P-BRs Ms. 032",
-            "srclink": "https://pemdatabase.eu/source/47990",
-            "chantlink": "https://pemdatabase.eu/musical-item/54477",
-            "folio": "262r",
-            "sequence": None,
-            "incipit": "Nocte surgentes*",
-            "feast": "Dom. 2 p. Pent.",
-            "office": "M",
-            "genre": "H",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/71166",
-            "mode": "*",
-            "fulltext": "Nocte surgentes*",
-            "melody": "",
-            "db": "PEM",
-        },
-        "1": {
-            "siglum": "P-Cua Liber Catenatus ",
-            "srclink": "https://pemdatabase.eu/source/46520",
-            "chantlink": "https://pemdatabase.eu/musical-item/94677",
-            "folio": "001v",
-            "sequence": None,
-            "incipit": "Nocte surgentes vigilemus omnes semper in",
-            "feast": "Dom. per annum",
-            "office": "M",
-            "genre": "H",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/58092",
-            "mode": "*",
-            "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus reboat per omnem gloria mundum | Amen",
-            "melody": "",
-            "db": "PEM",
-        },
-    },
-}
+mock_json_cid_008349_json: dict = ujson.loads(mock_json_cid_008349_text)
 
 ################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/006928") ###
@@ -223,59 +173,7 @@ mock_json_cid_006928_content: bytes = bytes(
     mock_json_cid_006928_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_006928_json: dict = {
-    "info": {
-        "field_ah_item": None,
-        "field_ah_volume": None,
-        "field_cao": "6928",
-        "field_cao_concordances": "CGBEMVHRDFSL",
-        "field_feast": "Dom. Septuagesimae",
-        "field_full_text": "In principio fecit deus caelum et terram et creavit in ea hominem ad imaginem et similitudinem suam",
-        "field_fulltext_source": None,
-        "field_genre": "R",
-        "field_language": None,
-        "field_notes": None,
-        "field_related_chant_id": None,
-        "field_similar_chant_id": None,
-        "field_troped_chant_id": None,
-    },
-    "chants": {
-        "0": {
-            "siglum": "P-BRs Ms. 032",
-            "srclink": "https://pemdatabase.eu/source/47990",
-            "chantlink": "https://pemdatabase.eu/musical-item/51656",
-            "folio": "119r",
-            "sequence": None,
-            "incipit": "In principio creauit deus celum et ",
-            "feast": "Dom. Septuagesimae",
-            "office": "M",
-            "genre": "R",
-            "position": "1",
-            "image": "https://pemdatabase.eu/image/71015",
-            "mode": "1",
-            "fulltext": "In principio creauit deus celum et terram et fecit in ea hominem ad imaginem et similitudinem suam",
-            "melody": "",
-            "db": "PEM",
-        },
-        "1": {
-            "siglum": "P-AR Res. Ms. 021",
-            "srclink": "https://pemdatabase.eu/source/62867",
-            "chantlink": "https://pemdatabase.eu/musical-item/65240",
-            "folio": "063r",
-            "sequence": None,
-            "incipit": "In principio*",
-            "feast": "Dom. Septuagesimae",
-            "office": "V",
-            "genre": "R",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/63266",
-            "mode": "1",
-            "fulltext": "In principio*",
-            "melody": "",
-            "db": "PEM",
-        },
-    },
-}
+mock_json_cid_006928_json: dict = ujson.loads(mock_json_cid_006928_text)
 
 #################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/008411c") ###
@@ -340,59 +238,7 @@ mock_json_cid_008411c_content: bytes = bytes(
     mock_json_cid_008411c_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_008411c_json: dict = {
-    "info": {
-        "field_ah_item": None,
-        "field_ah_volume": None,
-        "field_cao": None,
-        "field_cao_concordances": "SL",
-        "field_feast": "Mariae Magdalenae",
-        "field_full_text": "Hujus obtentu deus alme nostris parce jam culpis vitiis revulsis quo tibi puri resonet per aevum pectoris hymnus",
-        "field_fulltext_source": None,
-        "field_genre": "HV",
-        "field_language": None,
-        "field_notes": None,
-        "field_related_chant_id": None,
-        "field_similar_chant_id": None,
-        "field_troped_chant_id": None,
-    },
-    "chants": {
-        "1": {
-            "siglum": "P-ARRam ACA/E/002/Lv 002",
-            "srclink": "https://pemdatabase.eu/source/103757",
-            "chantlink": "https://pemdatabase.eu/musical-item/113818",
-            "folio": "r",
-            "sequence": None,
-            "incipit": "Hujus abtendu deus*",
-            "feast": "Mariae Magdalenae",
-            "office": "M",
-            "genre": "H",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/103759",
-            "mode": "*",
-            "fulltext": "Hujus abtendu deus*",
-            "melody": "",
-            "db": "PEM",
-        },
-        "0": {
-            "siglum": "P-Ln RES. 253 P.",
-            "srclink": "https://pemdatabase.eu/source/97935",
-            "chantlink": "https://pemdatabase.eu/musical-item/107270",
-            "folio": "189r",
-            "sequence": None,
-            "incipit": "Harum obtentu deus alme nostris parce",
-            "feast": "Comm. plurimorum Virginum",
-            "office": "V",
-            "genre": "HV",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/102010",
-            "mode": "*",
-            "fulltext": "Harum obtentu deus alme nostris parce jam culpis vitia revulsis quo tibi puri resonemus almum pectoris hymnus | Gloria patri genitoque proli et tibi compar utriusque semper super alme deus unus omni tempore saeculi",
-            "melody": "",
-            "db": "PEM",
-        },
-    },
-}
+mock_json_cid_008411c_json: dict = ujson.loads(mock_json_cid_008411c_text)
 
 ################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/008390") ###
@@ -440,42 +286,7 @@ mock_json_cid_008390_content: bytes = bytes(
     mock_json_cid_008390_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_008390_json: dict = {
-    "info": {
-        "field_ah_item": None,
-        "field_ah_volume": None,
-        "field_cao": "8390",
-        "field_cao_concordances": "SL",
-        "field_feast": "Comm. plurimorum Martyrum",
-        "field_full_text": "Sanctorum meritis inclyta gaudia pangamus socii gestaque fortia gliscit animus promere cantibus victorum genus optimum",
-        "field_fulltext_source": "A-HE (Heiligenkreuz im Wienerwald) 20, fol. 240v-241r",
-        "field_genre": "H",
-        "field_language": None,
-        "field_notes": "Full text submitted by Veronika Mr\u00e1\u010dkov\u00e1 | cf. 008390.1 for the 1632 Urban VIII revision of this hymn, which begins the same but contains multiple differences",
-        "field_related_chant_id": None,
-        "field_similar_chant_id": None,
-        "field_troped_chant_id": None,
-    },
-    "chants": {
-        "0": {
-            "siglum": "P-BRs Ms. 028",
-            "srclink": "https://pemdatabase.eu/source/48438",
-            "chantlink": "https://pemdatabase.eu/musical-item/44336",
-            "folio": "017r",
-            "sequence": None,
-            "incipit": "Sanctorum meritis*",
-            "feast": "Nat. Innocentium",
-            "office": "V2",
-            "genre": "H",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/85920",
-            "mode": "*",
-            "fulltext": "Sanctorum meritis*",
-            "melody": "",
-            "db": "PEM",
-        }
-    },
-}
+mock_json_cid_008390_json: dict = ujson.loads(mock_json_cid_008390_text)
 
 ################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/007713") ###
@@ -523,42 +334,7 @@ mock_json_cid_007713_content: bytes = bytes(
     mock_json_cid_007713_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_007713_json: dict = {
-    "info": {
-        "field_ah_item": None,
-        "field_ah_volume": None,
-        "field_cao": "7713",
-        "field_cao_concordances": "CGBEMVHRDFSL",
-        "field_feast": "Nat. Innocentium",
-        "field_full_text": "Sub altare dei audivi voces occisorum dicentium quare non defendis sanguinem nostrum et acceperunt divinum responsum adhuc sustinete modicum tempus donec impleatur numerus fratrum vestrorum",
-        "field_fulltext_source": None,
-        "field_genre": "R",
-        "field_language": None,
-        "field_notes": None,
-        "field_related_chant_id": None,
-        "field_similar_chant_id": None,
-        "field_troped_chant_id": None,
-    },
-    "chants": {
-        "0": {
-            "siglum": "P-BRs Ms. 028",
-            "srclink": "https://pemdatabase.eu/source/48438",
-            "chantlink": "https://pemdatabase.eu/musical-item/44288",
-            "folio": "013r",
-            "sequence": None,
-            "incipit": "Sub altare dei audivi voces occisorum ",
-            "feast": "Nat. Innocentium",
-            "office": "M",
-            "genre": "R",
-            "position": "1.1",
-            "image": "https://pemdatabase.eu/image/85916",
-            "mode": "7",
-            "fulltext": "Sub altare dei audivi voces occisorum dicentium quare non defendis sanguinem nostrum et acceperunt divinum responsum adhuc sustinete modicum tempus donec impleatur numerus fratrum vestrorum",
-            "melody": "",
-            "db": "PEM",
-        },
-    },
-}
+mock_json_cid_007713_json: dict = ujson.loads(mock_json_cid_007713_text)
 
 ################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/909030") ###
@@ -606,39 +382,4 @@ mock_json_cid_909030_content: bytes = bytes(
     mock_json_cid_909030_text,
     encoding="utf-8-sig",
 )
-mock_json_cid_909030_json: dict = {
-    "info": {
-        "field_ah_item": None,
-        "field_ah_volume": None,
-        "field_cao": None,
-        "field_cao_concordances": None,
-        "field_feast": "Invitatoria",
-        "field_full_text": "Venite exsultemus domino jubilemus deo salutari nostro praeoccupemus faciem ejus in confessione et in psalmis jubilemus ei | Quoniam deus magnus dominus et rex magnus super omnes deos quoniam non repellet dominus plebem suam quia in manu ejus sunt omnes fines terrae et altitudines montium ipse conspicit | Quoniam ipsius est mare et ipse fecit illud et aridam fundaverunt manus ejus venite adoremus et procidamus ante deum ploremus coram domino qui fecit nos quia ipse est dominus deus noster nos autem populus ejus et oves pascuae ejus | Hodie si vocem ejus audieritis nolite obdurare corda vestra sicut in exacerbatione secundum diem tentationis in deserto ubi tentaverunt me patres vestri probaverunt et viderunt opera mea | Quadraginta annis proximus fui generationi huic et dixi semper hi errant corde ipsi vero non cognoverunt vias meas quibus juravi in ira mea si introibunt in requiem meam | Gloria patri et filio et spiritui sancto sicut erat in principio et nunc et semper et in saecula saeculorum amen",
-        "field_fulltext_source": None,
-        "field_genre": "IP",
-        "field_language": None,
-        "field_notes": None,
-        "field_related_chant_id": None,
-        "field_similar_chant_id": None,
-        "field_troped_chant_id": None,
-    },
-    "chants": {
-        "0": {
-            "siglum": "P-Cug MM 0045",
-            "srclink": "https://pemdatabase.eu/source/46513",
-            "chantlink": "https://pemdatabase.eu/musical-item/50730",
-            "folio": "029r",
-            "sequence": None,
-            "incipit": "Venite exsultemus domino jubilemus deo salutari",
-            "feast": "De festis duplicibus",
-            "office": "M",
-            "genre": "IP",
-            "position": "",
-            "image": "https://pemdatabase.eu/image/84007",
-            "mode": "",
-            "fulltext": "Venite exsultemus domino jubilemus deo salutari nostro praeoccupemus faciem ejus in confessione et in psalmis jubilemus ei | Quoniam deus magnus | Quoniam ipsius est mare et ipse fecit illud et aridam fundaverunt manus ejus venite adoremus et procidamus ante deum ploremus coram domino qui fecit nos quia ipse est dominus deus noster nos autem populus ejus et oves pascuae ejus | Hodie si vocem | Quadraginta annis proximus fui generationi huic et dixi semper hi errant corde ipsi vero non cognoverunt vias meas quibus juravi in ira mea si introibunt in requiem meam | Gloria",
-            "melody": "",
-            "db": "PEM",
-        }
-    },
-}
+mock_json_cid_909030_json: dict = ujson.loads(mock_json_cid_909030_text)

--- a/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
+++ b/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
@@ -4,10 +4,12 @@
 
 mock_json_nextchants_001010_text: str = """
 [
-    {"cid":"008349","count":"17"},
     {"cid":"006928","count":"10"},
+    {"cid":"008349","count":"17"},
 ]
 """  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").text  # this doesn't include the BOM which we expect to see beginning response.text
+# CI seems to present these, sorted by "count", in descending order.
+# Here, they have been switched so we can ensure that our own sorting by number of occurrences is working properly
 mock_json_nextchants_001010_content: bytes = bytes(
     mock_json_nextchants_001010_text,
     encoding="utf-8-sig",

--- a/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
+++ b/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
@@ -4,26 +4,37 @@
 
 mock_json_nextchants_001010_text: str = """
 [
-    {"cid":"006928","count":"10"},
-    {"cid":"008349","count":"17"},
+    {"cid":"008349", "count": "12"},
+    {"cid":"006928", "count": "17"},
+    {"cid":"008411c","count":"4"},
+    {"cid":"008390","count":"3"},
+    {"cid":"007713","count":"2"},
+    {"cid":"909030","count":"1"}
 ]
-"""  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").text  # this doesn't include the BOM which we expect to see beginning response.text
+"""  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").text
+# this doesn't include the BOM which we expect to see beginning response.text
 # CI seems to present these, sorted by "count", in descending order.
-# Here, they have been switched so we can ensure that our own sorting by number of occurrences is working properly
+# Here, they have been switched around so we can ensure that our own
+# sorting by number of occurrences is working properly
 mock_json_nextchants_001010_content: bytes = bytes(
     mock_json_nextchants_001010_text,
     encoding="utf-8-sig",
-)  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").content  # we expect request.content to be encoded in signed utf-8
-mock_json_nextchants_001010_json: dict = [
-    {"cid": "008349", "count": "17"},
-    {"cid": "006928", "count": "10"},
+)  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").content
+# we expect request.content to be encoded in signed utf-8
+mock_json_nextchants_001010_json: list[dict] = [
+    {"cid": "008349", "count": "12"},
+    {"cid": "006928", "count": "17"},
+    {"cid": "008411c", "count": "4"},
+    {"cid": "008390", "count": "3"},
+    {"cid": "007713", "count": "2"},
+    {"cid": "909030", "count": "1"},
 ]  # request = requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010")
 # request.encoding = "utf-8-sig"
 # request.json
 
 
 ################################################################################
-### mocking requests.get("https://cantusindex.uwaterloo.ca/json_cid/008349") ###
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/008349") ###
 ################################################################################
 
 mock_json_cid_008349_text: str = """
@@ -140,7 +151,7 @@ mock_json_cid_008349_json: dict = {
 }
 
 ################################################################################
-### mocking requests.get("https://cantusindex.uwaterloo.ca/json_cid/006928") ###
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/006928") ###
 ################################################################################
 
 mock_json_cid_006928_text: str = """
@@ -253,5 +264,371 @@ mock_json_cid_006928_json: dict = {
             "melody": "",
             "db": "PEM",
         },
+    },
+}
+
+#################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/008411c") ###
+#################################################################################
+
+mock_json_cid_008411c_text: str = """
+{
+    "info": {
+        "field_ah_item": null,
+        "field_ah_volume": null,
+        "field_cao": null,
+        "field_cao_concordances": "SL",
+        "field_feast": "Mariae Magdalenae",
+        "field_full_text": "Hujus obtentu deus alme nostris parce jam culpis vitiis revulsis quo tibi puri resonet per aevum pectoris hymnus",
+        "field_fulltext_source": null,
+        "field_genre": "HV",
+        "field_language": null,
+        "field_notes": null,
+        "field_related_chant_id": null,
+        "field_similar_chant_id": null,
+        "field_troped_chant_id": null
+    },
+    "chants": {
+        "1": {
+            "siglum": "P-ARRam ACA/E/002/Lv 002",
+            "srclink": "https://pemdatabase.eu/source/103757",
+            "chantlink": "https://pemdatabase.eu/musical-item/113818",
+            "folio": "r",
+            "sequence": null,
+            "incipit": "Hujus abtendu deus*",
+            "feast": "Mariae Magdalenae",
+            "office": "M",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/103759",
+            "mode": "*",
+            "fulltext": "Hujus abtendu deus*",
+            "melody": "",
+            "db": "PEM"
+        },
+        "0": {
+            "siglum": "P-Ln RES. 253 P.",
+            "srclink": "https://pemdatabase.eu/source/97935",
+            "chantlink": "https://pemdatabase.eu/musical-item/107270",
+            "folio": "189r",
+            "sequence": null,
+            "incipit": "Harum obtentu deus alme nostris parce",
+            "feast": "Comm. plurimorum Virginum",
+            "office": "V",
+            "genre": "HV",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/102010",
+            "mode": "*",
+            "fulltext": "Harum obtentu deus alme nostris parce jam culpis vitia revulsis quo tibi puri resonemus almum pectoris hymnus | Gloria patri genitoque proli et tibi compar utriusque semper super alme deus unus omni tempore saeculi",
+            "melody": "",
+            "db": "PEM"
+        }
+    }
+}
+"""
+mock_json_cid_008411c_content: bytes = bytes(
+    mock_json_cid_008411c_text,
+    encoding="utf-8-sig",
+)
+mock_json_cid_008411c_json: dict = {
+    "info": {
+        "field_ah_item": None,
+        "field_ah_volume": None,
+        "field_cao": None,
+        "field_cao_concordances": "SL",
+        "field_feast": "Mariae Magdalenae",
+        "field_full_text": "Hujus obtentu deus alme nostris parce jam culpis vitiis revulsis quo tibi puri resonet per aevum pectoris hymnus",
+        "field_fulltext_source": None,
+        "field_genre": "HV",
+        "field_language": None,
+        "field_notes": None,
+        "field_related_chant_id": None,
+        "field_similar_chant_id": None,
+        "field_troped_chant_id": None,
+    },
+    "chants": {
+        "1": {
+            "siglum": "P-ARRam ACA/E/002/Lv 002",
+            "srclink": "https://pemdatabase.eu/source/103757",
+            "chantlink": "https://pemdatabase.eu/musical-item/113818",
+            "folio": "r",
+            "sequence": None,
+            "incipit": "Hujus abtendu deus*",
+            "feast": "Mariae Magdalenae",
+            "office": "M",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/103759",
+            "mode": "*",
+            "fulltext": "Hujus abtendu deus*",
+            "melody": "",
+            "db": "PEM",
+        },
+        "0": {
+            "siglum": "P-Ln RES. 253 P.",
+            "srclink": "https://pemdatabase.eu/source/97935",
+            "chantlink": "https://pemdatabase.eu/musical-item/107270",
+            "folio": "189r",
+            "sequence": None,
+            "incipit": "Harum obtentu deus alme nostris parce",
+            "feast": "Comm. plurimorum Virginum",
+            "office": "V",
+            "genre": "HV",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/102010",
+            "mode": "*",
+            "fulltext": "Harum obtentu deus alme nostris parce jam culpis vitia revulsis quo tibi puri resonemus almum pectoris hymnus | Gloria patri genitoque proli et tibi compar utriusque semper super alme deus unus omni tempore saeculi",
+            "melody": "",
+            "db": "PEM",
+        },
+    },
+}
+
+################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/008390") ###
+################################################################################
+
+mock_json_cid_008390_text: str = """
+{
+    "info": {
+        "field_ah_item": null,
+        "field_ah_volume": null,
+        "field_cao": "8390",
+        "field_cao_concordances": "SL",
+        "field_feast": "Comm. plurimorum Martyrum",
+        "field_full_text": "Sanctorum meritis inclyta gaudia pangamus socii gestaque fortia gliscit animus promere cantibus victorum genus optimum",
+        "field_fulltext_source": "A-HE (Heiligenkreuz im Wienerwald) 20, fol. 240v-241r",
+        "field_genre": "H",
+        "field_language": null,
+        "field_notes": "Full text submitted by Veronika Mr\u00e1\u010dkov\u00e1 | cf. 008390.1 for the 1632 Urban VIII revision of this hymn, which begins the same but contains multiple differences",
+        "field_related_chant_id": null,
+        "field_similar_chant_id": null,
+        "field_troped_chant_id": null
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 028",
+            "srclink": "https://pemdatabase.eu/source/48438",
+            "chantlink": "https://pemdatabase.eu/musical-item/44336",
+            "folio": "017r",
+            "sequence": null,
+            "incipit": "Sanctorum meritis*",
+            "feast": "Nat. Innocentium",
+            "office": "V2",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/85920",
+            "mode": "*",
+            "fulltext": "Sanctorum meritis*",
+            "melody": "",
+            "db": "PEM"
+        }
+	}
+}
+"""
+mock_json_cid_008390_content: bytes = bytes(
+    mock_json_cid_008390_text,
+    encoding="utf-8-sig",
+)
+mock_json_cid_008390_json: dict = {
+    "info": {
+        "field_ah_item": None,
+        "field_ah_volume": None,
+        "field_cao": "8390",
+        "field_cao_concordances": "SL",
+        "field_feast": "Comm. plurimorum Martyrum",
+        "field_full_text": "Sanctorum meritis inclyta gaudia pangamus socii gestaque fortia gliscit animus promere cantibus victorum genus optimum",
+        "field_fulltext_source": "A-HE (Heiligenkreuz im Wienerwald) 20, fol. 240v-241r",
+        "field_genre": "H",
+        "field_language": None,
+        "field_notes": "Full text submitted by Veronika Mr\u00e1\u010dkov\u00e1 | cf. 008390.1 for the 1632 Urban VIII revision of this hymn, which begins the same but contains multiple differences",
+        "field_related_chant_id": None,
+        "field_similar_chant_id": None,
+        "field_troped_chant_id": None,
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 028",
+            "srclink": "https://pemdatabase.eu/source/48438",
+            "chantlink": "https://pemdatabase.eu/musical-item/44336",
+            "folio": "017r",
+            "sequence": None,
+            "incipit": "Sanctorum meritis*",
+            "feast": "Nat. Innocentium",
+            "office": "V2",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/85920",
+            "mode": "*",
+            "fulltext": "Sanctorum meritis*",
+            "melody": "",
+            "db": "PEM",
+        }
+    },
+}
+
+################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/007713") ###
+################################################################################
+
+mock_json_cid_007713_text: str = """
+{
+    "info": {
+        "field_ah_item": null,
+        "field_ah_volume": null,
+        "field_cao": "7713",
+        "field_cao_concordances": "CGBEMVHRDFSL",
+        "field_feast": "Nat. Innocentium",
+        "field_full_text": "Sub altare dei audivi voces occisorum dicentium quare non defendis sanguinem nostrum et acceperunt divinum responsum adhuc sustinete modicum tempus donec impleatur numerus fratrum vestrorum",
+        "field_fulltext_source": null,
+        "field_genre": "R",
+        "field_language": null,
+        "field_notes": null,
+        "field_related_chant_id": null,
+        "field_similar_chant_id": null,
+        "field_troped_chant_id": null
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 028",
+            "srclink": "https://pemdatabase.eu/source/48438",
+            "chantlink": "https://pemdatabase.eu/musical-item/44288",
+            "folio": "013r",
+            "sequence": null,
+            "incipit": "Sub altare dei audivi voces occisorum ",
+            "feast": "Nat. Innocentium",
+            "office": "M",
+            "genre": "R",
+            "position": "1.1",
+            "image": "https://pemdatabase.eu/image/85916",
+            "mode": "7",
+            "fulltext": "Sub altare dei audivi voces occisorum dicentium quare non defendis sanguinem nostrum et acceperunt divinum responsum adhuc sustinete modicum tempus donec impleatur numerus fratrum vestrorum",
+            "melody": "",
+            "db": "PEM"
+        }
+    }
+}
+"""
+mock_json_cid_007713_content: bytes = bytes(
+    mock_json_cid_007713_text,
+    encoding="utf-8-sig",
+)
+mock_json_cid_007713_json: dict = {
+    "info": {
+        "field_ah_item": None,
+        "field_ah_volume": None,
+        "field_cao": "7713",
+        "field_cao_concordances": "CGBEMVHRDFSL",
+        "field_feast": "Nat. Innocentium",
+        "field_full_text": "Sub altare dei audivi voces occisorum dicentium quare non defendis sanguinem nostrum et acceperunt divinum responsum adhuc sustinete modicum tempus donec impleatur numerus fratrum vestrorum",
+        "field_fulltext_source": None,
+        "field_genre": "R",
+        "field_language": None,
+        "field_notes": None,
+        "field_related_chant_id": None,
+        "field_similar_chant_id": None,
+        "field_troped_chant_id": None,
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 028",
+            "srclink": "https://pemdatabase.eu/source/48438",
+            "chantlink": "https://pemdatabase.eu/musical-item/44288",
+            "folio": "013r",
+            "sequence": None,
+            "incipit": "Sub altare dei audivi voces occisorum ",
+            "feast": "Nat. Innocentium",
+            "office": "M",
+            "genre": "R",
+            "position": "1.1",
+            "image": "https://pemdatabase.eu/image/85916",
+            "mode": "7",
+            "fulltext": "Sub altare dei audivi voces occisorum dicentium quare non defendis sanguinem nostrum et acceperunt divinum responsum adhuc sustinete modicum tempus donec impleatur numerus fratrum vestrorum",
+            "melody": "",
+            "db": "PEM",
+        },
+    },
+}
+
+################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/909030") ###
+################################################################################
+
+mock_json_cid_909030_text: str = """
+{
+    "info": {
+        "field_ah_item": null,
+        "field_ah_volume": null,
+        "field_cao": null,
+        "field_cao_concordances": null,
+        "field_feast": "Invitatoria",
+        "field_full_text": "Venite exsultemus domino jubilemus deo salutari nostro praeoccupemus faciem ejus in confessione et in psalmis jubilemus ei | Quoniam deus magnus dominus et rex magnus super omnes deos quoniam non repellet dominus plebem suam quia in manu ejus sunt omnes fines terrae et altitudines montium ipse conspicit | Quoniam ipsius est mare et ipse fecit illud et aridam fundaverunt manus ejus venite adoremus et procidamus ante deum ploremus coram domino qui fecit nos quia ipse est dominus deus noster nos autem populus ejus et oves pascuae ejus | Hodie si vocem ejus audieritis nolite obdurare corda vestra sicut in exacerbatione secundum diem tentationis in deserto ubi tentaverunt me patres vestri probaverunt et viderunt opera mea | Quadraginta annis proximus fui generationi huic et dixi semper hi errant corde ipsi vero non cognoverunt vias meas quibus juravi in ira mea si introibunt in requiem meam | Gloria patri et filio et spiritui sancto sicut erat in principio et nunc et semper et in saecula saeculorum amen",
+        "field_fulltext_source": null,
+        "field_genre": "IP",
+        "field_language": null,
+        "field_notes": null,
+        "field_related_chant_id": null,
+        "field_similar_chant_id": null,
+        "field_troped_chant_id": null
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-Cug MM 0045",
+            "srclink": "https://pemdatabase.eu/source/46513",
+            "chantlink": "https://pemdatabase.eu/musical-item/50730",
+            "folio": "029r",
+            "sequence": null,
+            "incipit": "Venite exsultemus domino jubilemus deo salutari",
+            "feast": "De festis duplicibus",
+            "office": "M",
+            "genre": "IP",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/84007",
+            "mode": "",
+            "fulltext": "Venite exsultemus domino jubilemus deo salutari nostro praeoccupemus faciem ejus in confessione et in psalmis jubilemus ei | Quoniam deus magnus | Quoniam ipsius est mare et ipse fecit illud et aridam fundaverunt manus ejus venite adoremus et procidamus ante deum ploremus coram domino qui fecit nos quia ipse est dominus deus noster nos autem populus ejus et oves pascuae ejus | Hodie si vocem | Quadraginta annis proximus fui generationi huic et dixi semper hi errant corde ipsi vero non cognoverunt vias meas quibus juravi in ira mea si introibunt in requiem meam | Gloria",
+            "melody": "",
+            "db": "PEM"
+		}
+    }
+}
+"""
+mock_json_cid_909030_content: bytes = bytes(
+    mock_json_cid_909030_text,
+    encoding="utf-8-sig",
+)
+mock_json_cid_909030_json: dict = {
+    "info": {
+        "field_ah_item": None,
+        "field_ah_volume": None,
+        "field_cao": None,
+        "field_cao_concordances": None,
+        "field_feast": "Invitatoria",
+        "field_full_text": "Venite exsultemus domino jubilemus deo salutari nostro praeoccupemus faciem ejus in confessione et in psalmis jubilemus ei | Quoniam deus magnus dominus et rex magnus super omnes deos quoniam non repellet dominus plebem suam quia in manu ejus sunt omnes fines terrae et altitudines montium ipse conspicit | Quoniam ipsius est mare et ipse fecit illud et aridam fundaverunt manus ejus venite adoremus et procidamus ante deum ploremus coram domino qui fecit nos quia ipse est dominus deus noster nos autem populus ejus et oves pascuae ejus | Hodie si vocem ejus audieritis nolite obdurare corda vestra sicut in exacerbatione secundum diem tentationis in deserto ubi tentaverunt me patres vestri probaverunt et viderunt opera mea | Quadraginta annis proximus fui generationi huic et dixi semper hi errant corde ipsi vero non cognoverunt vias meas quibus juravi in ira mea si introibunt in requiem meam | Gloria patri et filio et spiritui sancto sicut erat in principio et nunc et semper et in saecula saeculorum amen",
+        "field_fulltext_source": None,
+        "field_genre": "IP",
+        "field_language": None,
+        "field_notes": None,
+        "field_related_chant_id": None,
+        "field_similar_chant_id": None,
+        "field_troped_chant_id": None,
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-Cug MM 0045",
+            "srclink": "https://pemdatabase.eu/source/46513",
+            "chantlink": "https://pemdatabase.eu/musical-item/50730",
+            "folio": "029r",
+            "sequence": None,
+            "incipit": "Venite exsultemus domino jubilemus deo salutari",
+            "feast": "De festis duplicibus",
+            "office": "M",
+            "genre": "IP",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/84007",
+            "mode": "",
+            "fulltext": "Venite exsultemus domino jubilemus deo salutari nostro praeoccupemus faciem ejus in confessione et in psalmis jubilemus ei | Quoniam deus magnus | Quoniam ipsius est mare et ipse fecit illud et aridam fundaverunt manus ejus venite adoremus et procidamus ante deum ploremus coram domino qui fecit nos quia ipse est dominus deus noster nos autem populus ejus et oves pascuae ejus | Hodie si vocem | Quadraginta annis proximus fui generationi huic et dixi semper hi errant corde ipsi vero non cognoverunt vias meas quibus juravi in ira mea si introibunt in requiem meam | Gloria",
+            "melody": "",
+            "db": "PEM",
+        }
     },
 }

--- a/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
+++ b/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
@@ -1,0 +1,255 @@
+#######################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010") ###
+#######################################################################################
+
+mock_json_nextchants_001010_text: str = """
+[
+    {"cid":"008349","count":"17"},
+    {"cid":"006928","count":"10"},
+]
+"""  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").text  # this doesn't include the BOM which we expect to see beginning response.text
+mock_json_nextchants_001010_content: bytes = bytes(
+    mock_json_nextchants_001010_text,
+    encoding="utf-8-sig",
+)  # requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010").content  # we expect request.content to be encoded in signed utf-8
+mock_json_nextchants_001010_json: dict = [
+    {"cid": "008349", "count": "17"},
+    {"cid": "006928", "count": "10"},
+]  # request = requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010")
+# request.encoding = "utf-8-sig"
+# request.json
+
+
+################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json_cid/008349") ###
+################################################################################
+
+mock_json_cid_008349_text: str = """
+{
+    "info": {
+        "field_ah_item": null,
+        "field_ah_volume": null,
+        "field_cao": "8349",
+        "field_cao_concordances": "S",
+        "field_feast": "Dominica in estate",
+        "field_full_text": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
+        "field_fulltext_source": null,
+        "field_genre": "H",
+        "field_language": null,
+        "field_notes": "The 1632 Urban VIII hymn revision is nearly identical to this version and so shares this Cantus ID.  Note the following differences: \"voci concordi\" (Urban VIII) instead of \"viribus totis\" in stanza 1 and \"perennem\" instead of \"beatam\" in stanza 2.",
+        "field_related_chant_id": null,
+        "field_similar_chant_id": null,
+        "field_troped_chant_id": null
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 032",
+            "srclink": "https://pemdatabase.eu/source/47990",
+            "chantlink": "https://pemdatabase.eu/musical-item/54477",
+            "folio": "262r",
+            "sequence": null,
+            "incipit": "Nocte surgentes*",
+            "feast": "Dom. 2 p. Pent.",
+            "office": "M",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/71166",
+            "mode": "*",
+            "fulltext": "Nocte surgentes*",
+            "melody": "",
+            "db": "PEM"
+        },
+        "1": {
+            "siglum": "P-Cua Liber Catenatus ",
+            "srclink": "https://pemdatabase.eu/source/46520",
+            "chantlink": "https://pemdatabase.eu/musical-item/94677",
+            "folio": "001v",
+            "sequence": null,
+            "incipit": "Nocte surgentes vigilemus omnes semper in",
+            "feast": "Dom. per annum",
+            "office": "M",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/58092",
+            "mode": "*",
+            "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus reboat per omnem gloria mundum | Amen",
+            "melody": "",
+            "db": "PEM"
+        }
+    }
+}
+"""
+mock_json_cid_008349_content: bytes = bytes(
+    mock_json_cid_008349_text,
+    encoding="utf-8-sig",
+)
+mock_json_cid_008349_json: dict = {
+    "info": {
+        "field_ah_item": None,
+        "field_ah_volume": None,
+        "field_cao": "8349",
+        "field_cao_concordances": "S",
+        "field_feast": "Dominica in estate",
+        "field_full_text": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
+        "field_fulltext_source": None,
+        "field_genre": "H",
+        "field_language": None,
+        "field_notes": 'The 1632 Urban VIII hymn revision is nearly identical to this version and so shares this Cantus ID.  Note the following differences: "voci concordi" (Urban VIII) instead of "viribus totis" in stanza 1 and "perennem" instead of "beatam" in stanza 2.',
+        "field_related_chant_id": None,
+        "field_similar_chant_id": None,
+        "field_troped_chant_id": None,
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 032",
+            "srclink": "https://pemdatabase.eu/source/47990",
+            "chantlink": "https://pemdatabase.eu/musical-item/54477",
+            "folio": "262r",
+            "sequence": None,
+            "incipit": "Nocte surgentes*",
+            "feast": "Dom. 2 p. Pent.",
+            "office": "M",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/71166",
+            "mode": "*",
+            "fulltext": "Nocte surgentes*",
+            "melody": "",
+            "db": "PEM",
+        },
+        "1": {
+            "siglum": "P-Cua Liber Catenatus ",
+            "srclink": "https://pemdatabase.eu/source/46520",
+            "chantlink": "https://pemdatabase.eu/musical-item/94677",
+            "folio": "001v",
+            "sequence": None,
+            "incipit": "Nocte surgentes vigilemus omnes semper in",
+            "feast": "Dom. per annum",
+            "office": "M",
+            "genre": "H",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/58092",
+            "mode": "*",
+            "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus reboat per omnem gloria mundum | Amen",
+            "melody": "",
+            "db": "PEM",
+        },
+    },
+}
+
+################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json_cid/006928") ###
+################################################################################
+
+mock_json_cid_006928_text: str = """
+{
+    "info": {
+        "field_ah_item": null,
+        "field_ah_volume": null,
+        "field_cao": "6928",
+        "field_cao_concordances": "CGBEMVHRDFSL",
+        "field_feast": "Dom. Septuagesimae",
+        "field_full_text": "In principio fecit deus caelum et terram et creavit in ea hominem ad imaginem et similitudinem suam",
+        "field_fulltext_source": null,
+        "field_genre": "R",
+        "field_language": null,
+        "field_notes": null,
+        "field_related_chant_id": null,
+        "field_similar_chant_id": null,
+        "field_troped_chant_id": null
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 032",
+            "srclink": "https://pemdatabase.eu/source/47990",
+            "chantlink": "https://pemdatabase.eu/musical-item/51656",
+            "folio": "119r",
+            "sequence": null,
+            "incipit": "In principio creauit deus celum et ",
+            "feast": "Dom. Septuagesimae",
+            "office": "M",
+            "genre": "R",
+            "position": "1",
+            "image": "https://pemdatabase.eu/image/71015",
+            "mode": "1",
+            "fulltext": "In principio creauit deus celum et terram et fecit in ea hominem ad imaginem et similitudinem suam",
+            "melody": "",
+            "db": "PEM"
+        },
+        "1": {
+            "siglum": "P-AR Res. Ms. 021",
+            "srclink": "https://pemdatabase.eu/source/62867",
+            "chantlink": "https://pemdatabase.eu/musical-item/65240",
+            "folio": "063r",
+            "sequence": null,
+            "incipit": "In principio*",
+            "feast": "Dom. Septuagesimae",
+            "office": "V",
+            "genre": "R",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/63266",
+            "mode": "1",
+            "fulltext": "In principio*",
+            "melody": "",
+            "db": "PEM"
+        }
+    }
+}
+"""
+mock_json_cid_006928_content: bytes = bytes(
+    mock_json_cid_006928_text,
+    encoding="utf-8-sig",
+)
+mock_json_cid_008349_json: dict = {
+    "info": {
+        "field_ah_item": None,
+        "field_ah_volume": None,
+        "field_cao": "6928",
+        "field_cao_concordances": "CGBEMVHRDFSL",
+        "field_feast": "Dom. Septuagesimae",
+        "field_full_text": "In principio fecit deus caelum et terram et creavit in ea hominem ad imaginem et similitudinem suam",
+        "field_fulltext_source": None,
+        "field_genre": "R",
+        "field_language": None,
+        "field_notes": None,
+        "field_related_chant_id": None,
+        "field_similar_chant_id": None,
+        "field_troped_chant_id": None,
+    },
+    "chants": {
+        "0": {
+            "siglum": "P-BRs Ms. 032",
+            "srclink": "https://pemdatabase.eu/source/47990",
+            "chantlink": "https://pemdatabase.eu/musical-item/51656",
+            "folio": "119r",
+            "sequence": None,
+            "incipit": "In principio creauit deus celum et ",
+            "feast": "Dom. Septuagesimae",
+            "office": "M",
+            "genre": "R",
+            "position": "1",
+            "image": "https://pemdatabase.eu/image/71015",
+            "mode": "1",
+            "fulltext": "In principio creauit deus celum et terram et fecit in ea hominem ad imaginem et similitudinem suam",
+            "melody": "",
+            "db": "PEM",
+        },
+        "1": {
+            "siglum": "P-AR Res. Ms. 021",
+            "srclink": "https://pemdatabase.eu/source/62867",
+            "chantlink": "https://pemdatabase.eu/musical-item/65240",
+            "folio": "063r",
+            "sequence": None,
+            "incipit": "In principio*",
+            "feast": "Dom. Septuagesimae",
+            "office": "V",
+            "genre": "R",
+            "position": "",
+            "image": "https://pemdatabase.eu/image/63266",
+            "mode": "1",
+            "fulltext": "In principio*",
+            "melody": "",
+            "db": "PEM",
+        },
+    },
+}

--- a/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
+++ b/django/cantusdb_project/main_app/tests/mock_cantusindex_data.py
@@ -33,6 +33,16 @@ mock_json_nextchants_001010_json: list[dict] = [
 # request.json
 
 
+#######################################################################################
+### mocking requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/a07763") ###
+#######################################################################################
+
+mock_json_nextchants_a07763_text: str = "\r\n"
+mock_json_nextchants_a07763_content: bytes = bytes(
+    mock_json_nextchants_a07763_text,
+    encoding="utf-8-sig",
+)
+
 ################################################################################
 ### mocking requests.get("https://cantusindex.uwaterloo.ca/json-cid/008349") ###
 ################################################################################

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -54,6 +54,7 @@ def mock_requests_get(url: str, timeout: int) -> MockResponse:
     if timeout < 0.001:
         raise requests.exceptions.ConnectTimeout
 
+    # mock call to /json-nextchants/001010
     if url in (
         "https://cantusindex.uwaterloo.ca/json-nextchants/001010",
         "https://cantusindex.org/json-nextchants/001010",
@@ -63,6 +64,8 @@ def mock_requests_get(url: str, timeout: int) -> MockResponse:
             content=mock_cantusindex_data.mock_json_nextchants_001010_content,
             json=mock_cantusindex_data.mock_json_nextchants_001010_json,
         )
+
+    # mock call to /json-cid/008349
     elif url in (
         "https://cantusindex.uwaterloo.ca/json-cid/008349",
         "https://cantusindex.org/json-cid/008349",
@@ -72,11 +75,18 @@ def mock_requests_get(url: str, timeout: int) -> MockResponse:
             content=mock_cantusindex_data.mock_json_cid_008349_content,
             json=mock_cantusindex_data.mock_json_cid_008349_json,
         )
+
+    # mock call to /json-cid/006928
     elif url in (
         "https://cantusindex.uwaterloo.ca/json-cid/006928",
         "https://cantusindex.org/json-cid/006928",
     ):
-        pass
+        return MockResponse(
+            status_code=200,
+            content=mock_cantusindex_data.mock_json_cid_006928_content,
+            json=mock_cantusindex_data.mock_json_cid_008349_json,
+        )
+
     else:
         raise ValueError(
             f"mock_requests_get is only set up to mock calls to specific URLs; {url} is not one of those URLs"

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -229,6 +229,10 @@ class CantusIndexFunctionsTest(TestCase):
             with self.subTest(key=key):
                 self.assertEqual(observed_val, expected_val)
 
+        with self.subTest("Ensure all values are of the correct type"):
+            self.assertIsInstance(observed_chant["cantus_id"], str)
+            self.assertIsInstance(observed_chant["occurrences"], int)
+
         with patch("requests.get", mock_requests_get):
             observed_chant_with_r_genre = get_suggested_chant(
                 cantus_id="006928", occurrences=occs
@@ -249,11 +253,46 @@ class CantusIndexFunctionsTest(TestCase):
             self.assertIsNone(observed_chant_short_timeout)
 
     def test_get_suggested_chants(self):
-        pass
+        h_genre = make_fake_genre(name="H")
+        r_genre = make_fake_genre(name="R")
+        expected_suggested_chants = [
+            {
+                "cantus_id": "008349",
+                "occurrences": 17,
+                "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
+                "incipit": "Nocte surgentes vigilemus omnes semper",
+                "genre_id": h_genre.id,
+            },
+            {
+                "cantus_id": "006928",
+                "occurrences": 10,
+                "fulltext": "In principio fecit deus caelum et terram et creavit in ea hominem ad imaginem et similitudinem suam",
+                "incipit": "In principio fecit deus caelum",
+                "genre_id": r_genre.id,
+            },
+        ]
+        with patch("requests.get", mock_requests_get):
+            observed_suggested_chants = get_suggested_chants(cantus_id="001010")
+
+        first_suggested_chant = observed_suggested_chants[0]
+        second_suggested_chant = observed_suggested_chants[1]
+        with self.subTest(
+            test="Ensure suggested chants are ordered by number of occurrences"
+        ):
+            self.assertLess(
+                second_suggested_chant["occurrences"],
+                first_suggested_chant["occurrences"],
+            )
+
+        with self.subTest(test="Ensure returned object is a list of dicts"):
+            self.assertIsInstance(observed_suggested_chants, list)
+            self.assertIsInstance(first_suggested_chant, dict)
 
     def test_get_json_from_ci_api(self):
         with patch("requests.get", mock_requests_get):
-            json_nextchants_response = get_json_from_ci_api(path="/json-cid/001010")
+            json_nextchants_response = get_json_from_ci_api(
+                path="/json-nextchants/001010"
+            )
         with self.subTest(
             test="Ensure properly handles /nextchants/<cantus_id> endpoint"
         ):

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -14,7 +14,7 @@ from main_app.tests.make_fakes import (
 )
 from main_app.management.commands import update_cached_concordances
 from main_app.signals import generate_incipit
-from cantusindex import get_suggested_chant
+from cantusindex import get_suggested_chant, get_suggested_chants, get_json_from_ci_api
 
 # run with `python -Wa manage.py test main_app.tests.test_functions`
 # the -Wa flag tells Python to display deprecation warnings
@@ -250,3 +250,32 @@ class CantusIndexFunctionsTest(TestCase):
 
     def test_get_suggested_chants(self):
         pass
+
+    def test_get_json_from_ci_api(self):
+        with self.subTest(
+            test="Ensure properly handles /nextchants/<cantus_id> endpoint"
+        ):
+            pass
+
+        with self.subTest(
+            test="Ensure properly handles /json-cid/<cantus_id> endpoint"
+        ):
+            pass
+
+        with self.subTest(test="Ensure returns None when requests.get times out"):
+            pass
+
+        # I can't figure out how to get assertRaises to work - even when the assertion should fail, it doesn't.
+        # It's not of vital importance that this argument check work correctly, I think, so I'm giving up in
+        # an effort not to get bogged down.
+        # Leaving a couple of commented-out attempts of things I've tried, for the benefit of some future, cleverer developer
+        # - Jacob dGM, April 2024
+
+        # with self.subTest(test="Ensure raises ValueError when path improperly formatted, attempt 1"):
+        #     self.assertRaises(ValueError, get_json_from_ci_api, "/for/some/reason/this/passes/even/with/a/leading/slash")
+
+        with self.subTest(
+            test="Ensure raises ValueError when path improperly formatted, attempt 2"
+        ):
+            with self.assertRaises(ValueError):
+                get_json_from_ci_api("/i/still/dont/understand/why/this/subtest/passes")

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -351,6 +351,13 @@ class CantusIndexFunctionsTest(TestCase):
         with self.subTest(test="Ensure None returned in case of nonexistent Cantus ID"):
             self.assertIsNone(suggested_chants_nonexistent_cantus_id)
 
+        with patch("requests.get", mock_requests_get):
+            suggested_chants_rare_cantus_id = get_suggested_chants(cantus_id="a07763")
+        with self.subTest(
+            test="Ensure None is returned in case of Cantus ID without suggestions"
+        ):
+            self.assertIsNone(suggested_chants_rare_cantus_id)
+
     def test_get_json_from_ci_api(self):
         with patch("requests.get", mock_requests_get):
             json_nextchants_response = get_json_from_ci_api(

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -252,30 +252,43 @@ class CantusIndexFunctionsTest(TestCase):
         pass
 
     def test_get_json_from_ci_api(self):
+        with patch("requests.get", mock_requests_get):
+            json_nextchants_response = get_json_from_ci_api(path="/json-cid/001010")
         with self.subTest(
             test="Ensure properly handles /nextchants/<cantus_id> endpoint"
         ):
-            pass
+            self.assertIsInstance(json_nextchants_response, list)
+            first_nextchant = json_nextchants_response[0]
+            self.assertIsInstance(first_nextchant, dict)
 
+        with patch("requests.get", mock_requests_get):
+            json_cid_response = get_json_from_ci_api(path="/json-cid/008349")
+        observed_json_cid_keys = json_cid_response.keys()
+        expected_json_cid_keys = ("info", "chants")
         with self.subTest(
             test="Ensure properly handles /json-cid/<cantus_id> endpoint"
         ):
-            pass
+            self.assertIsInstance(json_cid_response, dict)
+            for key in expected_json_cid_keys:
+                self.assertIn(key, observed_json_cid_keys)
 
+        with patch("requests.get", mock_requests_get):
+            response_short_timeout = get_json_from_ci_api(
+                path="/some/path", timeout=0.0001
+            )
         with self.subTest(test="Ensure returns None when requests.get times out"):
-            pass
+            self.assertIsNone(response_short_timeout)
 
         # I can't figure out how to get assertRaises to work - even when the assertion should fail, it doesn't.
         # It's not of vital importance that this argument check work correctly, I think, so I'm giving up in
         # an effort not to get bogged down.
-        # Leaving a couple of commented-out attempts of things I've tried, for the benefit of some future, cleverer developer
+        # Leaving a couple of commented-out attempts here with things I've tried, for the hopeful benefit of some
+        # future, cleverer developer
         # - Jacob dGM, April 2024
 
         # with self.subTest(test="Ensure raises ValueError when path improperly formatted, attempt 1"):
         #     self.assertRaises(ValueError, get_json_from_ci_api, "/for/some/reason/this/passes/even/with/a/leading/slash")
 
-        with self.subTest(
-            test="Ensure raises ValueError when path improperly formatted, attempt 2"
-        ):
-            with self.assertRaises(ValueError):
-                get_json_from_ci_api("/i/still/dont/understand/why/this/subtest/passes")
+        # with self.subTest(test="Ensure raises ValueError when path improperly formatted, attempt 2"):
+        #     with self.assertRaises(ValueError):
+        #         get_json_from_ci_api("/i/still/dont/understand/why/this/subtest/passes")

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -54,7 +54,7 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
         ValueError: This function is configured to mock requests to specific URLs only, including
             - /json-nextchants/001010
         If a call to requests.get with a different URL is made while mock_requests_get is patching it,
-        a ValueError is raised.
+        a NotImplementedError is raised.
 
     Returns:
         MockResponse: A mock response object

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -100,6 +100,30 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
                 content=mock_cantusindex_data.mock_json_cid_006928_content,
                 json=mock_cantusindex_data.mock_json_cid_006928_json,
             )
+        elif url.endswith("/008411c"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_cid_008411c_content,
+                json=mock_cantusindex_data.mock_json_cid_008411c_json,
+            )
+        elif url.endswith("/008390"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_cid_008390_content,
+                json=mock_cantusindex_data.mock_json_cid_008390_json,
+            )
+        elif url.endswith("/007713"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_cid_007713_content,
+                json=mock_cantusindex_data.mock_json_cid_007713_json,
+            )
+        elif url.endswith("/909030"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_cid_909030_content,
+                json=mock_cantusindex_data.mock_json_cid_909030_json,
+            )
         else:  # imitating CI's behavior when a made-up Cantus ID is entered.
             return MockResponse(
                 status_code=500,

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -302,44 +302,28 @@ class CantusIndexFunctionsTest(TestCase):
             self.assertIsNone(observed_chant_nonexistent_cantus_id)
 
     def test_get_suggested_chants(self):
-        h_genre = make_fake_genre(name="H")
-        r_genre = make_fake_genre(name="R")
-        expected_suggested_chants = [
-            {
-                "cantus_id": "008349",
-                "occurrences": 17,
-                "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
-                "incipit": "Nocte surgentes vigilemus omnes semper",
-                "genre_name": "H",
-                "genre_id": h_genre.id,
-                "clean_cantus_id": "008349",
-            },
-            {
-                "cantus_id": "006928",
-                "occurrences": 10,
-                "fulltext": "In principio fecit deus caelum et terram et creavit in ea hominem ad imaginem et similitudinem suam",
-                "incipit": "In principio fecit deus caelum",
-                "genre_name": "R",
-                "genre_id": r_genre.id,
-                "clean_cantus_id": "006928",
-            },
-        ]
         with patch("requests.get", mock_requests_get):
-            observed_suggested_chants = get_suggested_chants(cantus_id="001010")
+            suggested_chants = get_suggested_chants(cantus_id="001010")
 
-        first_suggested_chant = observed_suggested_chants[0]
-        second_suggested_chant = observed_suggested_chants[1]
+        initial_suggested_chant = suggested_chants[0]
+
+        with self.subTest(test="Ensure returned object is a list of dicts"):
+            self.assertIsInstance(suggested_chants, list)
+            self.assertIsInstance(initial_suggested_chant, dict)
+
+        with self.subTest(test="Ensure no more than 5 suggestions returned"):
+            self.assertLessEqual(len(suggested_chants), 5)
+
         with self.subTest(
             test="Ensure suggested chants are ordered by number of occurrences"
         ):
-            self.assertLess(
-                second_suggested_chant["occurrences"],
-                first_suggested_chant["occurrences"],
-            )
-
-        with self.subTest(test="Ensure returned object is a list of dicts"):
-            self.assertIsInstance(observed_suggested_chants, list)
-            self.assertIsInstance(first_suggested_chant, dict)
+            for i in range(4):
+                suggested_chant = suggested_chants[i]
+                following_suggested_chant = suggested_chants[i + 1]
+                self.assertLessEqual(
+                    suggested_chant["occurrences"],
+                    following_suggested_chant["occurrences"],
+                )
 
     def test_get_json_from_ci_api(self):
         with patch("requests.get", mock_requests_get):

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -230,14 +230,14 @@ class CantusIndexFunctionsTest(TestCase):
                 self.assertEqual(observed_val, expected_val)
 
         with patch("requests.get", mock_requests_get):
-            observed_chant_wo_matching_genre = get_suggested_chant(
+            observed_chant_with_r_genre = get_suggested_chant(
                 cantus_id="006928", occurrences=occs
             )
 
         with self.subTest(
             test="Ensure that genre_id=None when no matching Genre found"
         ):
-            observed_genre_id = observed_chant_wo_matching_genre["genre_id"]
+            observed_genre_id = observed_chant_with_r_genre["genre_id"]
             self.assertIsNone(observed_genre_id)
 
         with patch("requests.get", mock_requests_get):

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -60,42 +60,55 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
     if timeout < 0.001:
         raise requests.exceptions.ConnectTimeout
 
-    # mock call to /json-nextchants/001010
-    if url in (
-        "https://cantusindex.uwaterloo.ca/json-nextchants/001010",
-        "https://cantusindex.org/json-nextchants/001010",
+    if not (
+        "https://cantusindex.uwaterloo.ca" in url or "https://cantusindex.org" in url
     ):
-        return MockResponse(
-            status_code=200,
-            content=mock_cantusindex_data.mock_json_nextchants_001010_content,
-            json=mock_cantusindex_data.mock_json_nextchants_001010_json,
+        raise ValueError(
+            f"mock_requests_get is only set up to mock calls to Cantus Index. "
+            f"The protocol and domain of url {url} do not correspond to those of Cantus Index."
         )
 
-    # mock call to /json-cid/008349
-    elif url in (
-        "https://cantusindex.uwaterloo.ca/json-cid/008349",
-        "https://cantusindex.org/json-cid/008349",
+    if (
+        "https://cantusindex.uwaterloo.ca/json-nextchants/" in url
+        or "https://cantusindex.org/json-nextchants/" in url
     ):
-        return MockResponse(
-            status_code=200,
-            content=mock_cantusindex_data.mock_json_cid_008349_content,
-            json=mock_cantusindex_data.mock_json_cid_008349_json,
-        )
-
-    # mock call to /json-cid/006928
-    elif url in (
-        "https://cantusindex.uwaterloo.ca/json-cid/006928",
-        "https://cantusindex.org/json-cid/006928",
+        if url.endswith("/001010"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_nextchants_001010_content,
+                json=mock_cantusindex_data.mock_json_nextchants_001010_json,
+            )
+        else:  # imitating CI's behavior when a made-up Cantus ID is entered.
+            return MockResponse(
+                status_code=200,
+                content=bytes('["Cantus ID is not valid"]', encoding="utf-8-sig"),
+                json=["Cantus ID is not valid"],
+            )
+    elif (
+        "https://cantusindex.uwaterloo.ca/json-cid/" in url
+        or "https://cantusindex.org/json-cid/" in url
     ):
-        return MockResponse(
-            status_code=200,
-            content=mock_cantusindex_data.mock_json_cid_006928_content,
-            json=mock_cantusindex_data.mock_json_cid_006928_json,
-        )
-
+        if url.endswith("/008349"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_cid_008349_content,
+                json=mock_cantusindex_data.mock_json_cid_008349_json,
+            )
+        elif url.endswith("/006928"):
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_cid_006928_content,
+                json=mock_cantusindex_data.mock_json_cid_006928_json,
+            )
+        else:  # imitating CI's behavior when a made-up Cantus ID is entered.
+            return MockResponse(
+                status_code=500,
+            )
     else:
         raise ValueError(
-            f"mock_requests_get is only set up to mock calls to specific URLs; {url} is not one of those URLs"
+            f"mock_requests_get is only set up to imitate only the /json-nextchants/ "
+            f"and /json-cid/ endpoints on Cantus Index. The path of the url {url} does "
+            f"not match either of these endpoints."
         )
 
 

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -1,7 +1,7 @@
 import requests
 from main_app.tests import mock_cantusindex_data
 from django.test import TestCase
-from typing import Union
+from typing import Union, Optional
 from unittest.mock import patch
 from main_app.models import (
     Chant,
@@ -29,9 +29,9 @@ class MockResponse:
     def __init__(
         self,
         status_code: int,
-        text: str,
+        text: Optional[str],
         json: Union[dict, list, None],
-        content: bytes,
+        content: Optional[bytes],
         encoding: str = "utf-8",
         # >>> response = requests.get("https://cantusindex.uwaterloo.ca/json-nextchants/001010")
         # >>> response.encoding

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -24,6 +24,7 @@ class MockResponse:
     def __init__(
         self,
         status_code: int,
+        text: str,
         json: Union[dict, list, None],
         content: bytes,
         encoding: str = "utf-8",
@@ -35,6 +36,7 @@ class MockResponse:
         self._json = json
         self.content = content
         self.encoding = encoding
+        self.text = text
 
     def json(self):
         return self._json
@@ -76,12 +78,22 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_nextchants_001010_content,
+                text=mock_cantusindex_data.mock_json_nextchants_001010_text,
                 json=mock_cantusindex_data.mock_json_nextchants_001010_json,
+            )
+        elif url.endswith("/a07763"):
+            # this Cantus ID has no suggested chants
+            return MockResponse(
+                status_code=200,
+                content=mock_cantusindex_data.mock_json_nextchants_a07763_content,
+                text=mock_cantusindex_data.mock_json_nextchants_a07763_text,
+                json=None,
             )
         else:  # imitating CI's behavior when a made-up Cantus ID is entered.
             return MockResponse(
                 status_code=200,
                 content=bytes('["Cantus ID is not valid"]', encoding="utf-8-sig"),
+                text='["Cantus ID is not valid"]',
                 json=["Cantus ID is not valid"],
             )
     elif (
@@ -92,42 +104,49 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_cid_008349_content,
+                text=mock_cantusindex_data.mock_json_cid_008349_text,
                 json=mock_cantusindex_data.mock_json_cid_008349_json,
             )
         elif url.endswith("/006928"):
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_cid_006928_content,
+                text=mock_cantusindex_data.mock_json_cid_006928_text,
                 json=mock_cantusindex_data.mock_json_cid_006928_json,
             )
         elif url.endswith("/008411c"):
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_cid_008411c_content,
+                text=mock_cantusindex_data.mock_json_cid_008411c_text,
                 json=mock_cantusindex_data.mock_json_cid_008411c_json,
             )
         elif url.endswith("/008390"):
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_cid_008390_content,
+                text=mock_cantusindex_data.mock_json_cid_008390_text,
                 json=mock_cantusindex_data.mock_json_cid_008390_json,
             )
         elif url.endswith("/007713"):
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_cid_007713_content,
+                text=mock_cantusindex_data.mock_json_cid_007713_text,
                 json=mock_cantusindex_data.mock_json_cid_007713_json,
             )
         elif url.endswith("/909030"):
             return MockResponse(
                 status_code=200,
                 content=mock_cantusindex_data.mock_json_cid_909030_content,
+                text=mock_cantusindex_data.mock_json_cid_909030_text,
                 json=mock_cantusindex_data.mock_json_cid_909030_json,
             )
         else:  # imitating CI's behavior when a made-up Cantus ID is entered.
             return MockResponse(
                 status_code=5.00,
                 content=None,
+                text=None,
                 json=None,
             )
     else:

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -144,7 +144,7 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
             )
         else:  # imitating CI's behavior when a made-up Cantus ID is entered.
             return MockResponse(
-                status_code=5.00,
+                status_code=500,
                 content=None,
                 text=None,
                 json=None,
@@ -321,6 +321,7 @@ class CantusIndexFunctionsTest(TestCase):
             self.assertIsNone(observed_chant_nonexistent_cantus_id)
 
     def test_get_suggested_chants(self):
+        expected_number_of_suggestions: int = 3
         with patch("requests.get", mock_requests_get):
             suggested_chants = get_suggested_chants(cantus_id="001010")
 
@@ -330,13 +331,15 @@ class CantusIndexFunctionsTest(TestCase):
             self.assertIsInstance(suggested_chants, list)
             self.assertIsInstance(initial_suggested_chant, dict)
 
-        with self.subTest(test="Ensure no more than 5 suggestions returned"):
-            self.assertLessEqual(len(suggested_chants), 5)
+        with self.subTest(
+            test=f"Ensure no more than {expected_number_of_suggestions} suggestions returned"
+        ):
+            self.assertLessEqual(len(suggested_chants), expected_number_of_suggestions)
 
         with self.subTest(
             test="Ensure suggested chants are ordered by number of occurrences"
         ):
-            for i in range(4):
+            for i in range(expected_number_of_suggestions - 1):
                 suggested_chant = suggested_chants[i]
                 following_suggested_chant = suggested_chants[i + 1]
                 self.assertGreaterEqual(

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -118,3 +118,11 @@ class IncipitSignalTest(TestCase):
         observed_incipit_2 = generate_incipit(short_fulltext)
         with self.subTest(test="fulltext that's already a short incipit"):
             self.assertEqual(observed_incipit_2, expected_incipit_2)
+
+
+class CantusIndexFunctionsTest(TestCase):
+    def test_get_suggested_chant(self):
+        pass
+
+    def test_get_suggested_chants(self):
+        pass

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -397,16 +397,9 @@ class CantusIndexFunctionsTest(TestCase):
         ):
             self.assertIsNone(response_nonexistent_cantus_id)
 
-        # I can't figure out how to get assertRaises to work - even when the assertion should fail, it doesn't.
-        # It's not of vital importance that this argument check work correctly, I think, so I'm giving up in
-        # an effort not to get bogged down.
-        # Leaving a couple of commented-out attempts here with things I've tried, for the hopeful benefit of some
-        # future, cleverer developer
-        # - Jacob dGM, April 2024
-
-        # with self.subTest(test="Ensure raises ValueError when path improperly formatted, attempt 1"):
-        #     self.assertRaises(ValueError, get_json_from_ci_api, "/for/some/reason/this/passes/even/with/a/leading/slash")
-
-        # with self.subTest(test="Ensure raises ValueError when path improperly formatted, attempt 2"):
-        #     with self.assertRaises(ValueError):
-        #         get_json_from_ci_api("/i/still/dont/understand/why/this/subtest/passes")
+        with self.subTest(
+            test="Ensure raises ValueError when path lacks leading slash"
+        ):
+            self.assertRaises(
+                ValueError, get_json_from_ci_api, "path/lacking/a/leading/slash"
+            )

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -363,6 +363,15 @@ class CantusIndexFunctionsTest(TestCase):
         with self.subTest(test="Ensure returns None when requests.get times out"):
             self.assertIsNone(response_short_timeout)
 
+        with patch("requests.get", mock_requests_get):
+            response_nonexistent_cantus_id = get_json_from_ci_api(
+                path="/json-cid/notACantusID"
+            )
+        with self.subTest(
+            test="Ensure returns None when response status code is not 200"
+        ):
+            self.assertIsNone(response_nonexistent_cantus_id)
+
         # I can't figure out how to get assertRaises to work - even when the assertion should fail, it doesn't.
         # It's not of vital importance that this argument check work correctly, I think, so I'm giving up in
         # an effort not to get bogged down.

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -63,7 +63,7 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
     if not (
         "https://cantusindex.uwaterloo.ca" in url or "https://cantusindex.org" in url
     ):
-        raise ValueError(
+        raise NotImplementedError(
             f"mock_requests_get is only set up to mock calls to Cantus Index. "
             f"The protocol and domain of url {url} do not correspond to those of Cantus Index."
         )
@@ -105,7 +105,7 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
                 status_code=500,
             )
     else:
-        raise ValueError(
+        raise NotImplementedError(
             f"mock_requests_get is only set up to imitate only the /json-nextchants/ "
             f"and /json-cid/ endpoints on Cantus Index. The path of the url {url} does "
             f"not match either of these endpoints."

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -320,10 +320,17 @@ class CantusIndexFunctionsTest(TestCase):
             for i in range(4):
                 suggested_chant = suggested_chants[i]
                 following_suggested_chant = suggested_chants[i + 1]
-                self.assertLessEqual(
+                self.assertGreaterEqual(
                     suggested_chant["occurrences"],
                     following_suggested_chant["occurrences"],
                 )
+
+        with patch("requests.get", mock_requests_get):
+            suggested_chants_nonexistent_cantus_id = get_suggested_chants(
+                "NotACantusID"
+            )
+        with self.subTest(test="Ensure None returned in case of nonexistent Cantus ID"):
+            self.assertIsNone(suggested_chants_nonexistent_cantus_id)
 
     def test_get_json_from_ci_api(self):
         with patch("requests.get", mock_requests_get):

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -126,7 +126,9 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
             )
         else:  # imitating CI's behavior when a made-up Cantus ID is entered.
             return MockResponse(
-                status_code=500,
+                status_code=5.00,
+                content=None,
+                json=None,
             )
     else:
         raise NotImplementedError(
@@ -250,7 +252,9 @@ class CantusIndexFunctionsTest(TestCase):
             "occurrences": occs,
             "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
             "incipit": "Nocte surgentes vigilemus omnes semper",
+            "genre_name": "H",
             "genre_id": h_genre.id,
+            "clean_cantus_id": "008349",
         }
         with patch("requests.get", mock_requests_get):
             observed_chant = get_suggested_chant(cantus_id="008349", occurrences=occs)
@@ -298,14 +302,18 @@ class CantusIndexFunctionsTest(TestCase):
                 "occurrences": 17,
                 "fulltext": "Nocte surgentes vigilemus omnes semper in psalmis meditemur atque viribus totis domino canamus dulciter hymnos | Ut pio regi pariter canentes cum suis sanctis mereamur aulam ingredi caeli simul et beatam ducere vitam | Praestet hoc nobis deitas beata patris ac nati pariterque sancti spiritus cujus resonat per omnem gloria mundum | Amen",
                 "incipit": "Nocte surgentes vigilemus omnes semper",
+                "genre_name": "H",
                 "genre_id": h_genre.id,
+                "clean_cantus_id": "008349",
             },
             {
                 "cantus_id": "006928",
                 "occurrences": 10,
                 "fulltext": "In principio fecit deus caelum et terram et creavit in ea hominem ad imaginem et similitudinem suam",
                 "incipit": "In principio fecit deus caelum",
+                "genre_name": "R",
                 "genre_id": r_genre.id,
+                "clean_cantus_id": "006928",
             },
         ]
         with patch("requests.get", mock_requests_get):

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -278,7 +278,6 @@ class CantusIndexFunctionsTest(TestCase):
             observed_chant_with_r_genre = get_suggested_chant(
                 cantus_id="006928", occurrences=occs
             )
-
         with self.subTest(
             test="Ensure that genre_id=None when no matching Genre found"
         ):
@@ -289,9 +288,18 @@ class CantusIndexFunctionsTest(TestCase):
             observed_chant_short_timeout = get_suggested_chant(
                 cantus_id="008349", occurrences=occs, timeout=0.0001
             )
-
         with self.subTest(test="Ensure None is returned in case of timeout"):
             self.assertIsNone(observed_chant_short_timeout)
+
+        with patch("requests.get", mock_requests_get):
+            observed_chant_nonexistent_cantus_id = get_suggested_chant(
+                cantus_id="NotACantusID",
+                occurrences=occs,
+            )
+        with self.subTest(
+            test="Ensure None is returned in case of nonexistent Cantus ID"
+        ):
+            self.assertIsNone(observed_chant_nonexistent_cantus_id)
 
     def test_get_suggested_chants(self):
         h_genre = make_fake_genre(name="H")

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -14,7 +14,12 @@ from main_app.tests.make_fakes import (
 )
 from main_app.management.commands import update_cached_concordances
 from main_app.signals import generate_incipit
-from cantusindex import get_suggested_chant, get_suggested_chants, get_json_from_ci_api
+from cantusindex import (
+    get_suggested_chant,
+    get_suggested_chants,
+    get_json_from_ci_api,
+    CANTUS_INDEX_DOMAIN,
+)
 
 # run with `python -Wa manage.py test main_app.tests.test_functions`
 # the -Wa flag tells Python to display deprecation warnings
@@ -62,18 +67,13 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
     if timeout < 0.001:
         raise requests.exceptions.ConnectTimeout
 
-    if not (
-        "https://cantusindex.uwaterloo.ca" in url or "https://cantusindex.org" in url
-    ):
+    if not (CANTUS_INDEX_DOMAIN in url):
         raise NotImplementedError(
             f"mock_requests_get is only set up to mock calls to Cantus Index. "
             f"The protocol and domain of url {url} do not correspond to those of Cantus Index."
         )
 
-    if (
-        "https://cantusindex.uwaterloo.ca/json-nextchants/" in url
-        or "https://cantusindex.org/json-nextchants/" in url
-    ):
+    if f"{CANTUS_INDEX_DOMAIN}/json-nextchants/" in url:
         if url.endswith("/001010"):
             return MockResponse(
                 status_code=200,
@@ -96,10 +96,7 @@ def mock_requests_get(url: str, timeout: float) -> MockResponse:
                 text='["Cantus ID is not valid"]',
                 json=["Cantus ID is not valid"],
             )
-    elif (
-        "https://cantusindex.uwaterloo.ca/json-cid/" in url
-        or "https://cantusindex.org/json-cid/" in url
-    ):
+    elif f"{CANTUS_INDEX_DOMAIN}/json-cid/" in url:
         if url.endswith("/008349"):
             return MockResponse(
                 status_code=200,

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -2997,7 +2997,7 @@ class ChantCreateViewTest(TestCase):
                 response_after_previous_chant, "Suggestions based on previous chant:"
             )
             self.assertIsNotNone(suggested_chants)
-            self.assertEqual(len(suggested_chants), 5)
+            self.assertEqual(len(suggested_chants), 3)
 
         rare_chant: Chant = make_fake_chant(cantus_id="a07763", source=source)
         with patch("requests.get", mock_requests_get):

--- a/django/cantusdb_project/static/js/chant_create.js
+++ b/django/cantusdb_project/static/js/chant_create.js
@@ -30,3 +30,17 @@ function autoFillSuggestedChant(genreName, genreID, cantusID, fullText) {
         $('#id_genre').append(newOption).trigger('change');
     };
 }
+
+function autoFillFeast(feastName, feastID) {
+    // Since we're using a django-autocomplete-light widget for the Genre selector,
+    // we need to follow a special process in selecting a value from the widget:
+    // Set the value, creating a new option if necessary
+    if ($('#id_feast').find("option[value='" + feastID + "']").length) {
+        $('#id_feast').val(feastID).trigger('change');
+    } else { 
+        // Create a DOM Option and pre-select by default
+        var newOption = new Option(feastName, feastID, true, true);
+        // Append it to the select
+        $('#id_feast').append(newOption).trigger('change');
+    };
+}

--- a/django/cantusdb_project/static/js/chant_create.js
+++ b/django/cantusdb_project/static/js/chant_create.js
@@ -8,3 +8,25 @@ window.addEventListener("load", function () {
         document.getElementById('id_manuscript_full_text').value = standardText;
     }
 })
+
+function autoFillSuggestedChant(genreName, genreID, cantusID, fullText) {
+    document.getElementById('id_cantus_id').value = cantusID;
+    document.getElementById('id_manuscript_full_text_std_spelling').value = fullText;
+
+    // in case suggestion.genre_id was None, don't try to change the #id_genre selector
+    if (genreID === null) {
+        return
+    }
+
+    // Since we're using a django-autocomplete-light widget for the Genre selector,
+    // we need to follow a special process in selecting a value from the widget:
+    // Set the value, creating a new option if necessary
+    if ($('#id_genre').find("option[value='" + genreID + "']").length) {
+        $('#id_genre').val(genreID).trigger('change');
+    } else { 
+        // Create a DOM Option and pre-select by default
+        var newOption = new Option(genreName, genreID, true, true);
+        // Append it to the select
+        $('#id_genre').append(newOption).trigger('change');
+    };
+}


### PR DESCRIPTION
This PR reinstates the Suggested Chants buttons on the Chant Create page. It adds several functions in a new file, `cantusindex.py`. The main purpose of these functions is to request data from Cantus Index and parse it.

As part of writing these functions, I set up a system that allows us to replace `requests.get` calls with a mock function, so that CI doesn't get blitzed with requests whenever someone runs the test suite (and also so our test suite runs more quickly, and also so our tests don't start failing if the state of CI's database changes). These mock objects/functions are used extensively in `test_functions`, and are also used in `test_views.ChantCreateViewTest` wherever we had been requesting the Chant Create page. As we turn on features that request data from Cantus Index in other views, we should remember to patch any calls to `requests.get` in those views as well.

Once I had figured out how to refactor the `autoFillSuggestedChant` function(s) (see #1024), I went ahead and refactored the `autoFillFeast` functions as well.

This PR fixes #1388 and fixes #1024.