### PR TITLE
Comment out chant segment and BD-specific fields on chant forms

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -83,13 +83,14 @@ class ChantCreateForm(forms.ModelForm):
             "content_structure",
             "indexing_notes",
             "addendum",
-            "segment",
-            "liturgical_function",
-            "polyphony",
-            "cm_melody_id",
-            "incipit_of_refrain",
-            "later_addition",
-            "rubrics",
+            # See issue #1521: Temporarily commenting out segment-related functions on Chant
+            # "segment",
+            # "liturgical_function",
+            # "polyphony",
+            # "cm_melody_id",
+            # "incipit_of_refrain",
+            # "later_addition",
+            # "rubrics",
         ]
         # the widgets dictionary is ignored for a model field with a non-empty
         # choices attribute. In this case, you must override the form field to
@@ -148,13 +149,14 @@ class ChantCreateForm(forms.ModelForm):
         "Mass Alleluias. Punctuation is omitted.",
     )
 
-    segment = SelectWidgetNameModelChoiceField(
-        queryset=Segment.objects.all().order_by("id"),
-        required=True,
-        initial=Segment.objects.get(id=4063),  # Default to the "Cantus" segment
-        help_text="Select the Database segment that the chant belongs to. "
-        "In most cases, this will be the CANTUS segment.",
-    )
+    # See issue #1521: Temporarily commenting out segment-related functions on Chant
+    # segment = SelectWidgetNameModelChoiceField(
+    #     queryset=Segment.objects.all().order_by("id"),
+    #     required=True,
+    #     initial=Segment.objects.get(id=4063),  # Default to the "Cantus" segment
+    #     help_text="Select the Database segment that the chant belongs to. "
+    #     "In most cases, this will be the CANTUS segment.",
+    # )
 
     # automatically computed fields
     # source and incipit are mandatory fields in model,
@@ -281,13 +283,14 @@ class ChantEditForm(forms.ModelForm):
             "manuscript_full_text_proofread",
             "volpiano_proofread",
             "proofread_by",
-            "segment",
-            "liturgical_function",
-            "polyphony",
-            "cm_melody_id",
-            "incipit_of_refrain",
-            "later_addition",
-            "rubrics",
+            # See issue #1521: Temporarily commenting out segment-related functions on Chant
+            # "segment",
+            # "liturgical_function",
+            # "polyphony",
+            # "cm_melody_id",
+            # "incipit_of_refrain",
+            # "later_addition",
+            # "rubrics",
         ]
         widgets = {
             # manuscript_full_text_std_spelling: defined below (required)
@@ -317,12 +320,13 @@ class ChantEditForm(forms.ModelForm):
             "proofread_by": autocomplete.ModelSelect2Multiple(
                 url="proofread-by-autocomplete"
             ),
-            "polyphony": SelectWidget(),
-            "liturgical_function": SelectWidget(),
-            "cm_melody_id": TextInputWidget(),
-            "incipit_of_refrain": TextInputWidget(),
-            "later_addition": TextInputWidget(),
-            "rubrics": TextInputWidget(),
+            # See issue #1521: Temporarily commenting out segment-related functions on Chant
+            # "polyphony": SelectWidget(),
+            # "liturgical_function": SelectWidget(),
+            # "cm_melody_id": TextInputWidget(),
+            # "incipit_of_refrain": TextInputWidget(),
+            # "later_addition": TextInputWidget(),
+            # "rubrics": TextInputWidget(),
         }
 
     manuscript_full_text_std_spelling = forms.CharField(
@@ -347,12 +351,13 @@ class ChantEditForm(forms.ModelForm):
         help_text="Each folio starts with '1'.",
     )
 
-    segment = SelectWidgetNameModelChoiceField(
-        queryset=Segment.objects.all().order_by("id"),
-        required=True,
-        help_text="Select the Database segment that the chant belongs to. "
-        "In most cases, this will be the CANTUS segment.",
-    )
+    # See issue #1521: Temporarily commenting out segment-related functions on Chant
+    # segment = SelectWidgetNameModelChoiceField(
+    #     queryset=Segment.objects.all().order_by("id"),
+    #     required=True,
+    #     help_text="Select the Database segment that the chant belongs to. "
+    #     "In most cases, this will be the CANTUS segment.",
+    # )
 
 
 class SourceEditForm(forms.ModelForm):

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -84,7 +84,8 @@
                         <label for="{{ form.cantus_id.id_for_label }}"><small>Cantus ID:</small></label>
                         {{ form.cantus_id }}
                     </div>
-                    <div id="segment-select-field" class="form-group m-1 col-lg-4">
+                    <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+                    <!-- <div id="segment-select-field" class="form-group m-1 col-lg-4">
                         <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                         {{ form.segment }}
                     </div>
@@ -92,7 +93,7 @@
                     <div class="form-group m-1 col-lg-3">
                         <small>{{ form.liturgical_function.label_tag }}</small>
                         {{ form.liturgical_function }}
-                    </div> 
+                    </div>  -->
                 </div>
 
                 <div class="form-row">
@@ -140,10 +141,11 @@
                         {{ form.extra }}
                     </div>
 
-                    <div class="form-group m-1 col-lg-2">
+                    <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+                    <!-- <div class="form-group m-1 col-lg-2">
                         <small>{{ form.polyphony.label_tag }}</small>
                         {{ form.polyphony }}
-                    </div>
+                    </div> -->
                 </div>
 
                 <div class="form-row">
@@ -179,8 +181,9 @@
                     
                 </div>
 
+                <!-- See issue #1521: Temporarily commenting out segment-related functions on Chants -->
                 <!-- The next three rows of fields are hidden unless the Benedicamus Domino segment is selected. -->
-                <div id="benedicamus-domino-segment-fields" hidden>
+                <!-- <div id="benedicamus-domino-segment-fields" hidden>
                     <div class="form-row">
 
                         <div class="form-group m-1 col-lg-4">
@@ -209,7 +212,7 @@
                             {{ form.rubrics }}
                         </div>
                     </div>
-                </div>
+                </div> -->
             
                 <div class="form-row align-items-end">
                     <div class="form-group m-1 col-lg">

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -97,7 +97,8 @@
                             </label>
                             {{ form.melody_id }}
                         </div>
-                        <div id="segment-select-field" class="form-group m-1 col-lg-4">
+                        <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+                        <!-- <div id="segment-select-field" class="form-group m-1 col-lg-4">
                             <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
                             {{ form.segment }}
                         </div>
@@ -105,7 +106,7 @@
                         <div class="form-group m-1 col-lg-3">
                             <small>{{ form.liturgical_function.label_tag }}</small>
                             {{ form.liturgical_function }}
-                        </div> 
+                        </div>  -->
                     </div>
 
                     <div class="form-row">
@@ -125,10 +126,11 @@
                             <small>{{ form.extra.label_tag }}</small>
                             {{ form.extra }}
                         </div>
-                        <div class="form-group m-1 col-lg-2">
+                        <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+                        <!-- <div class="form-group m-1 col-lg-2">
                             <small>{{ form.polyphony.label_tag }}</small>
                             {{ form.polyphony }}
-                        </div>
+                        </div> -->
                     </div>
                     <div class="form-row">
                         <div class="form-group m-1 col-lg-12">
@@ -157,8 +159,9 @@
                         {% endif %}
                     </div>
 
+                    <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
                     <!-- The next three rows of fields are hidden unless the Benedicamus Domino segment is selected. -->
-                    <div id="benedicamus-domino-segment-fields" hidden>
+                    <!-- <div id="benedicamus-domino-segment-fields" hidden>
                         <div class="form-row">
 
                             <div class="form-group m-1 col-lg-4">
@@ -187,7 +190,7 @@
                                 {{ form.rubrics }}
                             </div>
                         </div>
-                    </div>
+                    </div> -->
 
                     {% if suggested_fulltext %}
                     <div class="form-row">


### PR DESCRIPTION
We're still figuring out how we will handle the need for both source and chant level "segments", so for now I'm commenting out the additional `segment` and other fields introduced in #1473 until we reach a final decision. This will allow us to update production with other changes while decision-making and development proceeds on those issues. Much of the functionality and the fields might still be needed, so I don't remove any fields from the chant model and I only comment out these fields on the chant edit and chant create forms. Getting these working is a high priority task, so I'm not worried that these comments will get hidden in the code base for long.

Closes #1521.