### PR TITLE
Fix cron script issues related to docker version upgrade on new servers

### DIFF
--- a/cron/management/manage.sh
+++ b/cron/management/manage.sh
@@ -7,4 +7,4 @@
 DOCKER_COMPOSE_FILE=$1                                              # This is the path to the docker-compose file.
 COMMAND=$2                                                          # This is the command to execute.
 
-/usr/local/bin/docker-compose -f $DOCKER_COMPOSE_FILE exec -T django python manage.py $COMMAND
+/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec -T django python manage.py $COMMAND

--- a/cron/postgres/db_backup.sh
+++ b/cron/postgres/db_backup.sh
@@ -20,9 +20,9 @@ BACKUP_FILENAME=$(date "+%Y-%m-%dT%H:%M:%S").sql.gz                 # This is th
 
 # Create the backup and copy it to the daily backup directory
 mkdir -p $BACKUP_DIR/daily $BACKUP_DIR/weekly $BACKUP_DIR/monthly $BACKUP_DIR/yearly
-/usr/bin/docker exec cantusdb_postgres_1 /usr/local/bin/postgres_backup.sh $BACKUP_FILENAME
-/usr/bin/docker cp cantusdb_postgres_1:/var/lib/postgresql/backups/$BACKUP_FILENAME $BACKUP_DIR/daily
-/usr/bin/docker exec cantusdb_postgres_1 rm /var/lib/postgresql/backups/$BACKUP_FILENAME
+/usr/bin/docker exec cantusdb-postgres-1 /usr/local/bin/postgres_backup.sh $BACKUP_FILENAME
+/usr/bin/docker cp cantusdb-postgres-1:/var/lib/postgresql/backups/$BACKUP_FILENAME $BACKUP_DIR/daily
+/usr/bin/docker exec cantusdb-postgres-1 rm /var/lib/postgresql/backups/$BACKUP_FILENAME
 
 # Manage retention of daily backups
 FILES_TO_REMOVE=$(ls -td $BACKUP_DIR/daily/* | tail -n +8)

--- a/docker-compose-dev-containers.yml
+++ b/docker-compose-dev-containers.yml
@@ -11,6 +11,7 @@ services:
       dockerfile: ./django/Dockerfile
       args:
         PROJECT_ENVIRONMENT: DEVELOPMENT
+    container_name: cantusdb-django-1
     volumes:
       - ./:/code/cantusdb_project
       - static_volume:/resources/static
@@ -31,6 +32,7 @@ services:
     ports:
       - 80:80
       - 443:443
+    container_name: cantusdb-nginx-1
     volumes:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
@@ -45,6 +47,7 @@ services:
     build:
       context: ./postgres
     env_file: ./config/envs/dev_env
+    container_name: cantusdb-postgres-1
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     ports:

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -2,7 +2,6 @@
 # When building the project locally, replace the contents of docker-compose.yml with the
 # contents of this file.
 
-
 version: '3'
 
 services:
@@ -12,6 +11,7 @@ services:
       dockerfile: ./django/Dockerfile
       args:
         PROJECT_ENVIRONMENT: DEVELOPMENT
+    container_name: cantusdb-django-1
     volumes:
       - ./django/cantusdb_project:/code/cantusdb_project
       - static_volume:/resources/static
@@ -23,13 +23,13 @@ services:
       - postgres
     command: [ "python", "manage.py", "runserver", "0:8000" ]
 
-
   nginx:
     build:
       context: ./nginx
     ports:
       - 80:80
       - 443:443
+    container_name: cantusdb-nginx-1
     volumes:
       - ./config/nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/resources/static
@@ -46,6 +46,7 @@ services:
     env_file: ./config/envs/dev_env
     ports:
       - 5432:5432
+    container_name: cantusdb-postgres-1
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     restart: always


### PR DESCRIPTION
As noted in this [Docker documentation](https://docs.docker.com/compose/migrate/#service-container-names), when Docker compose specifications migrated from V1 to V2, the word separator in the default container name changed from an underscore to a hyphen. Our new servers, with their upgraded version of Docker, use the hyphen. Since the documentation suggests an underlying networking reason for this change, this PR implements it.

The relevant container name in the `db_backup.sh` script is changed (`cantusdb_postgres_1` to `cantusdb-postgres-1`). 

This PR also updates all `docker-compose` files in this repo to specify the container name (although our scripts now conform to this naming convention, it doesn't hurt to make it explicit). 

The `docker-compose` command was also deprecated with the version of Docker server used on the new servers. This PR adjusts the `manage.sh` cron script to use `docker compose` rather than `docker-compose`. 

Closes #1489.

A companion PR in the ansible set-up (https://github.com/dact-chant/ansible.cantus-db/pull/39) makes the analogous change in the `docker-compose.yml` template.