### PR TITLE
Add build args to docker-compose-development.yml

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: .
       dockerfile: ./django/Dockerfile
+      args:
+        PROJECT_ENVIRONMENT: DEVELOPMENT
     volumes:
       - ./django/cantusdb_project:/code/cantusdb_project
       - static_volume:/resources/static


### PR DESCRIPTION
Adds the `PROJECT_ENVIRONMENT` build argument to `docker-compose-development.yml`. This governs the installation of packages in the `django` container (see `./django/Dockerfile` and `./django/install-packages.sh` for details.