### PR TITLE
Change custom error page location & remove htpasswd placeholder

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf.development
+++ b/config/nginx/conf.d/cantusdb.conf.development
@@ -10,6 +10,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
+        proxy_intercept_errors on;
     }
 
     location /static {
@@ -24,17 +25,10 @@ server {
         expires modified +24h;
     }
 
-    error_page 500 /500.html;
-    location = /500.html {
-        root /;
-    }
-
-    error_page 502 /502.html;
-    location = /502.html {
-        root /;
-    }
-    error_page 504 /504.html;
-    location = /504.html {
+    error_page 500 /error_pages/500.html;
+    error_page 502 /error_pages/502.html;
+    error_page 504 /error_pages/504.html;
+    location /error_pages {
         root /;
     }
 }

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,4 +7,3 @@ RUN curl -LJO https://github.com/go-acme/lego/releases/download/v4.14.2/lego_v4.
     rm lego_v4.14.2_linux_amd64.tar.gz
 RUN mkdir -p /var/www/lego
 COPY error_pages /error_pages
-COPY password/.htpasswd /etc/nginx/.htpasswd

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,5 +6,5 @@ RUN curl -LJO https://github.com/go-acme/lego/releases/download/v4.14.2/lego_v4.
     mv lego /usr/local/bin/lego && \
     rm lego_v4.14.2_linux_amd64.tar.gz
 RUN mkdir -p /var/www/lego
-COPY error_pages .
+COPY error_pages /error_pages
 COPY password/.htpasswd /etc/nginx/.htpasswd

--- a/nginx/password/.htpasswd
+++ b/nginx/password/.htpasswd
@@ -1,1 +1,0 @@
-# Note: This file is intentionally empty for development and production environments. It will be replaced with a file containing a hashed password on the staging server by ansible.


### PR DESCRIPTION
This PR fixes features that were added in #1520. 

#1520 added a placeholder password file (`nginx/password/.htpasswd`) that was then overwritten on the staging server by ansible. This meant that subsequent deployments with ansible on the staging server would fail because a subsequent `git pull` would find changes to the local working directory. This PR removes that placeholder `.htpasswd` file.

This PR also refactors the custom error pages served by nginx to make the nginx configuration file simpler. 

Finally, the custom error page was not showing when gunicorn returned a 500 error. Turning the `proxy_intercept_errors` configuration "on" means that nginx now intercepts this error from gunicorn and serves the custom 500 error page.

Fixes #1519. Refs https://github.com/dact-chant/ansible.cantus-db/issues/41.