### PR TITLE
Populate missing `diff_id` Chant fields

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/populate_diff_id_fields.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_diff_id_fields.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        CHUNK_SIZE = 1_000
+        CHUNK_SIZE = 500
         chants = Chant.objects.filter(
             Q(differentiae_database__isnull=False) & Q(diff_db__isnull=True)
         )

--- a/django/cantusdb_project/main_app/management/commands/populate_diff_id_fields.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_diff_id_fields.py
@@ -20,20 +20,16 @@ class Command(BaseCommand):
             for chant in chunk:
                 try:
                     differentia_id: Optional[str] = chant.differentiae_database
-                    if not differentia_id is None:
-
-                        differentia = Differentia.objects.get(
-                            differentia_id=differentia_id
+                    differentia = Differentia.objects.get(differentia_id=differentia_id)
+                    if differentia:
+                        chant.diff_db = differentia
+                    else:
+                        # If the Differentia doesn't exist, create a new one
+                        differentia = Differentia(
+                            differentia_id=differentia_id,
                         )
-                        if differentia:
-                            chant.diff_db = differentia
-                        else:
-                            # If the Differentia doesn't exist, create a new one
-                            differentia = Differentia(
-                                differentia_id=differentia_id,
-                            )
-                            differentia.save()
-                            chant.diff_db = differentia
+                        differentia.save()
+                        chant.diff_db = differentia
                     chant.save()
                 except Differentia.DoesNotExist:
                     print(f"Differentia not found for chant: {chant}")

--- a/django/cantusdb_project/main_app/management/commands/populate_diff_id_fields.py
+++ b/django/cantusdb_project/main_app/management/commands/populate_diff_id_fields.py
@@ -1,0 +1,50 @@
+from main_app.models import Chant, Differentia
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from typing import Optional
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        CHUNK_SIZE = 1_000
+        chants = Chant.objects.filter(
+            Q(differentiae_database__isnull=False) & Q(diff_db__isnull=True)
+        )
+        chants_count = chants.count()
+        start_index = 0
+        count = 0
+        while start_index <= chants_count:
+            self.stdout.write(f"processing chunk with {start_index=}")
+            chunk = chants[start_index : start_index + CHUNK_SIZE]
+
+            for chant in chunk:
+                try:
+                    differentia_id: Optional[str] = chant.differentiae_database
+                    if not differentia_id is None:
+
+                        differentia = Differentia.objects.get(
+                            differentia_id=differentia_id
+                        )
+                        if differentia:
+                            chant.diff_db = differentia
+                        else:
+                            # If the Differentia doesn't exist, create a new one
+                            differentia = Differentia(
+                                differentia_id=differentia_id,
+                            )
+                            differentia.save()
+                            chant.diff_db = differentia
+                    chant.save()
+                except Differentia.DoesNotExist:
+                    print(f"Differentia not found for chant: {chant}")
+                count += 1
+                if count % 100 == 0:
+                    print(
+                        f"------------------ {count} of {chants_count} chants updated ------------------"
+                    )
+            del chunk  # make sure we don't use too much RAM
+            start_index += CHUNK_SIZE
+
+        self.stdout.write(
+            self.style.SUCCESS("Success! Command has run to completion.\n")
+        )


### PR DESCRIPTION
In #1368, we noticed that there were many instances where a Chant's `differentiae_database` field was non-empty while the newly created `diff_db` field was empty.

This has occurred after running the management command in #1104 that had created new `Differentia` objects in the database and subsequently populated each chant with a ForeignKey `diff_id` that points to it's corresponding `Differentia` object.

For some reason, many chants were left unchanged (17634 on production). While I'm not 100% sure what caused this issue, I suspect it could be due to memory/resource problems while iterating through each chant in the database.

In this PR, I have created a new management command that will specifically target these chants with empty `diff_id` fields. Additionally, to reduce the risk of resource constraints, I have reduced the chunk size for batch processing. Running this script locally has eliminated all of the missing `diff_id` fields.