### PR TITLE
Use update rather than save in assign_chants_to_segments

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/assign_chants_to_segments.py
+++ b/django/cantusdb_project/main_app/management/commands/assign_chants_to_segments.py
@@ -9,8 +9,6 @@ all chants in the database to the segment of the source they belong to.
 from django.core.management.base import BaseCommand
 from main_app.models import Source, Chant, Segment
 
-CHANT_CHUNK_SIZE = 1_000
-
 
 class Command(BaseCommand):
     help = "Assigns all chants in the database to the segment of the source they belong to."
@@ -20,11 +18,4 @@ class Command(BaseCommand):
         for source in sources:
             segment = Segment.objects.get(id=source.segment_id)
             chants = Chant.objects.filter(source=source)
-            chants_count = chants.count()
-            start_index = 0
-            while start_index < chants_count:
-                chant_chunk = chants[start_index : start_index + CHANT_CHUNK_SIZE]
-                for chant in chant_chunk:
-                    chant.segment = segment
-                    chant.save()
-                start_index += CHANT_CHUNK_SIZE
+            chants.update(segment=segment)


### PR DESCRIPTION
In testing the `assign_chants_to_segments` command (introduces in #1434) for #1437, I was finding the command was taking a very long time (about 20,000 chants assigned over the course of about 12 hours). This meant we were looking at a weeks-long command run, which seemed ripe for things going wrong! 

This PR changes the command to use the `update` method to add the segment to the chants in a source. Run-time is considerably reduced in tests.

@lucasmarchd01 raised the point in #1434 that batching chants would reduce the possibility for memory error. The use of `update` also obviates that need because chant objects are never loaded into memory here, and the updates happen entirely on the SQL side (as such, the `update` method does not work on sliced query sets).