### PR TITLE
Replace instances of "Manuscript" with "Source"

### DIFF
--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -2,7 +2,7 @@
 {% load helper_tags %} {# for recent_articles #}
 {% block content %}
 <div class="container">
-    <title>{{ article.title }} | Cantus Manuscript Database</title>
+    <title>{{ article.title }} | Cantus Database</title>
     <div class="row">
         <div class="p-3 col-lg-8 bg-white rounded main-content">
             <h3>

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -2,7 +2,7 @@
 {% load helper_tags %} {# for recent_articles #}
 {% block content %}
 <div class="container">
-    <title>What's New | Cantus Manuscript Database</title>
+    <title>What's New | Cantus Database</title>
     <div class="row">
         <div class="p-3 col-lg-8 bg-white rounded main-content">
             <h3>What's New</h3>

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -681,7 +681,7 @@ class AdminSourceForm(forms.ModelForm):
     title = forms.CharField(
         required=True,
         widget=TextInputWidget,
-        help_text="Full Manuscript Identification (City, Archive, Shelf-mark)",
+        help_text="Full Source Identification (City, Archive, Shelf-mark)",
     )
     title.widget.attrs.update({"style": "width: 610px;"})
 

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -27,7 +27,7 @@ class Source(BaseModel):
 
     title = models.CharField(
         max_length=255,
-        help_text="Full Manuscript Identification (City, Archive, Shelf-mark)",
+        help_text="Full Source Identification (City, Archive, Shelf-mark)",
     )
     # the siglum field as implemented on the old Cantus is composed of both the RISM siglum and the shelfmark
     # it is a human-readable ID for a source
@@ -64,7 +64,7 @@ class Source(BaseModel):
         blank=True,
         null=True,
         max_length=63,
-        help_text='Date of the manuscript (e.g. "1200s", "1300-1350", etc.)',
+        help_text='Date of the source (e.g. "1200s", "1300-1350", etc.)',
     )
     century = models.ManyToManyField("Century", related_name="sources", blank=True)
     notation = models.ManyToManyField("Notation", related_name="sources", blank=True)

--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Browse Chants | Cantus Manuscript Database</title>
+<title>Browse Chants | Cantus Database</title>
 <script src="/static/js/chant_list.js"></script>
 
 <div class="container">

--- a/django/cantusdb_project/main_app/templates/century_detail.html
+++ b/django/cantusdb_project/main_app/templates/century_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ century.name }} | Cantus Manuscript Database</title>
+<title>{{ century.name }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-<title>Create Chant | Cantus Manuscript Database</title>
+<title>Create Chant | Cantus Database</title>
 <script src="/static/js/chant_create.js"></script>
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}
@@ -172,8 +172,7 @@
             
                 <div class="form-row align-items-end">
                     <div class="form-group m-1 col-lg">
-                        <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}"><small>Manuscript Reading
-                                Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small></label>
+                        <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}"><small>Full text as in Source (standardized spelling):<span class="text-danger" title="This field is required">*</span></small></label>
                         {{ form.manuscript_full_text_std_spelling }}
                         <p>
                             <small class="text-muted">{{ form.manuscript_full_text_std_spelling.help_text }}
@@ -191,8 +190,8 @@
 
                 <div class="form-row align-items-end">
                     <div class="form-group m-1 col-lg">
-                        <label for="{{ form.manuscript_full_text.id_for_label }}"><small>Manuscript Reading Full Text
-                                (MS spelling): </small></label>
+                        <label for="{{ form.manuscript_full_text.id_for_label }}"><small>Full text as in Source
+                                (source spelling): </small></label>
                         {{ form.manuscript_full_text }}
                         <p class="text-muted" style="line-height: normal">
                             <small>{{ form.manuscript_full_text.help_text }}

--- a/django/cantusdb_project/main_app/templates/chant_delete.html
+++ b/django/cantusdb_project/main_app/templates/chant_delete.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Delete Chant | Cantus Manuscript Database</title>
+<title>Delete Chant | Cantus Database</title>
 <div class="p-3 col-md-12 bg-white rounded">
     <form method="post">{% csrf_token %}
         <p>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ chant.incipit }} | Cantus Manuscript Database</title>
+<title>{{ chant.incipit }} | Cantus Database</title>
 <script src="/static/js/chant_detail.js"></script>
 
 <div class="container">
@@ -168,12 +168,12 @@
                 </div>
 
                 {% if chant.manuscript_full_text_std_spelling %}
-                    <dt>Manuscript Reading Full Text (standardized spelling)</dt>
+                    <dt>Full text as in Source (standardized spelling)</dt>
                     <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
                 {% endif %}
 
                 {% if chant.manuscript_full_text %}
-                    <dt>Manuscript Reading Full Text (MS spelling)</dt>
+                    <dt>Full text as in Source (source spelling)</dt>
                     <dd>{{ chant.manuscript_full_text }}</dd>
                 {% endif %}
 

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 {% load static %}
-<title>{{ source.title }} | Cantus Manuscript Database</title>
+<title>{{ source.title }} | Cantus Database</title>
 <script src="/static/js/chant_edit.js"></script>
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}
@@ -163,7 +163,7 @@
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                <small>Manuscript Reading Full Text (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
+                                <small>Full text as in Source (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
                             </label>
                             {{ form.manuscript_full_text_std_spelling }}
                         </div>
@@ -173,7 +173,7 @@
                         <div class="form-row">
                             <div class="form-group m-1 col-lg-12">
                                 <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                    <small>Manuscript Reading Full Text (standardized spelling) proofread:</small>
+                                    <small>Full text as in Source (standardized spelling) proofread:</small>
                                 </label>
                                 {{ form.manuscript_full_text_std_proofread }}
                             </div>
@@ -189,7 +189,7 @@
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
                             <label for="{{ form.manuscript_full_text.id_for_label }}">
-                                <small>Manuscript Reading Full Text (MS spelling):</small>
+                                <small>Full text as in Source (source spelling):</small>
                             </label>
                             {{ form.manuscript_full_text }}
                         </div>
@@ -199,7 +199,7 @@
                         <div class="form-row">
                             <div class="form-group m-1 col-lg-12">
                                 <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                    <small>Manuscript Reading Full Text (MS spelling) proofread:</small>
+                                    <small>Full text as in Source (source spelling) proofread:</small>
                                 </label>
                                 {{ form.manuscript_full_text_proofread }}
                             </div>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Search Chants | Cantus Manuscript Database</title>
+<title>Search Chants | Cantus Database</title>
 <script src="/static/js/chant_search.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
@@ -179,15 +179,15 @@
                                     <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
                                 {% endif %}
                             </th>
-                            <th scope="col" class="text-wrap" style="text-align:center" title="Manuscript Full Text">
+                            <th scope="col" class="text-wrap" style="text-align:center" title="Full Text">
                                 {% if order == "has_fulltext" %}
                                     {% if sort == "desc" %}
-                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a> ▼
+                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">FT</a> ▼
                                     {% else %}
-                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">MsFt</a> ▲
+                                        <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">FT</a> ▲
                                     {% endif %}
                                 {% else %}
-                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">MsFt</a>
+                                    <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">FT</a>
                                 {% endif %}
                             </th>
                             <th scope="col" class="text-wrap" style="text-align:center" title="Volpiano Melody">

--- a/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
+++ b/django/cantusdb_project/main_app/templates/chant_seq_by_cantus_id.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Chants by Cantus ID: {{ cantus_id }} | Cantus Manuscript Database</title>
+<title>Chants by Cantus ID: {{ cantus_id }} | Cantus Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <!-- global search bar-->
     <object align="right" class="search-bar">

--- a/django/cantusdb_project/main_app/templates/chant_syllabification_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_syllabification_edit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Edit Syllabification | Cantus Manuscript Database</title>
+<title>Edit Syllabification | Cantus Database</title>
 
 <div class="container">
     <div class="row">

--- a/django/cantusdb_project/main_app/templates/contact.html
+++ b/django/cantusdb_project/main_app/templates/contact.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Contact | Cantus Manuscript Database</title>
+<title>Contact | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <!-- global search bar-->
     <object align="right" class="search-bar">

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load helper_tags %} {# for classname, admin_url_name #}
 {% block content %}
-<title>Content Overview | Cantus Manuscript Database</title>
+<title>Content Overview | Cantus Database</title>
 
 <div class="p-3 col-12 mx-auto bg-white rounded">
     <h3>Content Overview</h3>

--- a/django/cantusdb_project/main_app/templates/feast_detail.html
+++ b/django/cantusdb_project/main_app/templates/feast_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load helper_tags %} {# for month_to_string #}
 {% block content %}
-<title>{{ feast.name }} | Cantus Manuscript Database</title>
+<title>{{ feast.name }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/feast_list.html
+++ b/django/cantusdb_project/main_app/templates/feast_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load helper_tags %} {# for month_to_string #}
 {% block content %}
-<title>List of Feasts | Cantus Manuscript Database</title>
+<title>List of Feasts | Cantus Database</title>
 <script src="/static/js/feast_list.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/full_inventory.html
+++ b/django/cantusdb_project/main_app/templates/full_inventory.html
@@ -18,8 +18,8 @@
 </head>
 
 <body>
-    <title>Inventory | Cantus Manuscript Database</title>
-    <h3>CANTUS Manuscript Inventory: 
+    <title>Inventory | Cantus Database</title>
+    <h3>Cantus Inventory: 
         <a href="{% url 'source-detail' source.id %}" target="_href">{{ source.title }}</a>
     </h3>
     This source inventory contains {{ chants.count }} chants.

--- a/django/cantusdb_project/main_app/templates/genre_detail.html
+++ b/django/cantusdb_project/main_app/templates/genre_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ genre.name }} | Cantus Manuscript Database</title>
+<title>{{ genre.name }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/genre_list.html
+++ b/django/cantusdb_project/main_app/templates/genre_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>List of Genres | Cantus Manuscript Database</title>
+<title>List of Genres | Cantus Database</title>
 <script src="/static/js/genre_list.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/indexer_list.html
+++ b/django/cantusdb_project/main_app/templates/indexer_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>List of Indexers | Cantus Manuscript Database</title>
+<title>List of Indexers | Cantus Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/items_count.html
+++ b/django/cantusdb_project/main_app/templates/items_count.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% block content %}
-<title>Content Statistics | Cantus Manuscript Database</title>
+<title>Content Statistics | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/melody_search.html
+++ b/django/cantusdb_project/main_app/templates/melody_search.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Search by melody | Cantus Manuscript Database</title>
+<title>Search by melody | Cantus Database</title>
 <script src="/static/js/melody_search.js"></script>
 <div class="container">
     <div class="row">

--- a/django/cantusdb_project/main_app/templates/notation_detail.html
+++ b/django/cantusdb_project/main_app/templates/notation_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ notation.name }} | Cantus Manuscript Database</title>
+<title>{{ notation.name }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/office_detail.html
+++ b/django/cantusdb_project/main_app/templates/office_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ office.name }} | Cantus Manuscript Database</title>
+<title>{{ office.name }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/office_list.html
+++ b/django/cantusdb_project/main_app/templates/office_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Service Abbreviations | Cantus Manuscript Database</title>
+<title>Service Abbreviations | Cantus Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/provenance_detail.html
+++ b/django/cantusdb_project/main_app/templates/provenance_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ provenance.name }} | Cantus Manuscript Database</title>
+<title>{{ provenance.name }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/registration/login.html
+++ b/django/cantusdb_project/main_app/templates/registration/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Log in | Cantus Manuscript Database</title>
+<title>Log in | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-12 bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<title>Request Password Reset | Cantus Manuscript Database</title>
+<title>Request Password Reset | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-12 bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_complete.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_complete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<title>Reset Password Complete | Cantus Manuscript Database</title>
+<title>Reset Password Complete | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-12 bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_confirm.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_confirm.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<title>Reset Password | Cantus Manuscript Database</title>
+<title>Reset Password | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-12 bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_sent.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_sent.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<title>Password Reset Email Sent | Cantus Manuscript Database</title>
+<title>Password Reset Email Sent | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-12 bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ sequence.title }} | Cantus Manuscript Database</title>
+<title>{{ sequence.title }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <!--Display "submit success" message -->
     {% if messages %}

--- a/django/cantusdb_project/main_app/templates/sequence_edit.html
+++ b/django/cantusdb_project/main_app/templates/sequence_edit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ sequence.title }} | Cantus Manuscript Database</title>
+<title>{{ sequence.title }} | Cantus Database</title>
 
 <div class="container">
     <div class="row">

--- a/django/cantusdb_project/main_app/templates/sequence_list.html
+++ b/django/cantusdb_project/main_app/templates/sequence_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Clavis Sequentiarum (Calvin Bower) | Cantus Manuscript Database</title>
+<title>Clavis Sequentiarum (Calvin Bower) | Cantus Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/source_create.html
+++ b/django/cantusdb_project/main_app/templates/source_create.html
@@ -3,7 +3,7 @@
 {% block content %}
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}
-<title>Create Source | Cantus Manuscript Database</title>
+<title>Create Source | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-lg-12 bg-white rounded">
@@ -40,7 +40,7 @@
 
                     <div class="form-group m-1 col-lg-6">
                         <label for="{{ form.title.id_for_label }}">
-                            <small>Full Manuscript Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span></small>
+                            <small>Full Source Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span></small>
                         </label>
                         {{ form.title }}
                     </div>

--- a/django/cantusdb_project/main_app/templates/source_delete.html
+++ b/django/cantusdb_project/main_app/templates/source_delete.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Delete Source | Cantus Manuscript Database</title>
+<title>Delete Source | Cantus Database</title>
 <div class="p-3 col-12 bg-white rounded">
     <form method="post">{% csrf_token %}
         <p>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 {% load helper_tags %}
-<title>{{ source.title }} | Cantus Manuscript Database</title>
+<title>{{ source.title }} | Cantus Database</title>
 <script src="/static/js/source_detail.js"></script>
 
 <div class="container">

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-<title>{{ source.title }} | Cantus Manuscript Database</title>
+<title>{{ source.title }} | Cantus Database</title>
 <script src="/static/js/source_detail.js"></script>
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>Browse Sources | Cantus Manuscript Database</title>
+<title>Browse Sources | Cantus Database</title>
 <script src="/static/js/source_list.js"></script>
 
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">

--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>{{ user.full_name|default_if_none:"User" }} | Cantus Manuscript Database</title>
+<title>{{ user.full_name|default_if_none:"User" }} | Cantus Database</title>
 <div class="mr-3 p-3 mx-auto bg-white rounded">
     <!-- global search bar-->
     <object align="right" class="search-bar">

--- a/django/cantusdb_project/main_app/templates/user_list.html
+++ b/django/cantusdb_project/main_app/templates/user_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<title>All Users | Cantus Manuscript Database</title>
+<title>All Users | Cantus Database</title>
 <div class="mr-3 p-3 col-md-12 mx-auto bg-white rounded">
     <object align="right" class="search-bar">
         {% include "global_search_bar.html" %}

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load helper_tags %} {# for url_add_get_params #}
 {% block content %}
-<title>My Sources | Cantus Manuscript Database</title>
+<title>My Sources | Cantus Database</title>
 <div class="container">
     <div class="row">
         <div class="p-3 col-lg-8 bg-white rounded main-content">

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -2,7 +2,7 @@
 {% load helper_tags %} {# for source_links, recent_articles, get_user_source_pagination, get_user_created_source_pagination #}
 {% block content %}
 <div class="container">
-    <title>{{ flatpage.title }} | Cantus Manuscript Database</title>
+    <title>{{ flatpage.title }} | Cantus Database</title>
     <div class="row">
         <div class="p-3 col-lg-8 bg-white rounded main-content">
             <h2>{{ flatpage.title }}</h2>


### PR DESCRIPTION
Following #1446 and the rest of the discussion on #1097, we can replace the remaining instances of "Manuscript" with "Source" based on the recommendations.

- Page titles on all pages: "Cantus Manuscript Database" -> "Cantus Database"
- Help text for source model `title` field: "Full Manuscript Identification (City, Archive, Shelf-mark)" -> "Full Source Identification (City, Archive, Shelf-mark)"
- Chant (detail, create, edit): 
    - "Manuscript Reading Full Text (standardized spelling)" -> "Full text as in Source (standardized spelling)"
    - "Manuscript Reading Full Text (MS spelling)" -> "Full text as in Source (source spelling)"
- Chant search: 
    - "Manuscript Full Text" -> "Full Text"
    - "MsFt" -> "FT"
- Full inventory: "CANTUS Manuscript Inventory" -> "Cantus Inventory"
- Source create: "Full Manuscript Identification (City, Archive, Shelf-mark)" -> "Full Source Identification (City, Archive, Shelf-mark)"

Resolves #1097 