### PR TITLE
Fix duplicate results in source search 

### DIFF
--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -321,8 +321,12 @@ class SourceListView(ListView):
             )
             q_obj_filter &= indexing_search_q
 
-        return queryset.filter(q_obj_filter).prefetch_related(
-            Prefetch("century", queryset=Century.objects.all().order_by("id"))
+        return (
+            queryset.filter(q_obj_filter)
+            .distinct()
+            .prefetch_related(
+                Prefetch("century", queryset=Century.objects.all().order_by("id"))
+            )
         )
 
 


### PR DESCRIPTION
This PR adds `.distinct()` to the queryset in the SourceListView so that duplicate results will not show up on the source search page when search terms are added.

This bug was introduced in https://github.com/DDMAL/CantusDB/pull/671#discussion_r1213485201, where we decided to remove it for no apparent reason...

Fixes #1480 