### PR TITLE
Remove duplicates from feast-folio dropdown

### DIFF
--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -158,8 +158,8 @@
 
                         <select name="feast" id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
-                            {% for folio, feast in feasts_with_folios %}
-                                <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
+                            {% for folio, feast_id, feast_name in feasts_with_folios %}
+                                <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
                             {% endfor %}
                         </select>
                         <br>

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -355,8 +355,8 @@
 
                             <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                                 <option value="">Select a feast:</option>
-                                {% for folio, feast in feasts_with_folios %}
-                                    <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
+                                {% for folio, feast_id, feast_name in feasts_with_folios %}
+                                    <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
                                 {% endfor %}
                             </select>
                             <br>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -201,8 +201,8 @@
 
                             <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                                 <option value="">Select a feast:</option>
-                                {% for folio, feast in feasts_with_folios %}
-                                    <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
+                                {% for folio, feast_id, feast_name in feasts_with_folios %}
+                                    <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
                                 {% endfor %}
                             </select>
 

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -250,8 +250,8 @@
 
                         <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
                             <option value="">Select a feast:</option>
-                            {% for folio, feast in feasts_with_folios %}
-                                <option value="{{ feast.id }}">{{ folio }} - {{ feast.name }}</option>
+                            {% for folio, feast_id, feast_name in feasts_with_folios %}
+                                <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
                             {% endfor %}
                         </select>          
 

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -706,7 +706,11 @@ class SourceBrowseChantsViewTest(TestCase):
         response = self.client.get(reverse("browse-chants", args=[source.id]))
         # context "feasts_with_folios" is a list of tuples
         # it records the folios where the feast changes
-        expected_result = [("001r", feast_1), ("001v", feast_2), ("002r", feast_1)]
+        expected_result = [
+            ("001r", feast_1.id, feast_1.name),
+            ("001v", feast_2.id, feast_2.name),
+            ("002r", feast_1.id, feast_1.name),
+        ]
         self.assertEqual(response.context["feasts_with_folios"], expected_result)
 
     def test_redirect_with_source_parameter(self):
@@ -4367,7 +4371,11 @@ class SourceDetailViewTest(TestCase):
         response = self.client.get(reverse("source-detail", args=[source.id]))
         # context "feasts_with_folios" is a list of tuples
         # it records the folios where the feast changes
-        expected_result = [("001r", feast_1), ("001v", feast_2), ("002r", feast_1)]
+        expected_result = [
+            ("001r", feast_1.id, feast_1.name),
+            ("001v", feast_2.id, feast_2.name),
+            ("002r", feast_1.id, feast_1.name),
+        ]
         self.assertEqual(response.context["feasts_with_folios"], expected_result)
 
     def test_context_sequences(self):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1,7 +1,6 @@
 import urllib
 from collections import Counter
-from typing import Optional
-
+from typing import Optional, Iterator, cast
 
 from volpiano_display_utilities.cantus_text_syllabification import (
     syllabify_text,
@@ -77,9 +76,7 @@ CHANT_SEARCH_TEMPLATE_VALUES: tuple[str, ...] = (
 )
 
 
-def get_feast_selector_options(
-    source: Source, folios: list[str]
-) -> list[tuple[str, Feast]]:
+def get_feast_selector_options(source: Source) -> list[tuple[str, int, str]]:
     """Generate folio-feast pairs as options for the feast selector
 
     Going through all chants in the source, folio by folio,
@@ -87,50 +84,22 @@ def get_feast_selector_options(
 
     Args:
         source (Source object): The source that the user is browsing in.
-        folios (list of strs): A list of folios in the source.
 
     Returns:
         list of tuples: A list of folios and Feast objects, to be unpacked in template.
     """
-    # the two lists to be zipped
-    feast_selector_feasts: list[Feast] = []
-    feast_selector_folios: list[str] = []
-    # get all chants in the source, select those that have a feast
-    chants_in_source: QuerySet[Chant] = (
+    folios_feasts_iter: Iterator[tuple[Optional[str], int, str]] = (
         source.chant_set.exclude(feast=None)
         .order_by("folio", "c_sequence")
-        .select_related("feast")
+        .values_list("folio", "feast_id", "feast__name")
+        .iterator()
     )
-    # initialize the feast selector options with the first chant in the source that has a feast
-    first_feast_chant: Optional[Feast] = chants_in_source.first()
-    if not first_feast_chant:
-        # if none of the chants in this source has a feast, return an empty list
-        return []
-    # if there is at least one chant that has a feast
-    current_feast: Feast = first_feast_chant.feast
-    feast_selector_feasts.append(current_feast)
-    current_folio: str = first_feast_chant.folio
-    feast_selector_folios.append(current_folio)
-
-    chants_by_folio: QuerySet[Chant] = chants_in_source.filter(
-        folio__in=folios
-    ).order_by("folio")
-    for chant in chants_by_folio:
-        if chant.feast != current_feast:
-            # if the feast changes, add the new feast and the corresponding folio to the lists
-            feast_selector_feasts.append(chant.feast)
-            feast_selector_folios.append(chant.folio)
-            # update the current_feast to track future changes
-            current_feast = chant.feast
-    # as the two lists will always be of the same length, no need for zip,
-    # just naively combine them
-    # if we use zip, the returned generator will be exhausted in rendering templates,
-    # making it hard to test the returned value
-    folios_with_feasts: list[tuple[str, Feast]] = [
-        (feast_selector_folios[i], feast_selector_feasts[i])
-        for i in range(len(feast_selector_folios))
-    ]
-    return folios_with_feasts
+    # Cast because we know, by restrictions on chant create form, that
+    # folio won't be None
+    folios_feasts_list = cast(list[tuple[str, int, str]], list(folios_feasts_iter))
+    # De-dupe query set while maintaining order
+    deduped_folios_feasts_lists = list(dict.fromkeys(folios_feasts_list))
+    return deduped_folios_feasts_lists
 
 
 class ChantDetailView(DetailView):
@@ -1066,7 +1035,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         )
         context["folios"] = folios
         # the options for the feast selector on the right, same as the source detail page
-        context["feasts_with_folios"] = get_feast_selector_options(source, folios)
+        context["feasts_with_folios"] = get_feast_selector_options(source)
 
         if self.request.GET.get("feast"):
             # if there is a "feast" query parameter, it means the user has chosen a specific feast

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1,6 +1,14 @@
-import requests
 import urllib
-import json
+from collections import Counter
+from typing import Optional
+
+
+from volpiano_display_utilities.cantus_text_syllabification import (
+    syllabify_text,
+    flatten_syllabified_text,
+)
+from volpiano_display_utilities.text_volpiano_alignment import align_text_and_volpiano
+
 from django.contrib import messages
 from django.db.models import Q, QuerySet
 from django.shortcuts import get_object_or_404
@@ -14,6 +22,11 @@ from django.views.generic import (
     UpdateView,
 )
 from django.core.exceptions import PermissionDenied
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
+
+from django.contrib.auth.mixins import UserPassesTestMixin
+
 from main_app.forms import (
     ChantCreateForm,
     ChantEditForm,
@@ -27,23 +40,12 @@ from main_app.models import (
     Sequence,
     Office,
 )
-from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import Http404
-from collections import Counter
-from django.contrib.auth.mixins import UserPassesTestMixin
-from typing import Optional
-from requests.exceptions import SSLError, Timeout, ConnectionError
-from requests import Response
 from main_app.permissions import (
     user_can_edit_chants_in_source,
     user_can_proofread_chant,
     user_can_view_chant,
 )
-from volpiano_display_utilities.cantus_text_syllabification import (
-    syllabify_text,
-    flatten_syllabified_text,
-)
-from volpiano_display_utilities.text_volpiano_alignment import align_text_and_volpiano
+
 from cantusindex import get_suggested_chants, get_suggested_fulltext
 
 CHANT_SEARCH_TEMPLATE_VALUES: tuple[str, ...] = (

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -156,7 +156,7 @@ class SourceBrowseChantsView(ListView):
             )
 
         # the options for the feast selector on the right, same as the source detail page
-        context["feasts_with_folios"] = get_feast_selector_options(source, folios)
+        context["feasts_with_folios"] = get_feast_selector_options(source)
         return context
 
 
@@ -191,7 +191,7 @@ class SourceDetailView(DetailView):
             )
             context["folios"] = folios
             # the options for the feast selector on the right, only chant sources have this
-            context["feasts_with_folios"] = get_feast_selector_options(source, folios)
+            context["feasts_with_folios"] = get_feast_selector_options(source)
 
         context["user_can_edit_chants"] = user_can_edit_chants_in_source(user, source)
         context["user_can_edit_source"] = user_can_edit_source(user, source)
@@ -404,7 +404,7 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             )
             context["folios"] = folios
             # the options for the feast selector on the right, only chant sources have this
-            context["feasts_with_folios"] = get_feast_selector_options(source, folios)
+            context["feasts_with_folios"] = get_feast_selector_options(source)
         return context
 
     def test_func(self):


### PR DESCRIPTION
Closes #916.

Also, takes this opportunity to clean up some of the imports in views.chant.