### PR TITLE
Add Management Command to Reflect Cantus ID Merge Events on CI to CD

### DIFF
--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -128,6 +128,15 @@ def get_suggested_fulltext(cantus_id: str) -> str:
     return suggested_fulltext
 
 
+def get_merged_chants():
+    endpoint_path: str = "/json-merged-chants"
+    json: Union[dict, list, None] = get_json_from_ci_api(endpoint_path)
+
+    if not isinstance(json, dict):
+        # mostly, in case of a timeout within get_json_from_ci_api
+        return None
+
+
 def get_json_from_ci_api(
     path: str, timeout: float = DEFAULT_TIMEOUT
 ) -> Union[dict, list, None]:

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -134,7 +134,7 @@ def get_merged_cantus_ids() -> Optional[list]:
 
     This function sends a request to the Cantus Index API endpoint for merged chants
     and retrieves the response. The response is expected to be a list of dictionaries,
-    each containing information about a merged chant, including the old Cantus ID,
+    each containing information about a merged Cantus ID, including the old Cantus ID,
     the new Cantus ID, and the date of the merge.
 
     Returns:

--- a/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
+++ b/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Optional, Union
+from typing import Optional
 from datetime import datetime
 from django.core.management.base import BaseCommand
 from main_app.models import Chant

--- a/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
+++ b/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
@@ -1,0 +1,99 @@
+import requests
+from typing import Optional, Union
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from main_app.models import Chant
+from cantusindex import get_merged_cantus_ids
+
+
+class Command(BaseCommand):
+    help = (
+        "Fetch and apply merge events from the /json-merged-chants API on Cantus Index"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "date",
+            nargs="?",
+            type=str,
+            help="Filter merges by date in the format YYYY-MM-DD",
+        )
+
+    def handle(self, *args, **kwargs):
+        date_filter: str = kwargs["date"]
+        if date_filter:
+            try:
+                date_filter = datetime.strptime(date_filter, "%Y-%m-%d")
+            except ValueError:
+                self.stdout.write(
+                    self.style.ERROR("Invalid date format. Please use YYYY-MM-DD.")
+                )
+                return
+
+        # Fetch the merge events from the Cantus Index API
+        merge_events: Optional[list] = get_merged_cantus_ids()
+
+        if not merge_events:
+            self.stdout.write(
+                self.style.ERROR("Failed to fetch data from Cantus Index.")
+            )
+            return
+
+        # Filter merge events by the provided date
+        if date_filter:
+            merge_events = self.filter_merge_events_by_date(merge_events, date_filter)
+
+        # Apply the new merge events on Cantus DB
+        for tx in merge_events:
+            self.apply_transaction(tx)
+
+    def filter_merge_events_by_date(self, merge_events: list, date_filter: str) -> list:
+
+        filtered_merge_events = []
+        for tx in merge_events:
+            try:
+                tx_date = datetime.strptime(tx["date"], "%Y-%m-%d")
+                if tx_date > date_filter:
+                    filtered_merge_events.append(tx)
+            except ValueError:
+                # Handle invalid date format (usually 0000-00-00)
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Ignoring merge event with invalid date format: {tx['date']}"
+                    )
+                )
+
+        return filtered_merge_events
+
+    def apply_transaction(self, transaction: dict) -> None:
+        old_cantus_id: str = transaction["old"]
+        new_cantus_id: str = transaction["new"]
+
+        if not old_cantus_id or not new_cantus_id:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Skipping transaction with missing cantus_id. Old: {old_cantus_id}, New: {new_cantus_id}"
+                )
+            )
+            return
+
+        affected_chants = Chant.objects.filter(cantus_id=old_cantus_id)
+
+        if affected_chants:
+            try:
+                affected_chants.update(cantus_id=new_cantus_id)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Old Cantus ID: {old_cantus_id} -> New Cantus ID: {new_cantus_id}\n"
+                    )
+                )
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"An error occurred while updating Chants with old cantus_id {old_cantus_id}: {e}"
+                    )
+                )
+        else:
+            self.stdout.write(
+                self.style.WARNING(f"No Chants found with cantus_id: {old_cantus_id}")
+            )

--- a/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
+++ b/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
@@ -46,7 +46,9 @@ class Command(BaseCommand):
         for tx in merge_events:
             self.apply_transaction(tx)
 
-    def filter_merge_events_by_date(self, merge_events: list, date_filter: str) -> list:
+    def filter_merge_events_by_date(
+        self, merge_events: list, date_filter: datetime
+    ) -> list:
         filtered_merge_events = []
         for tx in merge_events:
             try:

--- a/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
+++ b/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
@@ -48,7 +48,6 @@ class Command(BaseCommand):
             self.apply_transaction(tx)
 
     def filter_merge_events_by_date(self, merge_events: list, date_filter: str) -> list:
-
         filtered_merge_events = []
         for tx in merge_events:
             try:
@@ -62,13 +61,11 @@ class Command(BaseCommand):
                         f"Ignoring merge event with invalid date format: {tx['date']}"
                     )
                 )
-
         return filtered_merge_events
 
     def apply_transaction(self, transaction: dict) -> None:
         old_cantus_id: str = transaction["old"]
         new_cantus_id: str = transaction["new"]
-
         if not old_cantus_id or not new_cantus_id:
             self.stdout.write(
                 self.style.WARNING(
@@ -78,7 +75,6 @@ class Command(BaseCommand):
             return
 
         affected_chants = Chant.objects.filter(cantus_id=old_cantus_id)
-
         if affected_chants:
             try:
                 affected_chants.update(cantus_id=new_cantus_id)

--- a/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
+++ b/django/cantusdb_project/main_app/management/commands/add_cantus_index_merge_events.py
@@ -1,4 +1,3 @@
-import requests
 from typing import Optional
 from datetime import datetime
 from django.core.management.base import BaseCommand


### PR DESCRIPTION
In this PR, we set up a management command script to check the Cantus Index API endpoint `json-merged-chants`, which returns a list of dictionaries, each containing information about a merge event for Cantus ID's on Cantus Index.

- In `cantusindex.py`, a new function `get_merged_cantus_ids` is added that will retrieve the response from the `json-merged-chants` endpoint
- A management command `add_cantus_index_merge_events` is added, which will run under a cron job (I would say every week should be sufficient).
    - It uses the response from `get_merged_cantus_ids` to update the chants in our database with the new CantusIDs.
    - An optional "date" argument is added in case a user wants to run the management command manually and filter the response from a specific date.
- Fix typing in one other function inside `cantusindex.py`

We will still have to set up a cron job in https://github.com/dact-chant/ansible.cantus-db in order to get this working.

Resolves #877, Resolves #1158 