### PR TITLE
Fix `TypeError` in `get_suggested_chant()`

### DIFF
--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -91,9 +91,12 @@ def get_suggested_chant(
         # mostly, in case of a timeout within get_json_from_ci_api
         return None
 
-    fulltext: str = json["info"]["field_full_text"]
-    incipit: str = " ".join(fulltext.split(" ")[:5])
-    genre_name: str = json["info"]["field_genre"]
+    try:
+        fulltext: str = json["info"]["field_full_text"]
+        incipit: str = " ".join(fulltext.split(" ")[:5])
+        genre_name: str = json["info"]["field_genre"]
+    except TypeError:
+        return None
     genre_id: Optional[int] = None
     try:
         genre_id = Genre.objects.get(name=genre_name).id


### PR DESCRIPTION
This PR adds a try/except block inside the `get_suggested_chant` function.

Sometimes, the `json-cid` endpoint path will return a json response where the `info` key is `None`, causing a 500 error on the chant create page for certain CantusIDs.

Here, we return `None` if a `TypeError` exception is caught.

Will add more robust error handling for issue #1515, but we will leave the issue open until further checks are made on Cantus Index