### PR TITLE
Update manage.sh to include new path to docker executable

### DIFF
--- a/cron/management/manage.sh
+++ b/cron/management/manage.sh
@@ -7,4 +7,4 @@
 DOCKER_COMPOSE_FILE=$1                                              # This is the path to the docker-compose file.
 COMMAND=$2                                                          # This is the command to execute.
 
-/usr/local/bin/docker compose -f $DOCKER_COMPOSE_FILE exec -T django python manage.py $COMMAND
+/usr/bin/docker compose -f $DOCKER_COMPOSE_FILE exec -T django python manage.py $COMMAND


### PR DESCRIPTION
The path to the docker executable has changed on the new staging and production servers. We can expect this to remain the same on future servers because the docker installation process is now managed consistently by ansible.

Closes #1502.