### PR TITLE
Use safe template filter for source.indexing_notes in sidebar

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -471,7 +471,7 @@
                                     </ul>
                                 {% endif %}
 
-                                {{ source.indexing_notes|default_if_none:"" }}
+                                {{ source.indexing_notes|default_if_none:""|safe }}
                                 <br>
                                 {% with creator=source.created_by %}
                                     {% if creator %}

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -289,7 +289,7 @@
                                 {% endfor %}
                             </ul>
                         {% endif %}
-                        {{ source.indexing_notes|default_if_none:"" }}
+                        {{ source.indexing_notes|default_if_none:""|safe }}
                         <br>
                         {% with creator=source.created_by %}
                             {% if creator %}


### PR DESCRIPTION
Closes #1486.

Before (using plaintext link and no "safe" template tag in sidebar indexing notes):

![image](https://github.com/DDMAL/CantusDB/assets/11023634/4858a2db-b742-47b8-8a16-2f263aa4cfc0)


After (using anchor tag for link and the "safe" template tag in sidebar indexing notes):

![image](https://github.com/DDMAL/CantusDB/assets/11023634/a21fadb9-0ddc-4f4b-894c-5c16c30c32a1)
