### PR TITLE
Fix various simple html issues: copyright year, broken descriptions link, pagination with 1 page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -177,7 +177,7 @@
                         {{ form.manuscript_full_text_std_spelling }}
                         <p>
                             <small class="text-muted">{{ form.manuscript_full_text_std_spelling.help_text }}
-                                For more information, consult <a href="/field-descriptions/#Fulltext" target="_blank">Fields and Content Descriptions</a>.
+                                For more information, consult <a href="/description/#Fulltext" target="_blank">Fields and Content Descriptions</a>.
                             </small>
                         </p>
                     </div>

--- a/django/cantusdb_project/main_app/templates/pagination.html
+++ b/django/cantusdb_project/main_app/templates/pagination.html
@@ -1,5 +1,6 @@
 {% load helper_tags %} {# for url_add_get_params #}
 
+
 <div class="pagination">
     <span class="step-links">
         {% if page_obj.has_previous %}
@@ -29,4 +30,5 @@
         {% endif %}
     </span>
 </div>
+
 <span class="current">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -113,9 +113,9 @@
                 {% endfor %}
             </tbody>
         </table>
+        {% include "pagination.html" %}
     {% else %}
         No sources found.
     {% endif %}
-    {% include "pagination.html" %}
 </div>
 {% endblock %}

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -446,7 +446,7 @@
             <a href="mailto:debra.lacoste@dal.ca">
                 <img src="{% static "sendMailIcon.png" %}" alt="Send us email" loading="lazy">
             </a>
-            <small style="float: right">Cantus Database © 2012-2023</small>
+            <small style="float: right">Cantus Database © 2012-2024</small>
         </div>
     </footer>
 </body>

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -446,7 +446,7 @@
             <a href="mailto:debra.lacoste@dal.ca">
                 <img src="{% static "sendMailIcon.png" %}" alt="Send us email" loading="lazy">
             </a>
-            <small style="float: right">Cantus Database © 2012-2024</small>
+            <small style="float: right">Cantus Database © 2012-{% now "Y" %}</small>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
Decided to fix a number of small template-related issues.

This PR:
- Updates the copyright year in the footer. (Closes #1460 and closes #1348)
- Fixes a broken link under the full text field on the Chant Create page (Closes #1425)
- Brings pagination in the `source_list` template in line with pagination on the `chant_search` template -- no pagination is shown when there are no search results (Closes #1088)