### PR TITLE
Provisionally import debug_toolbar urls iff DEBUG = True

### DIFF
--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from django.conf import settings
 from django.contrib.auth.views import (
     PasswordResetView,
     PasswordResetDoneView,
@@ -6,7 +7,6 @@ from django.contrib.auth.views import (
     PasswordResetCompleteView,
 )
 from main_app.views import views
-import debug_toolbar
 from main_app.views.century import (
     CenturyDetailView,
 )
@@ -75,7 +75,6 @@ from main_app.views.views import (
 )
 
 urlpatterns = [
-    path("__debug__/", include(debug_toolbar.urls)),
     path(
         "contact/",
         views.contact,
@@ -512,3 +511,8 @@ urlpatterns = [
         name="differentia-autocomplete",
     ),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+
+    urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))


### PR DESCRIPTION
With #1429, we no longer install the django-debug-toolbar dependency in non-development environments. This means that we don't want to import `debug_toolbar` in our `urls.py` unless `DEBUG = True`. With this PR, the import of `debug_toolbar` in `urls.py` more closely matches how it is done in `settings.py`.