### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ config/envs/dev_env
 certificates/
 docker-compose.yml
 config/nginx/conf.d/cantusdb.conf
+config/nginx/conf.d/cantusdb.conf.development
 cron/cron.txt
 
 # Drupal scripts from old Cantus


### PR DESCRIPTION
Adds `config/nginx/conf.d/cantusdb.conf.development` to `.gitignore` so we aren't tracking changes to this file. I found this while setting up my environment locally this week. 