### PR TITLE
Preserve proofreader fields for contributor changes on chants

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1105,7 +1105,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
     def form_valid(self, form):
         if form.is_valid():
-            user = self.request.user
+            user: User = self.request.user
             chant: Chant = form.instance
 
             if not user_can_proofread_chant(user, chant):

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -25,7 +25,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponse
 
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.contrib.auth import get_user_model
 
 
 from main_app.forms import (

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1111,7 +1111,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
             if not user_can_proofread_chant(user, chant):
                 # Preserve the original values for proofreader-specific fields
-                original_chant: Chant = Chant.objects.get(pk=chant.pk)
+                original_chant: Chant = self.get_object()
                 chant.chant_range = original_chant.chant_range
                 chant.volpiano_proofread = original_chant.volpiano_proofread
                 chant.manuscript_full_text_std_proofread = (

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -41,6 +41,7 @@ from main_app.models import (
     Sequence,
     Office,
 )
+from users.models import User
 from main_app.permissions import (
     user_can_edit_chants_in_source,
     user_can_proofread_chant,
@@ -1119,7 +1120,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
                 chant.manuscript_full_text_proofread = (
                     original_chant.manuscript_full_text_proofread
                 )
-                proofreaders: list[Optional[get_user_model]] = list(
+                proofreaders: list[Optional[User]] = list(
                     original_chant.proofread_by.all()
                 )
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -1137,8 +1137,7 @@ class SourceEditChantsView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
             # The many-to-many `proofread_by` field is reset when the
             # parent class's `form_valid` method calls `save()` on the model instance.
             if not user_can_proofread_chant(user, chant):
-                for user in proofreaders:
-                    chant.proofread_by.add(user)
+                chant.proofread_by.set(proofreaders)
             messages.success(self.request, "Chant updated successfully!")
             return return_response
         else:


### PR DESCRIPTION
This PR modifies the model form for the chant edit page so that contributor changes to a chant do not affect certain proofreader fields. If a contributor makes a change to a chant, the following conditions are met:

1. When a contributor edits a Chant, the following fields are preserved:
    - `chant_range`
    - `proofread_by`
    - `volpiano_proofread`
    - `manuscript_full_text_std_proofread`
    - `manuscript_full_text_proofread`

2. However, if the contributor makes changes to the following fields:
    - `volpiano`
    - `manuscript_full_text_std_spelling`
    - `manuscript_full_text`

Then the respective proofreader checkboxes (`volpiano_proofread`, `manuscript_full_text_std_proofread`, `manuscript_full_text_proofread`) are set to `False`. 

Fixes #1491 
