### PR TITLE
Replace some instances of "manuscript" with "source"

### DIFF
--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -166,12 +166,12 @@
                         <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
                         <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
-                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
+                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
                         {% if source.image_link %}
                             <a href="{{ source.image_link }}" class="guillemet" target="_blank">Images</a>
                         {% endif %}
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
+                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
+                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
                     </small>
                 </div>    
 

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -211,12 +211,12 @@
                         {% endif %}
                         <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
-                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
+                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
                         {% if source.image_link %}
                             <a href="{{ source.image_link }}" class="guillemet" target="_blank">Images</a>
                         {% endif %}
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
+                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
+                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
                     </small>
                 </div>    
             </div>

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -37,7 +37,7 @@
 
                     <div class="form-group m-1 col-lg-9">
                         <label for="{{ form.title.id_for_label }}">
-                            Full Manuscript Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span>
+                            Full Source Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span>
                         </label>
                         {{ form.title }}
                     </div>
@@ -101,7 +101,7 @@
                     <div class="form-group m-1 col-lg-7">
                         {{ form.date.label_tag }}
                         {{ form.date }}
-                        <small>Date of the manuscript (e.g. "1200s", "1300-1350", etc.)</small>
+                        <small>Date of the source (e.g. "1200s", "1300-1350", etc.)</small>
                     </div>
                 </div>
 
@@ -262,12 +262,12 @@
                         {% endif %}
                         <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
                         <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
-                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this manuscript</a>
+                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
                         {% if source.image_link %}
                             <a href="{{ source.image_link }}" class="guillemet" target="_blank">Images</a>
                         {% endif %}
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this manuscript</a>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this manuscript (Cantus Analysis Tool)</a>
+                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
+                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
 
                     </small>
                     {% if chants.exists %}


### PR DESCRIPTION
Towards #1097, we want to change the site to display "source" wherever we currently display "manuscript".

There are still some cases where we aren't sure about what change to make or might need explicit approval from Debra, but in the meantime the following pages are deemed suitable to go ahead and make the change right away:

- Chant List: "Search chants in this manuscript" and "Analyse this manuscript (Cantus Analysis Tool)"
- Source Detail: "Search {chants|melodies} in this manuscript" and "Analyse this manuscript (Cantus Analysis Tool)"
- Source Edit: "Full Manuscript Identification (City, Archive, Shelf-mark)", "Date of the manuscript (e.g. "1200s", "1300-1350", etc.)"