### PR TITLE
Adjust query for `test_get_concordances`

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_models.py
+++ b/django/cantusdb_project/main_app/tests/test_models.py
@@ -90,7 +90,7 @@ class ChantModelTest(TestCase):
         self.assertEqual(weight_search_term_dict, expected_dict)
 
     def test_get_concordances(self):
-        chant = Chant.objects.get(id=1)
+        chant = Chant.objects.first()
         chant_with_same_cantus_id = Chant.objects.create(
             cantus_id=chant.cantus_id, source=chant.source
         )


### PR DESCRIPTION
For some reason, we were previously getting the test chant in `ChantModelTest.test_get_concordances` by id, uniquely in that `TestCase`. This PR conforms getting the test chant with `.first()`

Closes #1427.