### PR TITLE
Temporarily comment segment fields on chant create and edit forms

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -95,7 +95,8 @@ class ChantCreateForm(forms.ModelForm):
             "content_structure",
             "indexing_notes",
             "addendum",
-            "segment",
+            # Temporarily commented; see #1452
+            # "segment",
         ]
         # the widgets dictionary is ignored for a model field with a non-empty
         # choices attribute. In this case, you must override the form field to
@@ -148,13 +149,14 @@ class ChantCreateForm(forms.ModelForm):
         "Mass Alleluias. Punctuation is omitted.",
     )
 
-    segment = forms.ModelChoiceField(
-        queryset=Segment.objects.all().order_by("id"),
-        required=True,
-        initial=Segment.objects.get(id=4063),  # Default to the "Cantus" segment
-        help_text="Select the Database segment that the chant belongs to. "
-        "In most cases, this will be the CANTUS segment.",
-    )
+    # Temporarily commented; see #1452
+    # segment = forms.ModelChoiceField(
+    #     queryset=Segment.objects.all().order_by("id"),
+    #     required=True,
+    #     initial=Segment.objects.get(id=4063),  # Default to the "Cantus" segment
+    #     help_text="Select the Database segment that the chant belongs to. "
+    #     "In most cases, this will be the CANTUS segment.",
+    # )
 
     # automatically computed fields
     # source and incipit are mandatory fields in model,
@@ -281,7 +283,8 @@ class ChantEditForm(forms.ModelForm):
             "manuscript_full_text_proofread",
             "volpiano_proofread",
             "proofread_by",
-            "segment",
+            # Temporarily commented; see #1452
+            # "segment",
         ]
         widgets = {
             # manuscript_full_text_std_spelling: defined below (required)
@@ -335,12 +338,13 @@ class ChantEditForm(forms.ModelForm):
         help_text="Each folio starts with '1'.",
     )
 
-    segment = forms.ModelChoiceField(
-        queryset=Segment.objects.all().order_by("id"),
-        required=True,
-        help_text="Select the Database segment that the chant belongs to. "
-        "In most cases, this will be the CANTUS segment.",
-    )
+    # Temporarily commented; see #1452
+    # segment = forms.ModelChoiceField(
+    #     queryset=Segment.objects.all().order_by("id"),
+    #     required=True,
+    #     help_text="Select the Database segment that the chant belongs to. "
+    #     "In most cases, this will be the CANTUS segment.",
+    # )
 
 
 class SourceEditForm(forms.ModelForm):

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -84,11 +84,11 @@
                         <label for="{{ form.cantus_id.id_for_label }}"><small>Cantus ID:</small></label>
                         {{ form.cantus_id }}
                     </div>
-
-                    <div class="form-group m-1 col-lg-2">
+                    <!-- Temporarily commented; see #1452 -->
+                    <!-- <div class="form-group m-1 col-lg-2">
                         <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                         {{ form.segment }}
-                    </div>
+                    </div> -->
                 </div>
 
                 <div class="form-row">

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -97,10 +97,11 @@
                             </label>
                             {{ form.melody_id }}
                         </div>
-                        <div class="form-group m-1 col-lg-2">
+                        <!-- Temporarily commented; see #1452 -->
+                        <!-- <div class="form-group m-1 col-lg-2">
                             <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                             {{ form.segment }}
-                        </div>
+                        </div> -->
                     </div>
 
                     <div class="form-row">


### PR DESCRIPTION
In #1434, we added the `segment` field to the `BaseChant` model. Along with adding the field, we added the ability to set and edit that field in the chant create and chant edit forms, respectively. 

It turns out I was premature...we don't want this new field to show up on the chant forms without any update to the instructions and protocols! Otherwise, when this goes to production indexers will see this new field, perhaps without any warning or training. So, I'm turning it off here by commenting those relevant areas in `forms.py` and the templates. When we've coordinated "turning on" this feature with Debra, we can uncomment. 