### PR TITLE
Chant Edit: Reimplement Suggested Fulltext feature

### DIFF
--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -112,6 +112,22 @@ def get_suggested_chant(
     }
 
 
+def get_suggested_fulltext(cantus_id: str) -> str:
+    endpoint_path: str = f"/json-cid/{cantus_id}"
+    json: Union[dict, list, None] = get_json_from_ci_api(endpoint_path)
+
+    if not isinstance(json, dict):
+        # mostly, in case of a timeout within get_json_from_ci_api
+        return None
+
+    try:
+        suggested_fulltext = json["info"]["field_full_text"]
+    except KeyError:
+        return None
+
+    return suggested_fulltext
+
+
 def get_json_from_ci_api(
     path: str, timeout: float = DEFAULT_TIMEOUT
 ) -> Union[dict, list, None]:

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -3076,20 +3076,21 @@ class SourceEditChantsViewTest(TestCase):
         # must specify folio, or SourceEditChantsView.get_queryset will fail when it tries to default to displaying the first folio
         Chant.objects.create(source=source1, folio="001r")
 
-        response = self.client.get(reverse("source-edit-chants", args=[source1.id]))
+        with patch("requests.get", mock_requests_get):
+            response = self.client.get(reverse("source-edit-chants", args=[source1.id]))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "chant_edit.html")
-
-        response = self.client.get(
-            reverse("source-edit-chants", args=[source1.id + 100])
-        )
+        with patch("requests.get", mock_requests_get):
+            response = self.client.get(
+                reverse("source-edit-chants", args=[source1.id + 100])
+            )
         self.assertEqual(response.status_code, 404)
         self.assertTemplateUsed(response, "404.html")
 
         # trying to access chant-edit with a source that has no chant should return 200
         source2 = make_fake_source()
-
-        response = self.client.get(reverse("source-edit-chants", args=[source2.id]))
+        with patch("requests.get", mock_requests_get):
+            response = self.client.get(reverse("source-edit-chants", args=[source2.id]))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "chant_edit.html")
 
@@ -3098,10 +3099,10 @@ class SourceEditChantsViewTest(TestCase):
         chant = make_fake_chant(
             source=source, manuscript_full_text_std_spelling="initial"
         )
-
-        response = self.client.get(
-            reverse("source-edit-chants", args=[source.id]), {"pk": chant.id}
-        )
+        with patch("requests.get", mock_requests_get):
+            response = self.client.get(
+                reverse("source-edit-chants", args=[source.id]), {"pk": chant.id}
+            )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "chant_edit.html")
 
@@ -3166,7 +3167,10 @@ class SourceEditChantsViewTest(TestCase):
                 "volpiano": "abacadaeafagahaja",
             },
         )
-        chant_2 = Chant.objects.get(manuscript_full_text_std_spelling="resonare foobaz")
+        with patch("requests.get", mock_requests_get):
+            chant_2 = Chant.objects.get(
+                manuscript_full_text_std_spelling="resonare foobaz"
+            )
         self.assertEqual(chant_2.volpiano, expected_volpiano)
         self.assertEqual(chant_2.volpiano_intervals, expected_intervals)
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1118,7 +1118,10 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         context["user_can_proofread_chant"] = user_can_proofread_chant(user, chant)
         return context
 
-    def get_initial(self):
+    def get_initial(self) -> dict:
+        # in case the chant has no manuscript_full_text_std_spelling, we check Cantus Index
+        # for the expected text for chants with the same Cantus ID, and provide this as an
+        # initial value for the Manuscript Reading Full Text (standardized spelling) field
         initial: dict = super().get_initial()
         chant: Chant = self.get_object()
         cantus_id: str = chant.cantus_id

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1123,8 +1123,15 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         # for the expected text for chants with the same Cantus ID, and provide this as an
         # initial value for the Manuscript Reading Full Text (standardized spelling) field
         initial: dict = super().get_initial()
-        chant: Chant = self.get_object()
-        cantus_id: str = chant.cantus_id
+        chant: Optional[Chant] = self.get_object()
+
+        if not chant:
+            return initial
+
+        cantus_id: Optional[str] = chant.cantus_id
+
+        if not cantus_id:
+            return initial
 
         suggested_fulltext: Optional[str] = None
         if chant.manuscript_full_text_std_spelling == "":

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -44,7 +44,7 @@ from volpiano_display_utilities.cantus_text_syllabification import (
     flatten_syllabified_text,
 )
 from volpiano_display_utilities.text_volpiano_alignment import align_text_and_volpiano
-from cantusindex import get_suggested_chants
+from cantusindex import get_suggested_chants, get_suggested_fulltext
 
 CHANT_SEARCH_TEMPLATE_VALUES: tuple[str, ...] = (
     # for views that use chant_search.html, this allows them to
@@ -1117,6 +1117,20 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         user = self.request.user
         context["user_can_proofread_chant"] = user_can_proofread_chant(user, chant)
         return context
+
+    def get_initial(self):
+        initial: dict = super().get_initial()
+        chant: Chant = self.get_object()
+        cantus_id: str = chant.cantus_id
+
+        suggested_fulltext: Optional[str] = None
+        if chant.manuscript_full_text_std_spelling == "":
+            suggested_fulltext = get_suggested_fulltext(cantus_id)
+
+        if suggested_fulltext:
+            initial["manuscript_full_text_std_spelling"] = suggested_fulltext
+
+        return initial
 
     def form_valid(self, form):
         if form.is_valid():


### PR DESCRIPTION
This PR fixes #1390, reimplementing the Autofill Suggested Fulltext feature.

It's a draft for the time being, because tests still need to be written:
- [x] in `test_functions`, a test needs to be added for `cantusindex.get_suggested_fulltext`
- [ ] in `test_views`, a test needs to be added to `SourceEditChantsViewTest`