### PR TITLE
Reorder sources by `date_updated` on My Sources page and sidebar

### DIFF
--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -134,7 +134,7 @@ def get_user_source_pagination(context):
         Source.objects.filter(
             Q(current_editors=context["user"]) | Q(created_by=context["user"])
         )
-        .order_by("-date_created")
+        .order_by("-date_updated")
         .distinct()
     )
     paginator = Paginator(user_created_sources, 6)

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -104,7 +104,7 @@ class UserSourceListView(LoginRequiredMixin, ListView):
 
         user_created_sources = (
             Source.objects.filter(created_by=self.request.user)
-            .order_by("-date_created")
+            .order_by("-date_updated")
             .distinct()
         )
         user_created_paginator = Paginator(user_created_sources, 6)


### PR DESCRIPTION
Previously, we ordered sources on the "My Sources" page and sidebar by `date_created`. It makes more sense to order sources by `date_updated` so that sources don't get lost further down in the pagination for users that are editors on many sources. 

Fixes #1468