### PR TITLE
Send portions of sidebar to top on narrow screens; fix global search bar on dynamic pages

### DIFF
--- a/django/cantusdb_project/articles/templates/article_detail.html
+++ b/django/cantusdb_project/articles/templates/article_detail.html
@@ -1,40 +1,39 @@
-{% extends "base.html" %}
+{% extends "base_page_with_side_cards.html" %}
 {% load helper_tags %} {# for recent_articles #}
-{% block content %}
-<div class="container">
-    <title>{{ article.title }} | Cantus Database</title>
+{% block title %}
+<title>{{ article.title }} | Cantus Database</title>
+{% endblock %}
+
+{% block uppersidebar %}
+    <div class="search-bar mb-3">
+        {% include "global_search_bar.html" %}
+    </div>
+{% endblock %}
+
+{% block maincontent %}
+    <h3>
+        {{ article.title }}
+    </h3>
     <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h3>
-                {{ article.title }}
-            </h3>
-            <div class="row">
-                <div class="col">
-                    <div class="container">
-                        <div class="container text-wrap">
-                            <small>Submitted by <a href="{% url 'user-detail' article.author.id %}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
-                            <div style="padding-top: 1em;">
-                                {{ article.body.html|safe }}
-                            </div>
-                        </div>
+        <div class="col">
+            <div class="container">
+                <div class="container text-wrap">
+                    <small>Submitted by <a href="{% url 'user-detail' article.author.id %}">{{ article.author }}</a> on {{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
+                    <div style="padding-top: 1em;">
+                        {{ article.body.html|safe }}
                     </div>
                 </div>
             </div>
         </div>
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
-            <div class="card mt-3 w-100">
-                <div class="card-header">
-                    What's New
-                </div>
-                <div class="card-body">
-                    {% recent_articles %}
-                </div>
-            </div>
+    </div>
+{% endblock %}
+{% block lowersidebar %}
+    <div class="card">
+        <div class="card-header">
+            What's New
+        </div>
+        <div class="card-body">
+            {% recent_articles %}
         </div>
     </div>
-
-</div>
 {% endblock %}

--- a/django/cantusdb_project/articles/templates/article_list.html
+++ b/django/cantusdb_project/articles/templates/article_list.html
@@ -1,43 +1,39 @@
-{% extends "base.html" %}
-{% load helper_tags %} {# for recent_articles #}
-{% block content %}
-<div class="container">
-    <title>What's New | Cantus Database</title>
+{% extends "base_page_with_side_cards.html" %}
+{% load helper_tags %} {# for recent_articles #}\
+{% block title %}
+<title>What's New | Cantus Database</title>
+{% endblock %}
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
+</div>
+{% endblock %}
+{% block maincontent %}
+    <h3>What's New</h3>
+    {% for article in articles %}
     <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h3>What's New</h3>
-            {% for article in articles %}
-            <div class="row">
-                <div class="col">
-                    <small>{{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
-                    <h4>
-                        <a href="{% url 'article-detail' article.id %}">{{ article.title }}</a>
-                    </h4>
-                    <div class="container">
-                        <small>
-                        {{ article.body.html|safe|truncatechars_html:3000 }}
-                        </small>
-                    </div>
-                </div>
-            </div>
-            {% endfor %}
-            {% include "pagination.html" %}
-            <br>
-        </div>
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
-
-            <div class="card mt-3 w-100">
-                <div class="card-header">
-                    What's New
-                </div>
-                <div class="card-body">
-                    {% recent_articles %}
-                </div>
+        <div class="col">
+            <small>{{ article.date_created|date:"D, m/d/Y - H:i" }}</small>
+            <h4>
+                <a href="{% url 'article-detail' article.id %}">{{ article.title }}</a>
+            </h4>
+            <div class="container">
+                <small>
+                {{ article.body.html|safe|truncatechars_html:3000 }}
+                </small>
             </div>
         </div>
     </div>
-</div>
+    {% endfor %}
+    {% include "pagination.html" %}
+{% endblock %}
+{% block lowersidebar %}
+    <div class="card">
+        <div class="card-header">
+            What's New
+        </div>
+        <div class="card-body">
+            {% recent_articles %}
+        </div>
+    </div>
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -1,191 +1,191 @@
-{% extends "base.html" %}
-{% block content %}
+{% extends "base_page_with_side_cards.html" %}
+{% block title %}
 <title>Browse Chants | Cantus Database</title>
+{% endblock %}
+
+{% block script %}
 <script src="/static/js/chant_list.js"></script>
+{% endblock %}
 
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h3>Browse Chants</h3>
-            <small>Displaying <b>{{ page_obj.start_index }}-{{ page_obj.end_index }}</b> of <b>{{ page_obj.paginator.count }}</b> chants</small>
-            
-            <form method="get">
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <label for="sourceFilter"><small><b>Source</b></small></label>
-                        <select id="sourceFilter" name="source" class="form-control custom-select custom-select-sm">
-                            {% comment %} <option value="">- Any -</option> {% endcomment %}
-                            {% for source_obj in sources %}
-                                <option value="{{ source_obj.id }}"{% if source_obj.id == source.id %} selected {% endif %}>{{ source_obj.siglum }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <label for="feastFilter"><small><b>Feast</b></small></label>
-                        <select id="feastFilter" name="feast" class="form-control custom-select custom-select-sm">
-                            <option value="">- Any -</option>
-                            {% for feast in feasts %}
-                                <option value="{{ feast.id }}">{{ feast.name }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <label for="search"><small><b>Search Text</b></small></label>
-                        <input id="search" type="text" class="form-control form-control-sm" name="search_text" value="{{ request.GET.search_text }}">
-                    </div>
-
-                    <div class="form-group m-1 col-lg">
-                        <label for="genreFilter"><small><b>Genre</b></small></label>
-                        <select id="genreFilter" name="genre" class="form-control custom-select custom-select-sm">
-                            <option value="">- Any -</option>
-                            {% for genre in genres %}
-                                <option value="{{ genre.id }}">{{ genre.name }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                </div>
-
-            </form>
-            {% with exists_on_cantus_ultimus=source.exists_on_cantus_ultimus %}
-                {% if chants %}
-                    <table class="table table-responsive table-sm table-bordered small">
-                        <thead>
-                            <tr>
-                                <th scope="col" class="text-wrap" title="Siglum">Siglum</th>
-                                <th scope="col" class="text-wrap" title="Folio">Folio</th>
-                                <th scope="col" class="text-wrap" title="Sequence"></th>
-                                <th scope="col" class="text-wrap" title="Incipit / Full text">Incipit / Full text</th>
-                                <th scope="col" class="text-wrap" title="Feast">Feast</th>
-                                <th scope="col" class="text-wrap" title="Service"></th>
-                                <th scope="col" class="text-wrap" title="Genre"></th>
-                                <th scope="col" class="text-wrap" title="Position"></th>
-                                <th scope="col" class="text-wrap" title="Cantus ID">CantusID</th>
-                                <th scope="col" class="text-wrap" title="Mode">Mode</th>
-                                <th scope="col" class="text-wrap" title="Image link"></th>
-                                {% if user_can_edit_chant %}
-                                    <th scope="col" class="text-wrap" title="Edit Chant"></th>
-                                {% endif %}
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for chant in chants %}
-                            <tr>
-                                <td class="text-wrap" style="text-align:center" title="{{ source.title }}">{{ source.siglum|default:"" }}</td>
-                                <td class="text-wrap" style="text-align:center"><b>{{ chant.folio|default:"" }}</b></td>
-                                <td class="text-wrap" style="text-align:center">{{ chant.c_sequence|default_if_none:"" }}</td> {# default_if_none: sometimes, c_sequence is 0, and should still be displayed #}
-                                <td class="text-wrap">
-                                    <a href="{% url 'chant-detail' chant.id %}"><b>{{ chant.incipit|default:"" }}</b></a>
-                                    <p>{{ chant.manuscript_full_text_std_spelling|default:"" }}<br>
-                                    {% if chant.volpiano %}
-                                        <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
-                                    {% endif %}
-                                    </p>
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.feast %}
-                                        <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name|default:"" }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.office %}
-                                        <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if chant.genre %}
-                                        <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
-                                    {% endif %}
-                                </td>
-                                <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
-                                <td class="text-wrap" style="text-align:center">
-                                    <a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default:"" }}</a>
-                                </td>
-                                <td class="text-wrap" style="text-align:center">{{ chant.mode|default:"" }}</td>
-                                <td class="text-wrap" style="text-align:center">
-                                    {% if exists_on_cantus_ultimus %}
-                                            <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}" target="_blank">
-                                                Image
-                                            </a>
-                                    {% elif chant.image_link %}
-                                        <a href="{{ chant.image_link }}" target="_blank">Image</a>
-                                    {% endif %}
-                                </td>
-                                {% if user_can_edit_chant %}
-                                    <td class="text-wrap" style="text-align:center">
-                                        <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}&ref=chant-list">Edit</a>
-                                    </td>
-                                {% endif %}
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                    {% include "pagination.html" %}
-                {% else %}
-                    No chants found.
-                {% endif %}
-            {% endwith %}
-        </div>
-    
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
-
-            <div class="card w-100">
-
-                <div class="card-header">
-                    <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
-                </div>
-
-                <div class="card-body">
-                    <small>
-                        <!--a small selector of all folios of this source-->
-                        <select name="folio" id="folioFilter" class="w-30">
-                            <option value="">Select a folio:</option>
-                            {% for folio in folios %}
-                                <option value="{{ folio }}">{{ folio }}</option>
-                            {% endfor %}
-                        </select>
-
-                        {% if previous_folio %}
-                            <a href="{% url "browse-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
-                        {% endif %}
-                        {% if next_folio %}
-                            &nbsp;<a href="{% url "browse-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
-                        {% endif %}                                
-                        <br>
-
-                        <select name="feast" id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
-                            <option value="">Select a feast:</option>
-                            {% for folio, feast_id, feast_name in feasts_with_folios %}
-                                <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
-                            {% endfor %}
-                        </select>
-                        <br>
-                        <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
-                        <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
-                        {% if source.exists_on_cantus_ultimus %}
-                            <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}" class="guillemet" target="_blank">View inventory with images</a>
-                        {% endif %}
-                        {% if source.image_link %}
-                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
-                        {% endif %}                          
-                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
-                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
-                    </small>
-                </div>    
-
-            </div>
-
-        </div>
-    </div>
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
 </div>
+{% endblock %}
+
+{% block maincontent %}
+    <h3>Browse Chants</h3>
+    <small>Displaying <b>{{ page_obj.start_index }}-{{ page_obj.end_index }}</b> of <b>{{ page_obj.paginator.count }}</b> chants</small>
+    
+    <form method="get">
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <label for="sourceFilter"><small><b>Source</b></small></label>
+                <select id="sourceFilter" name="source" class="form-control custom-select custom-select-sm">
+                    {% comment %} <option value="">- Any -</option> {% endcomment %}
+                    {% for source_obj in sources %}
+                        <option value="{{ source_obj.id }}"{% if source_obj.id == source.id %} selected {% endif %}>{{ source_obj.siglum }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <label for="feastFilter"><small><b>Feast</b></small></label>
+                <select id="feastFilter" name="feast" class="form-control custom-select custom-select-sm">
+                    <option value="">- Any -</option>
+                    {% for feast in feasts %}
+                        <option value="{{ feast.id }}">{{ feast.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <label for="search"><small><b>Search Text</b></small></label>
+                <input id="search" type="text" class="form-control form-control-sm" name="search_text" value="{{ request.GET.search_text }}">
+            </div>
+
+            <div class="form-group m-1 col-lg">
+                <label for="genreFilter"><small><b>Genre</b></small></label>
+                <select id="genreFilter" name="genre" class="form-control custom-select custom-select-sm">
+                    <option value="">- Any -</option>
+                    {% for genre in genres %}
+                        <option value="{{ genre.id }}">{{ genre.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+    </form>
+    {% with exists_on_cantus_ultimus=source.exists_on_cantus_ultimus %}
+        {% if chants %}
+            <table class="table table-responsive table-sm table-bordered small">
+                <thead>
+                    <tr>
+                        <th scope="col" class="text-wrap" title="Siglum">Siglum</th>
+                        <th scope="col" class="text-wrap" title="Folio">Folio</th>
+                        <th scope="col" class="text-wrap" title="Sequence"></th>
+                        <th scope="col" class="text-wrap" title="Incipit / Full text">Incipit / Full text</th>
+                        <th scope="col" class="text-wrap" title="Feast">Feast</th>
+                        <th scope="col" class="text-wrap" title="Service"></th>
+                        <th scope="col" class="text-wrap" title="Genre"></th>
+                        <th scope="col" class="text-wrap" title="Position"></th>
+                        <th scope="col" class="text-wrap" title="Cantus ID">CantusID</th>
+                        <th scope="col" class="text-wrap" title="Mode">Mode</th>
+                        <th scope="col" class="text-wrap" title="Image link"></th>
+                        {% if user_can_edit_chant %}
+                            <th scope="col" class="text-wrap" title="Edit Chant"></th>
+                        {% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for chant in chants %}
+                    <tr>
+                        <td class="text-wrap" style="text-align:center" title="{{ source.title }}">{{ source.siglum|default:"" }}</td>
+                        <td class="text-wrap" style="text-align:center"><b>{{ chant.folio|default:"" }}</b></td>
+                        <td class="text-wrap" style="text-align:center">{{ chant.c_sequence|default_if_none:"" }}</td> {# default_if_none: sometimes, c_sequence is 0, and should still be displayed #}
+                        <td class="text-wrap">
+                            <a href="{% url 'chant-detail' chant.id %}"><b>{{ chant.incipit|default:"" }}</b></a>
+                            <p>{{ chant.manuscript_full_text_std_spelling|default:"" }}<br>
+                            {% if chant.volpiano %}
+                                <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
+                            {% endif %}
+                            </p>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if chant.feast %}
+                                <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name|default:"" }}</a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if chant.office %}
+                                <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name|default:"" }}</a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if chant.genre %}
+                                <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name|default:"" }}</a>
+                            {% endif %}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default:"" }}</a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">{{ chant.mode|default:"" }}</td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% if exists_on_cantus_ultimus %}
+                                    <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}" target="_blank">
+                                        Image
+                                    </a>
+                            {% elif chant.image_link %}
+                                <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                            {% endif %}
+                        </td>
+                        {% if user_can_edit_chant %}
+                            <td class="text-wrap" style="text-align:center">
+                                <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}&ref=chant-list">Edit</a>
+                            </td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% include "pagination.html" %}
+        {% else %}
+            No chants found.
+        {% endif %}
+    {% endwith %}
+{% endblock %}
+
+{% block lowersidebar %}
+    <div class="card w-100">
+
+        <div class="card-header">
+            <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
+        </div>
+
+        <div class="card-body">
+            <small>
+                <!--a small selector of all folios of this source-->
+                <select name="folio" id="folioFilter" class="w-30">
+                    <option value="">Select a folio:</option>
+                    {% for folio in folios %}
+                        <option value="{{ folio }}">{{ folio }}</option>
+                    {% endfor %}
+                </select>
+
+                {% if previous_folio %}
+                    <a href="{% url "browse-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
+                {% endif %}
+                {% if next_folio %}
+                    &nbsp;<a href="{% url "browse-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
+                {% endif %}                                
+                <br>
+
+                <select name="feast" id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                    <option value="">Select a feast:</option>
+                    {% for folio, feast_id, feast_name in feasts_with_folios %}
+                        <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
+                    {% endfor %}
+                </select>
+                <br>
+                <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
+                <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
+                {% if source.exists_on_cantus_ultimus %}
+                    <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}" class="guillemet" target="_blank">View inventory with images</a>
+                {% endif %}
+                {% if source.image_link %}
+                    <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
+                {% endif %}                          
+                <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank">CSV export</a>
+                <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
+                <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
+                <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
+            </small>
+        </div>    
+
+    </div>
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -1,334 +1,332 @@
-{% extends "base.html" %}
+{% extends "base_page_with_side_cards.html" %}
 {% load static %}
-{% block content %}
+{% block title %}
 <title>Create Chant | Cantus Database</title>
+{% endblock %}
+{% block script %}
 <script src="/static/js/chant_create.js"></script>
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h3>Create Chant</h3>
+{% endblock %}
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
+</div>
+{% endblock %}
+{% block maincontent %}
+    <h3>Create Chant</h3>
 
-            <!--Display "submit success" message -->
-            {% if messages %}
-            <div class="alert alert-success alert-dismissible">
-                {% for message in messages %}
+    <!--Display "submit success" message -->
+    {% if messages %}
+    <div class="alert alert-success alert-dismissible">
+        {% for message in messages %}
+        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+        <a href="{% url 'chant-detail' previous_chant.id %}" style="color:#155724" target="_blank">{{ message }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <!--Display form error message -->
+    {% if form.errors %}
+    <div class="alert alert-danger alert-dismissible">
+        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+        {% for error in form.non_field_errors %}
+            <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+            {{ error }}
+        {% endfor %}
+        {% for field in form %}
+            {% if field.errors %}
                 <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                <a href="{% url 'chant-detail' previous_chant.id %}" style="color:#155724" target="_blank">{{ message }}</a>
-                {% endfor %}
-            </div>
+                {{ field.label }}: {{ field.errors|striptags }}
             {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
 
-            <!--Display form error message -->
-            {% if form.errors %}
-            <div class="alert alert-danger alert-dismissible">
-                <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                {% for error in form.non_field_errors %}
-                    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                    {{ error }}
-                {% endfor %}
-                {% for field in form %}
-                    {% if field.errors %}
-                        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                        {{ field.label }}: {{ field.errors|striptags }}
-                    {% endif %}
-                {% endfor %}
+    <form method="post" style="line-height: normal">{% csrf_token %}
+        <div class="form-row">
+
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.marginalia.label_tag }}</small>
+                {{ form.marginalia }}
             </div>
-            {% endif %}
 
-            <form method="post" style="line-height: normal">{% csrf_token %}
-                <div class="form-row">
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
+                {{ form.folio }}
+                <p class=text-muted><small>{{ form.folio.help_text}}</small></p>
+            </div>
 
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.marginalia.label_tag }}</small>
-                        {{ form.marginalia }}
-                    </div>
+            <div class="form-group m-1 col-lg-2">
+                <label for="{{ form.c_sequence.id_for_label }}"><small>Sequence:</small><span class="text-danger" title="This field is required">*</span></label>
+                {{ form.c_sequence }}
+                <p class=text-muted><small>{{ form.c_sequence.help_text}}</small></p>
+            </div>
 
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
-                        {{ form.folio }}
-                        <p class=text-muted><small>{{ form.folio.help_text}}</small></p>
-                    </div>
+        </div>
 
-                    <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.c_sequence.id_for_label }}"><small>Sequence:</small><span class="text-danger" title="This field is required">*</span></label>
-                        {{ form.c_sequence }}
-                        <p class=text-muted><small>{{ form.c_sequence.help_text}}</small></p>
-                    </div>
+        <div class="form-row">
+            <div class="form-group m-1 col-lg-2">
+                <label for="{{ form.office.id_for_label }}"><small>Service:</small></label>
+                <br>{{ form.office }}
+                <a href="/description/#Office"><small>?</small></a>
+            </div>
+        </div>
 
-                </div>
+        <div class="form-row">
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.genre.label_tag }}</small>
+                <br>{{ form.genre }}
+            </div>
+        </div>
 
-                <div class="form-row">
-                    <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.office.id_for_label }}"><small>Service:</small></label>
-                        <br>{{ form.office }}
-                        <a href="/description/#Office"><small>?</small></a>
-                    </div>
-                </div>
+        <div class="form-row">
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.position.label_tag }}</small>
+                {{ form.position }}
+            </div>
 
-                <div class="form-row">
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.genre.label_tag }}</small>
-                        <br>{{ form.genre }}
-                    </div>
-                </div>
+            <div class="form-group m-1 col-lg-2">
+                <label for="{{ form.cantus_id.id_for_label }}"><small>Cantus ID:</small></label>
+                {{ form.cantus_id }}
+            </div>
+            <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+            <!-- <div id="segment-select-field" class="form-group m-1 col-lg-4">
+                <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
+                {{ form.segment }}
+            </div>
 
-                <div class="form-row">
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.position.label_tag }}</small>
-                        {{ form.position }}
-                    </div>
+            <div class="form-group m-1 col-lg-3">
+                <small>{{ form.liturgical_function.label_tag }}</small>
+                {{ form.liturgical_function }}
+            </div>  -->
+        </div>
 
-                    <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.cantus_id.id_for_label }}"><small>Cantus ID:</small></label>
-                        {{ form.cantus_id }}
-                    </div>
-                    <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
-                    <!-- <div id="segment-select-field" class="form-group m-1 col-lg-4">
-                        <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
-                        {{ form.segment }}
-                    </div>
+        <div class="form-row">
 
-                    <div class="form-group m-1 col-lg-3">
-                        <small>{{ form.liturgical_function.label_tag }}</small>
-                        {{ form.liturgical_function }}
-                    </div>  -->
-                </div>
+            <div class="form-group m-1 col-lg-3">
+                <small>{{ form.feast.label_tag }}</small>
+                <br>{{ form.feast }}
+            </div>
+            
+        </div>
 
-                <div class="form-row">
-
-                    <div class="form-group m-1 col-lg-3">
-                        <small>{{ form.feast.label_tag }}</small>
-                        <br>{{ form.feast }}
-                    </div>
+        <p>
+            <small>
+                {% if previous_chant %}
+                    Feasts that follow:
+                        {% for feast, count in suggested_feasts.items %}
+                            <a href="javascript:" onclick='autoFillFeast("{{ feast.name }}", {{ feast.id }});'>{{ feast.name }}</a> ({{ count }}x) |
+                        {% endfor %}                                                                                                      
                     
+                    <!-- eventually, perhaps: implement a "Reverse Changes" button -->
+                {% endif %}
+
+            </small>
+        </p>
+
+        <div class="form-row">
+
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.mode.label_tag }}</small>
+                {{ form.mode }}
+            </div>
+
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.finalis.label_tag }}</small>
+                {{ form.finalis }}
+            </div>
+
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.differentia.label_tag }}</small>
+                {{ form.differentia }}
+            </div>
+
+            <div class="form-group m-1 col-lg-2">
+                <small>{{ form.extra.label_tag }}</small>
+                {{ form.extra }}
+            </div>
+
+            <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+            <!-- <div class="form-group m-1 col-lg-2">
+                <small>{{ form.polyphony.label_tag }}</small>
+                {{ form.polyphony }}
+            </div> -->
+        </div>
+
+        <div class="form-row">
+            <div class="form-group m-1 col-lg-12">
+                <label for="{{ form.diff_db.id_for_label }}"><small>Differentiae Database:</small></label>
+                <br>{{ form.diff_db }}
+                <div>
+                    <small class="text-muted">
+                        For a list of Differentia IDs, refer to
+                        the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
+                    </small>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-row">
+
+            <div class="form-group m-1 col-lg-2">
+                <label for="{{ form.chant_range.id_for_label }}"><small>Range:</small></label>
+                {{ form.chant_range }}
+                <p class="text-muted"><small>{{ form.chant_range.help_text }}</small></p>
+            </div>
+
+            <div class="form-group m-1 col-lg-2">
+                <label for="{{ form.melody_id.id_for_label }}"><small>Melody ID:</small></label>
+                {{ form.melody_id }}
+            </div>
+
+            <div class="form-group m-1 col-lg">
+                <small>{{ form.addendum.label_tag }}</small>
+                {{ form.addendum }}
+            </div>
+            
+        </div>
+
+        <!-- See issue #1521: Temporarily commenting out segment-related functions on Chants -->
+        <!-- The next three rows of fields are hidden unless the Benedicamus Domino segment is selected. -->
+        <!-- <div id="benedicamus-domino-segment-fields" hidden>
+            <div class="form-row">
+
+                <div class="form-group m-1 col-lg-4">
+                    <small>{{ form.cm_melody_id.label_tag }}</small>
+                    {{ form.cm_melody_id }}
                 </div>
 
-                <p>
-                    <small>
-                        {% if previous_chant %}
-                            Feasts that follow:
-                               {% for feast, count in suggested_feasts.items %}
-                                    <a href="javascript:" onclick='autoFillFeast("{{ feast.name }}", {{ feast.id }});'>{{ feast.name }}</a> ({{ count }}x) |
-                               {% endfor %}                                                                                                      
-                            
-                            <!-- eventually, perhaps: implement a "Reverse Changes" button -->
-                        {% endif %}
+                <div class="form-group m-1 col-lg">
+                    <small>{{ form.incipit_of_refrain.label_tag }}</small>
+                    {{ form.incipit_of_refrain }}
+                </div>
 
+
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg">
+                    <small>{{ form.later_addition.label_tag }}</small>
+                    {{ form.later_addition }}
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg">
+                    <small>{{ form.rubrics.label_tag }}</small>
+                    {{ form.rubrics }}
+                </div>
+            </div>
+        </div> -->
+    
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}"><small>Full text as in Source (standardized spelling):<span class="text-danger" title="This field is required">*</span></small></label>
+                {{ form.manuscript_full_text_std_spelling }}
+                <p>
+                    <small class="text-muted">{{ form.manuscript_full_text_std_spelling.help_text }}
+                        For more information, consult <a href="/description/#Fulltext" target="_blank">Fields and Content Descriptions</a>.
                     </small>
                 </p>
-
-                <div class="form-row">
-
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.mode.label_tag }}</small>
-                        {{ form.mode }}
-                    </div>
-
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.finalis.label_tag }}</small>
-                        {{ form.finalis }}
-                    </div>
-
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.differentia.label_tag }}</small>
-                        {{ form.differentia }}
-                    </div>
-
-                    <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.extra.label_tag }}</small>
-                        {{ form.extra }}
-                    </div>
-
-                    <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
-                    <!-- <div class="form-group m-1 col-lg-2">
-                        <small>{{ form.polyphony.label_tag }}</small>
-                        {{ form.polyphony }}
-                    </div> -->
-                </div>
-
-                <div class="form-row">
-                    <div class="form-group m-1 col-lg-12">
-                        <label for="{{ form.diff_db.id_for_label }}"><small>Differentiae Database:</small></label>
-                        <br>{{ form.diff_db }}
-                        <div>
-                            <small class="text-muted">
-                                For a list of Differentia IDs, refer to
-                                the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
-                            </small>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="form-row">
-
-                    <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.chant_range.id_for_label }}"><small>Range:</small></label>
-                        {{ form.chant_range }}
-                        <p class="text-muted"><small>{{ form.chant_range.help_text }}</small></p>
-                    </div>
-
-                    <div class="form-group m-1 col-lg-2">
-                        <label for="{{ form.melody_id.id_for_label }}"><small>Melody ID:</small></label>
-                        {{ form.melody_id }}
-                    </div>
-
-                    <div class="form-group m-1 col-lg">
-                        <small>{{ form.addendum.label_tag }}</small>
-                        {{ form.addendum }}
-                    </div>
-                    
-                </div>
-
-                <!-- See issue #1521: Temporarily commenting out segment-related functions on Chants -->
-                <!-- The next three rows of fields are hidden unless the Benedicamus Domino segment is selected. -->
-                <!-- <div id="benedicamus-domino-segment-fields" hidden>
-                    <div class="form-row">
-
-                        <div class="form-group m-1 col-lg-4">
-                            <small>{{ form.cm_melody_id.label_tag }}</small>
-                            {{ form.cm_melody_id }}
-                        </div>
-
-                        <div class="form-group m-1 col-lg">
-                            <small>{{ form.incipit_of_refrain.label_tag }}</small>
-                            {{ form.incipit_of_refrain }}
-                        </div>
-
-
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg">
-                            <small>{{ form.later_addition.label_tag }}</small>
-                            {{ form.later_addition }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg">
-                            <small>{{ form.rubrics.label_tag }}</small>
-                            {{ form.rubrics }}
-                        </div>
-                    </div>
-                </div> -->
-            
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}"><small>Full text as in Source (standardized spelling):<span class="text-danger" title="This field is required">*</span></small></label>
-                        {{ form.manuscript_full_text_std_spelling }}
-                        <p>
-                            <small class="text-muted">{{ form.manuscript_full_text_std_spelling.help_text }}
-                                For more information, consult <a href="/description/#Fulltext" target="_blank">Fields and Content Descriptions</a>.
-                            </small>
-                        </p>
-                    </div>
-                </div>
-
-                <div class="form-row">
-                    <div class="form-group m-1 col-lg-4">
-                        <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <label for="{{ form.manuscript_full_text.id_for_label }}"><small>Full text as in Source
-                                (source spelling): </small></label>
-                        {{ form.manuscript_full_text }}
-                        <p class="text-muted" style="line-height: normal">
-                            <small>{{ form.manuscript_full_text.help_text }}
-                                For more information, <a href="{% url 'contact' %}" target="_blank">contact Cantus Database staff</a>.
-                            </small>
-                        </p>
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <small>{{ form.volpiano.label_tag }}</small>
-                        {{ form.volpiano }}
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg-8">
-                        <small>{{ form.image_link.label_tag }}</small>
-                        {{ form.image_link }}
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg-8">
-                        <small>{{ form.content_structure.label_tag }}</small> <!-- the Content Structure field is no longer there in OldCantus... -->
-                        {{ form.content_structure }}
-                        <p class="text-muted" style="line-height: normal">
-                            <small>{{ form.content_structure.help_text }}</small>
-                        </p>
-                    </div>
-                </div>
-
-                <div class="form-row align-items-end">
-                    <div class="form-group m-1 col-lg">
-                        <small>{{ form.indexing_notes.label_tag }}</small>
-                        {{ form.indexing_notes }}
-                    </div>
-                </div>
-
-                <div class="form-group m-1 col-lg-2">
-                    <button type="submit" class="btn btn-dark btn-sm" id="btn-submit"> Save
-                    </button>
-                </div>
-            </form>
+            </div>
         </div>
 
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
+        <div class="form-row">
+            <div class="form-group m-1 col-lg-4">
+                <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
             </div>
+        </div>
 
-            <div class="card w-100 mb-3">
-                <div class="card-header">
-                    <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h5>
-                </div>
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <label for="{{ form.manuscript_full_text.id_for_label }}"><small>Full text as in Source
+                        (source spelling): </small></label>
+                {{ form.manuscript_full_text }}
+                <p class="text-muted" style="line-height: normal">
+                    <small>{{ form.manuscript_full_text.help_text }}
+                        For more information, <a href="{% url 'contact' %}" target="_blank">contact Cantus Database staff</a>.
+                    </small>
+                </p>
             </div>
+        </div>
 
-            {% if previous_chant %}
-                <div class="card w-100">
-                    <div class="card-body">
-                        <small>
-                            <b>Suggestions based on previous chant:</b><br>
-                            <div>
-                                {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{% url 'chant-detail' previous_chant.id %}" target="_blank">{{ previous_chant.incipit }}</a><br>
-                                {% if previous_chant.cantus_id %}
-                                    (Cantus ID: <b><a href="https://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a></b>)
-                                {% endif %}
-                            </div>
-                        {% if suggested_chants %}
-                            {% for suggestion in suggested_chants %}
-                                <input
-                                    type="button"
-                                    style="width: 80px"
-                                    value="{{ suggestion.cantus_id }}"
-                                    title="{{ suggestion.cantus_id }}"
-                                    onclick='autoFillSuggestedChant(
-                                        "{{ suggestion.genre_name }}",
-                                        {{ suggestion.genre_id | default_if_none:"null" }},
-                                        "{{ suggestion.cantus_id }}",
-                                        "{{ suggestion.fulltext }}"
-                                    )'
-                                >
-                                <strong>{{ suggestion.genre_name }}</strong> - <span title="{{ suggestion.fulltext }}">{{ suggestion.incipit }}</span> (<strong>{{ suggestion.occurrences }}x</strong>)<br>
-                            {% endfor %}
-                        {% else %}
-                            Sorry! No suggestions found.<br>
-                        {% endif %}
-                        </small>
-                    </div>
-                </div>
-            {% endif %}
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <small>{{ form.volpiano.label_tag }}</small>
+                {{ form.volpiano }}
+            </div>
+        </div>
+
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg-8">
+                <small>{{ form.image_link.label_tag }}</small>
+                {{ form.image_link }}
+            </div>
+        </div>
+
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg-8">
+                <small>{{ form.content_structure.label_tag }}</small> <!-- the Content Structure field is no longer there in OldCantus... -->
+                {{ form.content_structure }}
+                <p class="text-muted" style="line-height: normal">
+                    <small>{{ form.content_structure.help_text }}</small>
+                </p>
+            </div>
+        </div>
+
+        <div class="form-row align-items-end">
+            <div class="form-group m-1 col-lg">
+                <small>{{ form.indexing_notes.label_tag }}</small>
+                {{ form.indexing_notes }}
+            </div>
+        </div>
+
+        <div class="form-group m-1 col-lg-2">
+            <button type="submit" class="btn btn-dark btn-sm" id="btn-submit"> Save
+            </button>
+        </div>
+    </form>
+{% endblock %}
+{% block lowersidebar %}
+    <div class="card w-100 mb-3">
+        <div class="card-header">
+            <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h5>
         </div>
     </div>
-</div>
+
+    {% if previous_chant %}
+        <div class="card w-100">
+            <div class="card-body">
+                <small>
+                    <b>Suggestions based on previous chant:</b><br>
+                    <div>
+                        {{ previous_chant.folio }} {{ previous_chant.c_sequence}} <a href="{% url 'chant-detail' previous_chant.id %}" target="_blank">{{ previous_chant.incipit }}</a><br>
+                        {% if previous_chant.cantus_id %}
+                            (Cantus ID: <b><a href="https://cantusindex.org/id/{{ previous_chant.cantus_id }}" target="_blank">{{ previous_chant.cantus_id }}</a></b>)
+                        {% endif %}
+                    </div>
+                {% if suggested_chants %}
+                    {% for suggestion in suggested_chants %}
+                        <input
+                            type="button"
+                            style="width: 80px"
+                            value="{{ suggestion.cantus_id }}"
+                            title="{{ suggestion.cantus_id }}"
+                            onclick='autoFillSuggestedChant(
+                                "{{ suggestion.genre_name }}",
+                                {{ suggestion.genre_id | default_if_none:"null" }},
+                                "{{ suggestion.cantus_id }}",
+                                "{{ suggestion.fulltext }}"
+                            )'
+                        >
+                        <strong>{{ suggestion.genre_name }}</strong> - <span title="{{ suggestion.fulltext }}">{{ suggestion.incipit }}</span> (<strong>{{ suggestion.occurrences }}x</strong>)<br>
+                    {% endfor %}
+                {% else %}
+                    Sorry! No suggestions found.<br>
+                {% endif %}
+                </small>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -1,493 +1,493 @@
-{% extends "base.html" %}
-{% block content %}
+{% extends "base_page_with_side_cards.html" %}
+
+{% block title %}
 <title>{{ chant.incipit }} | Cantus Database</title>
+{% endblock %}
+
+{% block script %}
 <script src="/static/js/chant_detail.js"></script>
+{% endblock %}
 
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
+{% block uppersidebar %}
+    <div class="search-bar mb-3">
+        {% include "global_search_bar.html" %}
+    </div>
+{% endblock %}
 
-            <!--Display "submit success" message -->
-            {% if messages %}
-                <div class="alert alert-success alert-dismissible">
-                    {% for message in messages %}
-                        {{ message }}
-                    {% endfor %}
+{% block maincontent %}
+    <!--Display "submit success" message -->
+    {% if messages %}
+        <div class="alert alert-success alert-dismissible">
+            {% for message in messages %}
+                {{ message }}
+            {% endfor %}
+        </div>
+    {% endif %}
+    
+    {% if user_can_edit_chant %}
+        <p>
+            View | <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}&ref=chant-detail">Edit</a>
+        </p>
+    {% endif %}
+    
+    <h3>{{ chant.incipit }}</h3>
+
+    <dl>
+        <div class="row">
+            {% if chant.source %}
+                <div class="col">
+                    <dt>Source</dt>
+                    <dd>
+                        <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.title }}</a>
+                    </dd>
                 </div>
             {% endif %}
-            
-            {% if user_can_edit_chant %}
-                <p>
-                    View | <a href="{% url 'source-edit-chants' chant.source.id %}?pk={{ chant.id }}&folio={{ chant.folio }}&ref=chant-detail">Edit</a>
-                </p>
+
+            {% if chant.marginalia %}
+                <div class="col">
+                    <dt> Marginalia</dt>
+                    <dd>{{ chant.marginalia }}</dd>
+                </div>
             {% endif %}
-            
-            <h3>{{ chant.incipit }}</h3>
+        </div>
 
-            <dl>
-                <div class="row">
-                    {% if chant.source %}
-                        <div class="col">
-                            <dt>Source</dt>
-                            <dd>
-                                <a href="{% url 'source-detail' chant.source.id %}">{{ chant.source.title }}</a>
-                            </dd>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.marginalia %}
-                        <div class="col">
-                            <dt> Marginalia</dt>
-                            <dd>{{ chant.marginalia }}</dd>
-                        </div>
-                    {% endif %}
+        <div class="form-row">
+            {% if chant.folio %}
+                <div class="form-group col-lg-2  col-sm-6 col-6">
+                    <dt>Folio</dt>
+                    <dd>{{ chant.folio }}</dd>
                 </div>
+            {% endif %}
 
-                <div class="form-row">
-                    {% if chant.folio %}
-                        <div class="form-group col-lg-2  col-sm-6 col-6">
-                            <dt>Folio</dt>
-                            <dd>{{ chant.folio }}</dd>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.c_sequence is not None %} {# check that it isn't None, since sometimes c_sequence is 0 #}
-                        <div class="form-group col-lg-2  col-sm-6 col-6">
-                            <dt>Sequence</dt>
-                            <dd>{{ chant.c_sequence }}</dd>
-                        </div>
-                    {% endif %}
+            {% if chant.c_sequence is not None %} {# check that it isn't None, since sometimes c_sequence is 0 #}
+                <div class="form-group col-lg-2  col-sm-6 col-6">
+                    <dt>Sequence</dt>
+                    <dd>{{ chant.c_sequence }}</dd>
                 </div>
-                
-                <div class="form-row">
-                    {% if chant.feast %}
-                        <div class="form-group col-lg-2  col-sm-6 col-6">
-                            <dt>Feast</dt>
-                            <dd>
-                                <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name }}</a>
-                            </dd>
-                        </div>
-                    {% endif %}
-                
-                    {% if chant.office %}
-                        <div class="form-group col-lg-2 col-sm-6 col-6">
-                            <dt>Service</dt>
-                            <dd>
-                                <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
-                            </dd>
-                        </div>
-                    {% endif %}
-                
-                    {% if chant.genre %}
-                        <div class="form-group col-lg-2 col-sm-6 col-6">
-                            <dt>Genre</dt>
-                            <dd>
-                                <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
-                            </dd>
-                        </div>
-                    {% endif %}
-                
-                    {% if chant.position %}
-                        <div class="form-group col-lg-2 col-sm-6 col-6">
-                            <dt>Position</dt>
-                            <dd>{{ chant.position }}</dd>
-                        </div>
-                    {% endif %}
-                
-                    {% if chant.cantus_id %}
-                        <div class="form-group col-lg-2 col-sm-6 col-6">
-                            <dt>Cantus ID</dt>
-                            <dd>
-                                <a href="{{ chant.get_ci_url }}" target="_blank">
-                                    {{ chant.cantus_id }}
-                                </a>
-                            </dd>
-                        </div>
-                    {% endif %}
-                
-                    {% if chant.mode %}
-                        <div class="form-group col-lg-2 col-sm-6 col-6">
-                            <dt>Mode</dt>
-                            <dd>{{ chant.mode }}</dd>
-                        </div>
-                    {% endif %}
-                </div>
-                
-
-                <div class="row">
-                    {% if chant.finalis %}
-                        <div class="col">
-                            <dt>Finalis</dt>
-                            <dd>{{ chant.finalis }}</dd>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.differentia %}
-                        <div class="col">
-                            <dt>Differentia</dt>
-                            <dd>{{ chant.differentia }}</dd>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.diff_db %}
-                        <div class="col">
-                            <dt>Differentia&nbsp;Database</dt>
-                            <dd>
-                                {% if chant.diff_db.melodic_transcription %}
-                                    <p style="font-family: volpiano; font-size:28px; margin-bottom: 0px;">{{ chant.diff_db.melodic_transcription }}</p>
-                                {% endif %}
-                                <a href="https://differentiaedatabase.ca/differentia/{{ chant.diff_db }}" target="_blank">
-                                    {{ chant.diff_db }}
-                                </a>
-                            </dd>    
-                        </div>
-                    {% endif %}
-
-                    {% if chant.chant_range %}
-                        <div class="col">
-                            <dt>Range</dt>
-                            <dd>
-                                <p style="font-family: volpiano; font-size:28px">{{ chant.chant_range }}</p>
-                            </dd>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.addendum %}
-                        <div class="col">
-                            <dt>Addendum</dt>
-                            <dd>{{ chant.addendum }}</dd>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.extra %}
-                        <div class="col">
-                            <dt>Extra</dt>
-                            <dd>{{ chant.extra }}</dd>
-                        </div>
-                    {% endif %}
-                </div>
-
-                {% if chant.manuscript_full_text_std_spelling %}
-                    <dt>Full text as in Source (standardized spelling)</dt>
-                    <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
-                {% endif %}
-
-                {% if chant.manuscript_full_text %}
-                    <dt>Full text as in Source (source spelling)</dt>
-                    <dd>{{ chant.manuscript_full_text }}</dd>
-                {% endif %}
-
-                {% if chant.volpiano %}
-                    <dt>Volpiano</dt>
+            {% endif %}
+        </div>
+        
+        <div class="form-row">
+            {% if chant.feast %}
+                <div class="form-group col-lg-2  col-sm-6 col-6">
+                    <dt>Feast</dt>
                     <dd>
-                        <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+                        <a href="{% url 'feast-detail' chant.feast.id %}" title="{{ chant.feast.description }}">{{ chant.feast.name }}</a>
                     </dd>
-                {% endif %}
-
-                {% if chant.indexing_notes %}
-                    <dt>Indexing Notes</dt>
-                    <dd>{{ chant.indexing_notes }}</dd>
-                {% endif %}
-
-                {% if chant.volpiano %}
-                    <div class="row">
-                        <div class="col">
-                            <dt>Melody with text</dt>
-                            {% if chant.manuscript_syllabized_full_text %}
-                                <p><small>Syllabification is based on saved syllabized text.</small></p>
-                            {% endif %}
-                            <dd>
-                                {% for syl_text, syl_mel in syllabized_text_with_melody %}
-                                    <span style="float: left">
-                                        <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
-                                        <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
-                                        <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
-                                    </span>
-                                {% endfor %}
-                            </dd>
-                        </div>
-                    </div>
-                {% endif %}
-
-                {% if chant.image_link %}
-                    <dt>Image link</dt>
+                </div>
+            {% endif %}
+        
+            {% if chant.office %}
+                <div class="form-group col-lg-2 col-sm-6 col-6">
+                    <dt>Service</dt>
                     <dd>
-                        <a href="{{ chant.image_link }}" target="_blank" style="word-break: break-all">{{ chant.image_link }}</a>
+                        <a href="{% url 'office-detail' chant.office.id %}" title="{{ chant.office.description }}">{{ chant.office.name }}</a>
                     </dd>
-                {% endif %}
-                {% if exists_on_cantus_ultimus %}
-                    <dt>Image link (Cantus Ultimus)</dt>
+                </div>
+            {% endif %}
+        
+            {% if chant.genre %}
+                <div class="form-group col-lg-2 col-sm-6 col-6">
+                    <dt>Genre</dt>
                     <dd>
-                        <a href="https://cantus.simssa.ca/manuscript/{{ chant.source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}" target="_blank" style="word-break: break-all">
-                            https://cantus.simssa.ca/manuscript/{{ chant.source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}
+                        <a href="{% url 'genre-detail' chant.genre.id %}" title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
+                    </dd>
+                </div>
+            {% endif %}
+        
+            {% if chant.position %}
+                <div class="form-group col-lg-2 col-sm-6 col-6">
+                    <dt>Position</dt>
+                    <dd>{{ chant.position }}</dd>
+                </div>
+            {% endif %}
+        
+            {% if chant.cantus_id %}
+                <div class="form-group col-lg-2 col-sm-6 col-6">
+                    <dt>Cantus ID</dt>
+                    <dd>
+                        <a href="{{ chant.get_ci_url }}" target="_blank">
+                            {{ chant.cantus_id }}
                         </a>
                     </dd>
-                {% endif %}
-            </dl>
-            {% if chant.cantus_id %}
-                <h4 id="concordances">List of concordances</h4>
-                <p>
-                    For concordances, please consult the
-                    <a href="https://cantusindex.org/" target="_blank">Cantus Index</a> entry for Cantus ID
-                    <b><a href="https://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{ chant.cantus_id }}</a></b>.
-                </p>
+                </div>
+            {% endif %}
+        
+            {% if chant.mode %}
+                <div class="form-group col-lg-2 col-sm-6 col-6">
+                    <dt>Mode</dt>
+                    <dd>{{ chant.mode }}</dd>
+                </div>
+            {% endif %}
+        </div>
+        
 
-                <h4>List of melodies</h4>
-                <span id="melodyLoadingPrompt" style="display: none; color: #922"><b>Loading melodies...</b></span>
-                <a id="melodyButton" href="#" class="guillemet" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">Display the melodies connected with this chant</a>
-                <div id="melodyDiv"></div>        
+        <div class="row">
+            {% if chant.finalis %}
+                <div class="col">
+                    <dt>Finalis</dt>
+                    <dd>{{ chant.finalis }}</dd>
+                </div>
             {% endif %}
 
+            {% if chant.differentia %}
+                <div class="col">
+                    <dt>Differentia</dt>
+                    <dd>{{ chant.differentia }}</dd>
+                </div>
+            {% endif %}
+
+            {% if chant.diff_db %}
+                <div class="col">
+                    <dt>Differentia&nbsp;Database</dt>
+                    <dd>
+                        {% if chant.diff_db.melodic_transcription %}
+                            <p style="font-family: volpiano; font-size:28px; margin-bottom: 0px;">{{ chant.diff_db.melodic_transcription }}</p>
+                        {% endif %}
+                        <a href="https://differentiaedatabase.ca/differentia/{{ chant.diff_db }}" target="_blank">
+                            {{ chant.diff_db }}
+                        </a>
+                    </dd>    
+                </div>
+            {% endif %}
+
+            {% if chant.chant_range %}
+                <div class="col">
+                    <dt>Range</dt>
+                    <dd>
+                        <p style="font-family: volpiano; font-size:28px">{{ chant.chant_range }}</p>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if chant.addendum %}
+                <div class="col">
+                    <dt>Addendum</dt>
+                    <dd>{{ chant.addendum }}</dd>
+                </div>
+            {% endif %}
+
+            {% if chant.extra %}
+                <div class="col">
+                    <dt>Extra</dt>
+                    <dd>{{ chant.extra }}</dd>
+                </div>
+            {% endif %}
         </div>
 
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
+        {% if chant.manuscript_full_text_std_spelling %}
+            <dt>Full text as in Source (standardized spelling)</dt>
+            <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>
+        {% endif %}
+
+        {% if chant.manuscript_full_text %}
+            <dt>Full text as in Source (source spelling)</dt>
+            <dd>{{ chant.manuscript_full_text }}</dd>
+        {% endif %}
+
+        {% if chant.volpiano %}
+            <dt>Volpiano</dt>
+            <dd>
+                <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
+            </dd>
+        {% endif %}
+
+        {% if chant.indexing_notes %}
+            <dt>Indexing Notes</dt>
+            <dd>{{ chant.indexing_notes }}</dd>
+        {% endif %}
+
+        {% if chant.volpiano %}
+            <div class="row">
+                <div class="col">
+                    <dt>Melody with text</dt>
+                    {% if chant.manuscript_syllabized_full_text %}
+                        <p><small>Syllabification is based on saved syllabized text.</small></p>
+                    {% endif %}
+                    <dd>
+                        {% for syl_text, syl_mel in syllabized_text_with_melody %}
+                            <span style="float: left">
+                                <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
+                                <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
+                                <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
+                            </span>
+                        {% endfor %}
+                    </dd>
+                </div>
+            </div>
+        {% endif %}
+
+        {% if chant.image_link %}
+            <dt>Image link</dt>
+            <dd>
+                <a href="{{ chant.image_link }}" target="_blank" style="word-break: break-all">{{ chant.image_link }}</a>
+            </dd>
+        {% endif %}
+        {% if exists_on_cantus_ultimus %}
+            <dt>Image link (Cantus Ultimus)</dt>
+            <dd>
+                <a href="https://cantus.simssa.ca/manuscript/{{ chant.source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}" target="_blank" style="word-break: break-all">
+                    https://cantus.simssa.ca/manuscript/{{ chant.source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}
+                </a>
+            </dd>
+        {% endif %}
+    </dl>
+    {% if chant.cantus_id %}
+        <h4 id="concordances">List of concordances</h4>
+        <p>
+            For concordances, please consult the
+            <a href="https://cantusindex.org/" target="_blank">Cantus Index</a> entry for Cantus ID
+            <b><a href="https://cantusindex.org/id/{{ chant.cantus_id }}" target="_blank">{{ chant.cantus_id }}</a></b>.
+        </p>
+
+        <h4>List of melodies</h4>
+        <span id="melodyLoadingPrompt" style="display: none; color: #922"><b>Loading melodies...</b></span>
+        <a id="melodyButton" href="#" class="guillemet" onclick="loadMelodies('{{ chant.cantus_id }}'); return false;">Display the melodies connected with this chant</a>
+        <div id="melodyDiv"></div>        
+    {% endif %}
+{% endblock %}
+
+{% block lowersidebar %}
+    {% with source=chant.source %}
+        <div class="card mb-3 w-100">
+            <div class="card-header">
+                <b>Source navigation</b>
+                <br>
+                {% if source %}
+                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"> <b>{{ source.siglum }}</b> </a>
+                {% else %}
+                    This chant is not associated with any source. 
+                {% endif %}                            
             </div>
 
-            {% with source=chant.source %}
-                <div class="card mb-3 w-100">
-                    <div class="card-header">
-                        <b>Source navigation</b>
-                        <br>
-                        {% if source %}
-                            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}"> <b>{{ source.siglum }}</b> </a>
-                        {% else %}
-                            This chant is not associated with any source. 
-                        {% endif %}                            
-                    </div>
-
-                    {% if source %}
-                        <div class="card-body">
-                            <small>
-                                <!--a small selector of all folios of this source-->
-                                <select name="folios" id="folioSelect" class="w-30" onchange="jumpToFolio('{{ source.id }}')">
-                                    <option value="">Select a folio</option>
-                                    {% for folio in folios %}
-                                        {% if folio == chant.folio %}
-                                            <option selected value="{{ folio }}">{{ folio }}</option>
-                                        {% else %}
-                                            <option value="{{ folio }}">{{ folio }}</option>
-                                        {% endif %}
-                                    {% endfor %}
-                                </select>
-
-                                {% if previous_folio %}
-                                    <a href="{% url "browse-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
+            {% if source %}
+                <div class="card-body">
+                    <small>
+                        <!--a small selector of all folios of this source-->
+                        <select name="folios" id="folioSelect" class="w-30" onchange="jumpToFolio('{{ source.id }}')">
+                            <option value="">Select a folio</option>
+                            {% for folio in folios %}
+                                {% if folio == chant.folio %}
+                                    <option selected value="{{ folio }}">{{ folio }}</option>
+                                {% else %}
+                                    <option value="{{ folio }}">{{ folio }}</option>
                                 {% endif %}
-                                {% if next_folio %}
-                                    &nbsp;<a href="{% url "browse-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
-                                {% endif %}
+                            {% endfor %}
+                        </select>
 
-                                {% if exists_on_cantus_ultimus %}
-                                    <a href="https://cantus.simssa.ca/manuscript/{{ chant.source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}" class="guillemet" target="_blank">
-                                        Display facsimile <b>({{ chant.folio }})
-                                    </a>
-                                {% elif chant.image_link %}
-                                    <a href={{ chant.image_link }} class="guillemet" target="_blank">Display facsimile <b>({{ chant.folio }})</b></a>
-                                {% endif %}
+                        {% if previous_folio %}
+                            <a href="{% url "browse-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
+                        {% endif %}
+                        {% if next_folio %}
+                            &nbsp;<a href="{% url "browse-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
+                        {% endif %}
 
-                                {% if previous_folio %}
-                                    <br>
-                                    <div id="previousDiv" style="display:none">
-                                        {% for feast, chants in feasts_previous_folio %}
-                                            Folio: <b>{{ previous_folio }}</b> - Feast: <b>{{ feast.name }}</b>
-                                            <table class="table table-sm small table-bordered">     
-                                                {% for chant in chants %}
-                                                    <tr>
-                                                        <td>
-                                                            {{ chant.c_sequence }}
-                                                        </td>
-                                                        <td>
-                                                            <span title="{{ chant.office.description }}">
-                                                                {{ chant.office.name|default_if_none:"" }}
-                                                            </span>
-                                                            <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
-                                                            {{ chant.position|default_if_none:"" }}
-                                                        </td>
-                                                        <td>
-                                                            <a href="{% url 'chant-detail' chant.id %}">
-                                                                {{ chant.incipit|default_if_none:"" }}
-                                                            </a>
-                                                        </td>
-                                                        <td>
-                                                            <a href="{{ chant.get_ci_url }}" target="_blank">
-                                                                {{ chant.cantus_id|default_if_none:"" }}
-                                                            </a>
-                                                        </td>
-                                                    </tr>
-                                                {% endfor %}
-                                            </table>
-                                        {% endfor %}
-                                    </div>
-                                    <a id="previousToggle" href="#" onclick="togglePrevious(); return false;">Display previous chants ▾</a>
-                                {% endif %}
-                                <br>
-                                {% with chant.c_sequence as current_seq %}
-                                    {% for feast, chants in feasts_current_folio %}
-                                        Folio: <b>{{ chant.folio }}</b> - Feast: <b title="{{ feast.description }}">{{ feast.name }}</b>
-                                        <table class="table table-sm small table-bordered">     
-                                            {% for chant in chants %}
-                                                <tr>
-                                                    <td>
-                                                        {{ chant.c_sequence }}
-                                                    </td>
-                                                    <td>
-                                                        <span title="{{ chant.office.description }}">
-                                                            {{ chant.office.name|default_if_none:"" }}
-                                                        </span>
-                                                        <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
-                                                        {{ chant.position|default_if_none:"" }}
-                                                    </td>
-                                                    <td>
-                                                        <a href="{% url 'chant-detail' chant.id %}">
-                                                            {% if chant.c_sequence == current_seq %}
-                                                                <b>{{ chant.incipit|default_if_none:"" }}</b>
-                                                            {% else %}
-                                                                {{ chant.incipit|default_if_none:"" }}
-                                                            {% endif %}
-                                                        </a>
-                                                    </td>
-                                                    <td>
-                                                        <a href="{{ chant.get_ci_url }}" target="_blank">
-                                                            {{ chant.cantus_id|default_if_none:"" }}
-                                                        </a>
-                                                    </td>
-                                                </tr>
-                                            {% endfor %}
-                                        </table>
-                                    {% endfor %}
-                                {% endwith %}
+                        {% if exists_on_cantus_ultimus %}
+                            <a href="https://cantus.simssa.ca/manuscript/{{ chant.source.id }}/?folio={{ chant.folio }}&chant={{ chant.c_sequence }}" class="guillemet" target="_blank">
+                                Display facsimile <b>({{ chant.folio }})
+                            </a>
+                        {% elif chant.image_link %}
+                            <a href={{ chant.image_link }} class="guillemet" target="_blank">Display facsimile <b>({{ chant.folio }})</b></a>
+                        {% endif %}
 
-                                {% if next_folio %}
-                                    <a id="nextToggle" href="#" onclick="toggleNext(); return false;">Display next chants ▾</a>
-                                    <br>
-                                    <div id="nextDiv" style="display:none">
-                                        {% for feast, chants in feasts_next_folio %}
-                                            Folio: <b>{{ next_folio }}</b> - Feast: <b title="{{ feast.description }}">{{ feast.name }}</b>
-                                            <table class="table table-sm small table-bordered">     
-                                                {% for chant in chants %}
-                                                    <tr>
-                                                        <td>
-                                                            {{ chant.c_sequence }}
-                                                        </td>
-                                                        <td>
-                                                            <span title="{{ chant.office.description }}">
-                                                                {{ chant.office.name|default_if_none:"" }}
-                                                            </span>
-                                                            <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
-                                                            {{ chant.position|default_if_none:"" }}
-                                                        </td>
-                                                        <td>
-                                                            <a href="{% url 'chant-detail' chant.id %}">
-                                                                {{ chant.incipit|default_if_none:"" }}
-                                                            </a>
-                                                        </td>
-                                                        <td>
-                                                             <a href="{{ chant.get_ci_url }}" target="_blank">
-                                                                {{ chant.cantus_id|default_if_none:"" }}
-                                                            </a>
-                                                        </td>
-                                                    </tr>
-                                                {% endfor %}
-                                            </table>
-                                        {% endfor %}
-                                    </div>
-                                {% endif %}
-                            </small>
-                        </div>
-                    {% endif %}
-                </div>
-
-                {% if source %}
-                    <div class="card w-100">
-                        <div class="card-header">
-                            <small><a href="/sources?segment={{ source.segment.id }}">{{ source.segment.name }}</a></small>
+                        {% if previous_folio %}
                             <br>
-                            <span title="{{ source.title }}">{{ source.siglum }}</span>
-                        </div>
-                        <div class=" card-body">
-                            <small>
-                                {% if source.provenance.name %}
-                                    Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
-                                    <br>
-                                {% endif %}
-
-                                {% if source.date %}
-                                    Date: 
-                                    {% for century in source.century.all %}
-                                        <b>
-                                            <a href="{% url 'century-detail' century.id %}">{{ century.name }}</a>
-                                        </b>
+                            <div id="previousDiv" style="display:none">
+                                {% for feast, chants in feasts_previous_folio %}
+                                    Folio: <b>{{ previous_folio }}</b> - Feast: <b>{{ feast.name }}</b>
+                                    <table class="table table-sm small table-bordered">     
+                                        {% for chant in chants %}
+                                            <tr>
+                                                <td>
+                                                    {{ chant.c_sequence }}
+                                                </td>
+                                                <td>
+                                                    <span title="{{ chant.office.description }}">
+                                                        {{ chant.office.name|default_if_none:"" }}
+                                                    </span>
+                                                    <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
+                                                    {{ chant.position|default_if_none:"" }}
+                                                </td>
+                                                <td>
+                                                    <a href="{% url 'chant-detail' chant.id %}">
+                                                        {{ chant.incipit|default_if_none:"" }}
+                                                    </a>
+                                                </td>
+                                                <td>
+                                                    <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                        {{ chant.cantus_id|default_if_none:"" }}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                    </table>
+                                {% endfor %}
+                            </div>
+                            <a id="previousToggle" href="#" onclick="togglePrevious(); return false;">Display previous chants ▾</a>
+                        {% endif %}
+                        <br>
+                        {% with chant.c_sequence as current_seq %}
+                            {% for feast, chants in feasts_current_folio %}
+                                Folio: <b>{{ chant.folio }}</b> - Feast: <b title="{{ feast.description }}">{{ feast.name }}</b>
+                                <table class="table table-sm small table-bordered">     
+                                    {% for chant in chants %}
+                                        <tr>
+                                            <td>
+                                                {{ chant.c_sequence }}
+                                            </td>
+                                            <td>
+                                                <span title="{{ chant.office.description }}">
+                                                    {{ chant.office.name|default_if_none:"" }}
+                                                </span>
+                                                <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
+                                                {{ chant.position|default_if_none:"" }}
+                                            </td>
+                                            <td>
+                                                <a href="{% url 'chant-detail' chant.id %}">
+                                                    {% if chant.c_sequence == current_seq %}
+                                                        <b>{{ chant.incipit|default_if_none:"" }}</b>
+                                                    {% else %}
+                                                        {{ chant.incipit|default_if_none:"" }}
+                                                    {% endif %}
+                                                </a>
+                                            </td>
+                                            <td>
+                                                <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                    {{ chant.cantus_id|default_if_none:"" }}
+                                                </a>
+                                            </td>
+                                        </tr>
                                     {% endfor %}
-                                    |
-                                    <b>{{ source.date|default_if_none:"" }}</b>
-                                    <br>
-                                {% endif %}
+                                </table>
+                            {% endfor %}
+                        {% endwith %}
 
-                                {% if source.cursus %}
-                                    Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
-                                    <br>
-                                {% endif %}
-
-                                {% if source.notation.exists %}
-                                    <b>
-                                        <a href="{% url 'notation-detail' source.notation.all.first.id %}">{{ source.notation.all.first.name }}</a>
-                                    </b>
-                                    <br>
-                                {% endif %}
-
-                                {% if source.inventoried_by.exists %}
-                                    Inventoried by:
-                                    <ul>
-                                        {% for editor in source.inventoried_by.all %}
-                                            <li>
-                                                {% if editor.full_name %}
-                                                    <a href="{% url 'user-detail' editor.id %}"><b>{{ editor.full_name }}</b></a>
-                                                {% else %}
-                                                    <a href="{% url 'user-detail' editor.id %}"><b>User {{ editor.id }}</b></a>
-                                                {% endif %}
-                                                <br>
-                                                {{ editor.institution|default_if_none:"" }}
-                                            </li>
+                        {% if next_folio %}
+                            <a id="nextToggle" href="#" onclick="toggleNext(); return false;">Display next chants ▾</a>
+                            <br>
+                            <div id="nextDiv" style="display:none">
+                                {% for feast, chants in feasts_next_folio %}
+                                    Folio: <b>{{ next_folio }}</b> - Feast: <b title="{{ feast.description }}">{{ feast.name }}</b>
+                                    <table class="table table-sm small table-bordered">     
+                                        {% for chant in chants %}
+                                            <tr>
+                                                <td>
+                                                    {{ chant.c_sequence }}
+                                                </td>
+                                                <td>
+                                                    <span title="{{ chant.office.description }}">
+                                                        {{ chant.office.name|default_if_none:"" }}
+                                                    </span>
+                                                    <b title="{{ chant.genre.description }}">{{ chant.genre.name|default_if_none:"" }}</b>
+                                                    {{ chant.position|default_if_none:"" }}
+                                                </td>
+                                                <td>
+                                                    <a href="{% url 'chant-detail' chant.id %}">
+                                                        {{ chant.incipit|default_if_none:"" }}
+                                                    </a>
+                                                </td>
+                                                <td>
+                                                        <a href="{{ chant.get_ci_url }}" target="_blank">
+                                                        {{ chant.cantus_id|default_if_none:"" }}
+                                                    </a>
+                                                </td>
+                                            </tr>
                                         {% endfor %}
-                                    </ul>
-                                {% endif %}
-
-                                {% if source.proofreaders.exists %}
-                                    Proofreader{{ source.proofreaders.all|pluralize }}:
-                                    <br>
-                                    <ul>
-                                        {% for editor in source.proofreaders.all %}
-                                            <li>
-                                                {% if editor.full_name %}
-                                                    <a href="{% url 'user-detail' editor.id %}"><b>{{ editor.full_name }}</b></a>
-                                                {% else %}
-                                                    <a href="{% url 'user-detail' editor.id %}"><b>User {{ editor.id }}</b></a>
-                                                {% endif %}
-                                            </li>
-                                            <br>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-
-                                {{ source.indexing_notes|default_if_none:""|safe }}
-                                <br>
-                                {% with creator=source.created_by %}
-                                    {% if creator %}
-                                        {% if creator.full_name %}
-                                            Contributor: <a href={% url 'user-detail' creator.id %}><b>{{ creator.full_name }}</b></a>
-                                        {% else %}
-                                            Contributor: <a href={% url 'user-detail' creator.id %}><b>User {{creator.id}}</b></a>
-                                        {% endif %}
-                                    {% endif %}
-                                {% endwith %}
-                            </small>
-                        </div>
-                    </div>
-                {% endif %}
-            {% endwith %}
+                                    </table>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </small>
+                </div>
+            {% endif %}
         </div>
-    </div>
-</div>
+
+        {% if source %}
+            <div class="card w-100">
+                <div class="card-header">
+                    <small><a href="/sources?segment={{ source.segment.id }}">{{ source.segment.name }}</a></small>
+                    <br>
+                    <span title="{{ source.title }}">{{ source.siglum }}</span>
+                </div>
+                <div class=" card-body">
+                    <small>
+                        {% if source.provenance.name %}
+                            Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
+                            <br>
+                        {% endif %}
+
+                        {% if source.date %}
+                            Date: 
+                            {% for century in source.century.all %}
+                                <b>
+                                    <a href="{% url 'century-detail' century.id %}">{{ century.name }}</a>
+                                </b>
+                            {% endfor %}
+                            |
+                            <b>{{ source.date|default_if_none:"" }}</b>
+                            <br>
+                        {% endif %}
+
+                        {% if source.cursus %}
+                            Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
+                            <br>
+                        {% endif %}
+
+                        {% if source.notation.exists %}
+                            <b>
+                                <a href="{% url 'notation-detail' source.notation.all.first.id %}">{{ source.notation.all.first.name }}</a>
+                            </b>
+                            <br>
+                        {% endif %}
+
+                        {% if source.inventoried_by.exists %}
+                            Inventoried by:
+                            <ul>
+                                {% for editor in source.inventoried_by.all %}
+                                    <li>
+                                        {% if editor.full_name %}
+                                            <a href="{% url 'user-detail' editor.id %}"><b>{{ editor.full_name }}</b></a>
+                                        {% else %}
+                                            <a href="{% url 'user-detail' editor.id %}"><b>User {{ editor.id }}</b></a>
+                                        {% endif %}
+                                        <br>
+                                        {{ editor.institution|default_if_none:"" }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+
+                        {% if source.proofreaders.exists %}
+                            Proofreader{{ source.proofreaders.all|pluralize }}:
+                            <br>
+                            <ul>
+                                {% for editor in source.proofreaders.all %}
+                                    <li>
+                                        {% if editor.full_name %}
+                                            <a href="{% url 'user-detail' editor.id %}"><b>{{ editor.full_name }}</b></a>
+                                        {% else %}
+                                            <a href="{% url 'user-detail' editor.id %}"><b>User {{ editor.id }}</b></a>
+                                        {% endif %}
+                                    </li>
+                                    <br>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+
+                        {{ source.indexing_notes|default_if_none:""|safe }}
+                        <br>
+                        {% with creator=source.created_by %}
+                            {% if creator %}
+                                {% if creator.full_name %}
+                                    Contributor: <a href={% url 'user-detail' creator.id %}><b>{{ creator.full_name }}</b></a>
+                                {% else %}
+                                    Contributor: <a href={% url 'user-detail' creator.id %}><b>User {{creator.id}}</b></a>
+                                {% endif %}
+                            {% endif %}
+                        {% endwith %}
+                    </small>
+                </div>
+            </div>
+        {% endif %}
+    {% endwith %}
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/chant_edit.html
+++ b/django/cantusdb_project/main_app/templates/chant_edit.html
@@ -1,499 +1,497 @@
-{% extends "base.html" %}
-{% block content %}
+{% extends "base_page_with_side_cards.html" %}
 {% load static %}
+{% block title %}
 <title>{{ source.title }} | Cantus Database</title>
+{% endblock %}
+{% block script %}
 <script src="/static/js/chant_edit.js"></script>
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-
-            <!--Display messages -->
-            {% for message in messages %}
-                <div class="alert {{ message.tags }} alert-dismissible" role="alert" >
-                    {{ message }}
-                </div>
-            {% endfor %}
-
-            <!--Display form error message -->
-            {% if form.errors %}
-                <div class="alert alert-danger alert-dismissible">
-                    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                    {% for error in form.non_field_errors %}
-                        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                        {{ error }}
-                    {% endfor %}
-                    {% for field in form %}
-                        {% if field.errors %}
-                            <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                            {{ field.label }}: {{ field.errors|striptags }}
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            {% endif %}
-
-            {% if pk_specified %}
-                {% if user.is_authenticated %}
-                    <p>
-                        <a href="{% url 'chant-detail' chant.id %}">View</a> | Edit
-                    </p>
-                {% endif %}
-                <form method="post" style="line-height: normal">{% csrf_token %}
-                    <input type="hidden" name="referrer" value="{{ request.META.HTTP_REFERER }}">
-                    
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.marginalia.label_tag }}</small>
-                            {{ form.marginalia }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
-                            {{ form.folio }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <label for="{{ form.c_sequence.id_for_label }}">
-                                <small>Sequence:<span class="text-danger" title="This field is required">*</span></small>
-                            </label>
-                            {{ form.c_sequence }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-3">
-                            <small>{{ form.feast.label_tag }}</small>
-                            <br>{{ form.feast }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-3">
-                            <label for="{{ form.office.id_for_label }}"><small>Service:</small></label>
-                            <br>{{ form.office }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-3">
-                            <small>{{ form.genre.label_tag }}</small>
-                            <br>{{ form.genre }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.position.label_tag }}</small>
-                            {{ form.position }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <label for="{{ form.cantus_id.id_for_label }}">
-                                <small>Cantus ID:</small>
-                            </label>
-                            {{ form.cantus_id }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <label for="{{ form.melody_id.id_for_label }}">
-                                <small>Melody ID:</small>
-                            </label>
-                            {{ form.melody_id }}
-                        </div>
-                        <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
-                        <!-- <div id="segment-select-field" class="form-group m-1 col-lg-4">
-                            <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
-                            {{ form.segment }}
-                        </div>
-    
-                        <div class="form-group m-1 col-lg-3">
-                            <small>{{ form.liturgical_function.label_tag }}</small>
-                            {{ form.liturgical_function }}
-                        </div>  -->
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.mode.label_tag }}</small>
-                            {{ form.mode }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.finalis.label_tag }}</small>
-                            {{ form.finalis }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.differentia.label_tag }}</small>
-                            {{ form.differentia }}
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.extra.label_tag }}</small>
-                            {{ form.extra }}
-                        </div>
-                        <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
-                        <!-- <div class="form-group m-1 col-lg-2">
-                            <small>{{ form.polyphony.label_tag }}</small>
-                            {{ form.polyphony }}
-                        </div> -->
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.diff_db.id_for_label }}">
-                                <small>Differentiae Database:</small>
-                            </label>
-                            <br>{{ form.diff_db }}
-                            <div>
-                                <small class="text-muted">
-                                    For a list of Differentia IDs, refer to
-                                    the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
-                                </small>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-8">
-                            <small>{{ form.addendum.label_tag }}</small>
-                            {{ form.addendum }}
-                        </div>
-                        {% if user_can_proofread_chant %}
-                            <div class="form-group m-1 col-lg-2">
-                                <small>{{ form.chant_range.label_tag }}</small>
-                                {{ form.chant_range }}
-                            </div>
-                        {% endif %}
-                    </div>
-
-                    <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
-                    <!-- The next three rows of fields are hidden unless the Benedicamus Domino segment is selected. -->
-                    <!-- <div id="benedicamus-domino-segment-fields" hidden>
-                        <div class="form-row">
-
-                            <div class="form-group m-1 col-lg-4">
-                                <small>{{ form.cm_melody_id.label_tag }}</small>
-                                {{ form.cm_melody_id }}
-                            </div>
-
-                            <div class="form-group m-1 col-lg">
-                                <small>{{ form.incipit_of_refrain.label_tag }}</small>
-                                {{ form.incipit_of_refrain }}
-                            </div>
-
-
-                        </div>
-
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg">
-                                <small>{{ form.later_addition.label_tag }}</small>
-                                {{ form.later_addition }}
-                            </div>
-                        </div>
-
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg">
-                                <small>{{ form.rubrics.label_tag }}</small>
-                                {{ form.rubrics }}
-                            </div>
-                        </div>
-                    </div> -->
-
-                    {% if suggested_fulltext %}
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <input type="button"
-                            value="Fill suggested text"
-                            title="Fill suggested text"
-                            onclick='autoFillSuggestedFullText("{{ suggested_fulltext }}")'>
-                        </div>
-                    </div>
-                    {% endif %}
-                                        
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                <small>Full text as in Source (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
-                            </label>
-                            {{ form.manuscript_full_text_std_spelling }}
-                        </div>
-                    </div>
-
-                    {% if user_can_proofread_chant %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                    <small>Full text as in Source (standardized spelling) proofread:</small>
-                                </label>
-                                {{ form.manuscript_full_text_std_proofread }}
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-4">
-                            <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.manuscript_full_text.id_for_label }}">
-                                <small>Full text as in Source (source spelling):</small>
-                            </label>
-                            {{ form.manuscript_full_text }}
-                        </div>
-                    </div>
-
-                    {% if user_can_proofread_chant %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
-                                    <small>Full text as in Source (source spelling) proofread:</small>
-                                </label>
-                                {{ form.manuscript_full_text_proofread }}
-                            </div>
-                        </div>
-                    {% endif %}
-        
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <label for="{{ form.volpiano.id_for_label }}">
-                                <small>Volpiano:</small>
-                            </label>
-                            {{ form.volpiano }}
-                        </div>
-                    </div>
-
-                    {% if user_can_proofread_chant %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <label for="{{ form.volpiano.id_for_label }}">
-                                    <small>Volpiano proofread:</small>
-                                </label>
-                                {{ form.volpiano_proofread }}
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    {% if chant.volpiano %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <small>Preview of melody with text:</small>
-                                {% if chant.manuscript_syllabized_full_text %}
-                                    <p><small>Syllabification is based on saved syllabized text.</small></p>
-                                {% endif %}
-                                <dd>
-                                    {% for syl_text, syl_mel in syllabized_text_with_melody %}
-                                        <span style="float: left">
-                                            <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
-                                            <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
-                                            <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
-                                        </span>
-                                    {% endfor %}
-                                </dd>
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-4">
-                            <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
-                                <small>Edit syllabification (new window)</small>
-                            </a>
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <small>{{ form.image_link.label_tag }}</small>
-                            {{ form.image_link }}
-                        </div>
-                    </div>
-                    {% if user_can_proofread_chant %}
-                        <div class="form-row">
-                            <div class="form-group m-1 col-lg-12">
-                                <small>{{ form.proofread_by.label_tag }}</small>
-                                <br>{{ form.proofread_by }}
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-12">
-                            <small>{{ form.indexing_notes.label_tag }}</small>
-                            {{ form.indexing_notes }}
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-1">
-                            <button type="submit" class="btn btn-dark btn-sm" id="btn-submit">Save</button>
-                        </div>
-                        <div class="form-group m-1 col-lg-2">
-                            <a href="{% url "chant-delete" chant.id %}" class="btn btn-danger btn-sm" id="btn-delete">Delete</a>
-                        </div>
-                    </div>
-
-                    <div class="form-row">
-                        <div class="form-group m-1 col-lg-4">
-                            <small>
-                                <a href="{% url "chant-detail" chant.id %}" target="_blank">Open chant page (new window)</a>
-                            </small>
-                        </div>
-                    </div>
-                </form> 
-            {% else %}
-                <h3>Full text &amp; Volpiano edit form</h3>
-                <br>
-                <dl>
-                    <dd><small>1) Select a <b>folio</b> or a <b>feast</b> (in the right block)</small></dd>
-                    <dd><small>2) Click <b>"EDIT"</b> next to any chant</small></dd>
-                    <dd><small>3) The <b>fulltext</b> and <b>Volpiano</b> fields should appear in this area</small></dd>
-                    <dd><small>4) Edit the fields <b>according to the manuscript, following the fulltext guidelines created by Cantus</b></small></dd>
-                    <dd><small>5) Click <b>"SAVE"</b></small></dd>
-                </dl>
-                <div style="margin-top:5px;">
-                    <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">
-                        {{ source.siglum }}
-                    </a>
-                </div>
-                <div style="margin-top:5px;">
-                    <a href="{% url "chant-create" source.pk %}">
-                        <small><b>&plus; Add new chant</b></small>
-                    </a>
-                </div>
-                <div style="margin-top:5px;">
-                    <a href="{% url "source-create" %}">
-                        <small><b>&plus; Add new source</b></small>
-                    </a>
-                </div>
-            {% endif %}
+{% endblock %}
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
+</div>
+{% endblock %}
+{% block maincontent %}
+    <!--Display messages -->
+    {% for message in messages %}
+        <div class="alert {{ message.tags }} alert-dismissible" role="alert" >
+            {{ message }}
         </div>
+    {% endfor %}
 
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
+    <!--Display form error message -->
+    {% if form.errors %}
+        <div class="alert alert-danger alert-dismissible">
+            <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+            {% for error in form.non_field_errors %}
+                <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                {{ error }}
+            {% endfor %}
+            {% for field in form %}
+                {% if field.errors %}
+                    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                    {{ field.label }}: {{ field.errors|striptags }}
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    {% if pk_specified %}
+        {% if user.is_authenticated %}
+            <p>
+                <a href="{% url 'chant-detail' chant.id %}">View</a> | Edit
+            </p>
+        {% endif %}
+        <form method="post" style="line-height: normal">{% csrf_token %}
+            <input type="hidden" name="referrer" value="{{ request.META.HTTP_REFERER }}">
+            
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.marginalia.label_tag }}</small>
+                    {{ form.marginalia }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.folio.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
+                    {{ form.folio }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <label for="{{ form.c_sequence.id_for_label }}">
+                        <small>Sequence:<span class="text-danger" title="This field is required">*</span></small>
+                    </label>
+                    {{ form.c_sequence }}
+                </div>
             </div>
 
-            <div class="card mb-3 w-100">
-                <div class="card-header">
-                    <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-3">
+                    <small>{{ form.feast.label_tag }}</small>
+                    <br>{{ form.feast }}
                 </div>
-                <div class="card-body">
-                    {% if source.chant_set.exists %}
-                        <small>
-                            <!--a small selector of all folios of this source-->
-                            <select id="folioSelect" class="w-30">
-                                <option value="">Select a folio:</option>
-                                {% for folio in folios %}
-                                    {% if folio == initial_GET_folio %}
-                                        <option value="{{ folio }}" selected>{{ folio }}</option>
-                                    {% else %}
-                                        <option value="{{ folio }}">{{ folio }}</option>
-                                    {% endif %}
-                                {% endfor %}
-                            </select>             
-                            
-                            {% if previous_folio %}
-                                <a href="{% url "source-edit-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
-                            {% endif %}
-                            {% if next_folio %}
-                                &nbsp;<a href="{% url "source-edit-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
-                            {% endif %}             
+            </div>
 
-                            <br>
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-3">
+                    <label for="{{ form.office.id_for_label }}"><small>Service:</small></label>
+                    <br>{{ form.office }}
+                </div>
+            </div>
 
-                            <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
-                                <option value="">Select a feast:</option>
-                                {% for folio, feast_id, feast_name in feasts_with_folios %}
-                                    <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
-                                {% endfor %}
-                            </select>
-                            <br>
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-3">
+                    <small>{{ form.genre.label_tag }}</small>
+                    <br>{{ form.genre }}
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.position.label_tag }}</small>
+                    {{ form.position }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <label for="{{ form.cantus_id.id_for_label }}">
+                        <small>Cantus ID:</small>
+                    </label>
+                    {{ form.cantus_id }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <label for="{{ form.melody_id.id_for_label }}">
+                        <small>Melody ID:</small>
+                    </label>
+                    {{ form.melody_id }}
+                </div>
+                <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+                <!-- <div id="segment-select-field" class="form-group m-1 col-lg-4">
+                    <small>{{ form.segment.label_tag }}<span class="text-danger" title="This field is required">*</span></small>
+                    {{ form.segment }}
+                </div>
+
+                <div class="form-group m-1 col-lg-3">
+                    <small>{{ form.liturgical_function.label_tag }}</small>
+                    {{ form.liturgical_function }}
+                </div>  -->
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.mode.label_tag }}</small>
+                    {{ form.mode }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.finalis.label_tag }}</small>
+                    {{ form.finalis }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.differentia.label_tag }}</small>
+                    {{ form.differentia }}
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.extra.label_tag }}</small>
+                    {{ form.extra }}
+                </div>
+                <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+                <!-- <div class="form-group m-1 col-lg-2">
+                    <small>{{ form.polyphony.label_tag }}</small>
+                    {{ form.polyphony }}
+                </div> -->
+            </div>
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <label for="{{ form.diff_db.id_for_label }}">
+                        <small>Differentiae Database:</small>
+                    </label>
+                    <br>{{ form.diff_db }}
+                    <div>
+                        <small class="text-muted">
+                            For a list of Differentia IDs, refer to
+                            the <a href="https://differentiaedatabase.ca/index" target="_blank">Differentiae Database</a>.
                         </small>
-                    {% else %}
-                        <small>Source contains no chants – <a href="{% url "chant-create" source.pk %}">Add new chant</a></small>
-                    {% endif %}
-                    {% comment %} render if the user has selected a specific folio {% endcomment %}
-                    {% if feasts_current_folio %}
-                        {% for feast, chants in feasts_current_folio %}
-                            <small>Folio: <b>{{ chant.folio }}</b> - Feast: <b title="{{ chant.feast.description }}">{{ feast.name }}</b></small>
-                            <table class="table table-sm small table-bordered">     
-                                {% for chant in chants %}
-                                    <tr>
-                                        <td class="h-25" style="width: 5%">
-                                            {{ chant.c_sequence }}
-                                        </td>
-                                        <td class="h-25" style="width: 20%">
-                                            <span title="{{ chant.office.description }}">
-                                                {{ chant.office.name|default_if_none:"" }}
-                                            </span>
-                                            <b title="{{ chant.genre.description }}">
-                                                {{ chant.genre.name|default_if_none:"" }}
-                                            </b>
-                                            {{ chant.position|default_if_none:"" }}
-                                        </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
-                                            <a href="{% url 'chant-detail' chant.id %}" target="_blank">
-                                                {{ chant.incipit|default_if_none:"" }}
-                                            </a>
-                                        </td>
-                                        <td class="h-25" style="width: 20%">
-                                            <a href="{{ chant.get_ci_url }}" target="_blank">
-                                                {{ chant.cantus_id|default_if_none:"" }}
-                                            </a>
-                                        </td>
-                                        <td class="h-25" style="width: 5%">
-                                            {{ chant.mode|default:"" }}
-                                        </td>
-                                        <td class="h-25" style="width: 10%">
-                                            <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&folio={{ chant.folio }}">
-                                                EDIT
-                                            </a>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </table>
-                        {% endfor %}
-                    {% comment %} render if the user has selected a specific feast {% endcomment %}
-                    {% elif folios_current_feast %}
-                        {% for folio, chants in folios_current_feast %}
-                            <small>Folio: <b>{{ folio }}</b> - Feast: <b title="{{ chant.feast.description }}">{{ chant.feast }}</b></small>
-                            <table class="table table-sm small table-bordered">     
-                                {% for chant in chants %}
-                                    <tr>
-                                        <td class="h-25" style="width: 5%">
-                                            {{ chant.c_sequence }}
-                                        </td>
-                                        <td class="h-25" style="width: 20%">
-                                            <span title="{{ chant.office.description }}">
-                                                {{ chant.office.name|default_if_none:"" }}
-                                            </span>
-                                            <b title="{{ chant.genre.description }}">
-                                                {{ chant.genre.name|default_if_none:"" }}
-                                            </b>
-                                            {{ chant.position|default_if_none:"" }}
-                                        </td>
-                                        <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
-                                            <a href="{% url 'chant-detail' chant.id %}" target="_blank">
-                                                {{ chant.incipit|default_if_none:"" }}
-                                            </a>
-                                        </td>
-                                        <td class="h-25" style="width: 20%">
-                                            <a href="{{ chant.get_ci_url }}" target="_blank">
-                                                {{ chant.cantus_id|default_if_none:"" }}
-                                            </a>
-                                        </td>
-                                        <td class="h-25" style="width: 5%">
-                                            {{ chant.mode|default:"" }}
-                                        </td>
-                                        <td class="h-25" style="width: 10%">
-                                            <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&feast={{ chant.feast.id }}">
-                                                EDIT
-                                            </a>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </table>
-                        {% endfor %}
-                    {% endif %}
-                </div>    
-            </div>    
+                    </div>
+                </div>
+            </div>
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-8">
+                    <small>{{ form.addendum.label_tag }}</small>
+                    {{ form.addendum }}
+                </div>
+                {% if user_can_proofread_chant %}
+                    <div class="form-group m-1 col-lg-2">
+                        <small>{{ form.chant_range.label_tag }}</small>
+                        {{ form.chant_range }}
+                    </div>
+                {% endif %}
+            </div>
+
+            <!-- # See issue #1521: Temporarily commenting out segment-related functions on Chant -->
+            <!-- The next three rows of fields are hidden unless the Benedicamus Domino segment is selected. -->
+            <!-- <div id="benedicamus-domino-segment-fields" hidden>
+                <div class="form-row">
+
+                    <div class="form-group m-1 col-lg-4">
+                        <small>{{ form.cm_melody_id.label_tag }}</small>
+                        {{ form.cm_melody_id }}
+                    </div>
+
+                    <div class="form-group m-1 col-lg">
+                        <small>{{ form.incipit_of_refrain.label_tag }}</small>
+                        {{ form.incipit_of_refrain }}
+                    </div>
+
+
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg">
+                        <small>{{ form.later_addition.label_tag }}</small>
+                        {{ form.later_addition }}
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg">
+                        <small>{{ form.rubrics.label_tag }}</small>
+                        {{ form.rubrics }}
+                    </div>
+                </div>
+            </div> -->
+
+            {% if suggested_fulltext %}
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <input type="button"
+                    value="Fill suggested text"
+                    title="Fill suggested text"
+                    onclick='autoFillSuggestedFullText("{{ suggested_fulltext }}")'>
+                </div>
+            </div>
+            {% endif %}
+                                
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
+                        <small>Full text as in Source (standardized spelling):<span class="text-danger" title="This field is required">*</span></small>
+                    </label>
+                    {{ form.manuscript_full_text_std_spelling }}
+                </div>
+            </div>
+
+            {% if user_can_proofread_chant %}
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-12">
+                        <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
+                            <small>Full text as in Source (standardized spelling) proofread:</small>
+                        </label>
+                        {{ form.manuscript_full_text_std_proofread }}
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-4">
+                    <button type="button" class="btn btn-dark btn-sm" id="copyFullTextBelow">Copy full text below</button>                
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <label for="{{ form.manuscript_full_text.id_for_label }}">
+                        <small>Full text as in Source (source spelling):</small>
+                    </label>
+                    {{ form.manuscript_full_text }}
+                </div>
+            </div>
+
+            {% if user_can_proofread_chant %}
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-12">
+                        <label for="{{ form.manuscript_full_text_std_spelling.id_for_label }}">
+                            <small>Full text as in Source (source spelling) proofread:</small>
+                        </label>
+                        {{ form.manuscript_full_text_proofread }}
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <label for="{{ form.volpiano.id_for_label }}">
+                        <small>Volpiano:</small>
+                    </label>
+                    {{ form.volpiano }}
+                </div>
+            </div>
+
+            {% if user_can_proofread_chant %}
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-12">
+                        <label for="{{ form.volpiano.id_for_label }}">
+                            <small>Volpiano proofread:</small>
+                        </label>
+                        {{ form.volpiano_proofread }}
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if chant.volpiano %}
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-12">
+                        <small>Preview of melody with text:</small>
+                        {% if chant.manuscript_syllabized_full_text %}
+                            <p><small>Syllabification is based on saved syllabized text.</small></p>
+                        {% endif %}
+                        <dd>
+                            {% for syl_text, syl_mel in syllabized_text_with_melody %}
+                                <span style="float: left">
+                                    <div style="font-family: volpiano; font-size: 36px">{{ syl_mel }}</div>
+                                    <!-- "mt" is margin at the top, so that the lowest note in volpiano don't overlap with text -->
+                                    <div class="mt-2" style="font-size: 12px; "><pre>{{ syl_text }}</pre></div>
+                                </span>
+                            {% endfor %}
+                        </dd>
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-4">
+                    <a href="{% url "source-edit-syllabification" chant.id %}" style="display: inline-block; margin-top:5px;" target="_blank">
+                        <small>Edit syllabification (new window)</small>
+                    </a>
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <small>{{ form.image_link.label_tag }}</small>
+                    {{ form.image_link }}
+                </div>
+            </div>
+            {% if user_can_proofread_chant %}
+                <div class="form-row">
+                    <div class="form-group m-1 col-lg-12">
+                        <small>{{ form.proofread_by.label_tag }}</small>
+                        <br>{{ form.proofread_by }}
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-12">
+                    <small>{{ form.indexing_notes.label_tag }}</small>
+                    {{ form.indexing_notes }}
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-1">
+                    <button type="submit" class="btn btn-dark btn-sm" id="btn-submit">Save</button>
+                </div>
+                <div class="form-group m-1 col-lg-2">
+                    <a href="{% url "chant-delete" chant.id %}" class="btn btn-danger btn-sm" id="btn-delete">Delete</a>
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group m-1 col-lg-4">
+                    <small>
+                        <a href="{% url "chant-detail" chant.id %}" target="_blank">Open chant page (new window)</a>
+                    </small>
+                </div>
+            </div>
+        </form> 
+    {% else %}
+        <h3>Full text &amp; Volpiano edit form</h3>
+        <br>
+        <dl>
+            <dd><small>1) Select a <b>folio</b> or a <b>feast</b> (in the right block)</small></dd>
+            <dd><small>2) Click <b>"EDIT"</b> next to any chant</small></dd>
+            <dd><small>3) The <b>fulltext</b> and <b>Volpiano</b> fields should appear in this area</small></dd>
+            <dd><small>4) Edit the fields <b>according to the manuscript, following the fulltext guidelines created by Cantus</b></small></dd>
+            <dd><small>5) Click <b>"SAVE"</b></small></dd>
+        </dl>
+        <div style="margin-top:5px;">
+            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">
+                {{ source.siglum }}
+            </a>
         </div>
-    </div>
-</div>
+        <div style="margin-top:5px;">
+            <a href="{% url "chant-create" source.pk %}">
+                <small><b>&plus; Add new chant</b></small>
+            </a>
+        </div>
+        <div style="margin-top:5px;">
+            <a href="{% url "source-create" %}">
+                <small><b>&plus; Add new source</b></small>
+            </a>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block lowersidebar %}
+    <div class="card mb-3 w-100">
+        <div class="card-header">
+            <h4><a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a></h4>
+        </div>
+        <div class="card-body">
+            {% if source.chant_set.exists %}
+                <small>
+                    <!--a small selector of all folios of this source-->
+                    <select id="folioSelect" class="w-30">
+                        <option value="">Select a folio:</option>
+                        {% for folio in folios %}
+                            {% if folio == initial_GET_folio %}
+                                <option value="{{ folio }}" selected>{{ folio }}</option>
+                            {% else %}
+                                <option value="{{ folio }}">{{ folio }}</option>
+                            {% endif %}
+                        {% endfor %}
+                    </select>             
+                    
+                    {% if previous_folio %}
+                        <a href="{% url "source-edit-chants" source.id %}?folio={{ previous_folio }}">{{ previous_folio }} <</a>
+                    {% endif %}
+                    {% if next_folio %}
+                        &nbsp;<a href="{% url "source-edit-chants" source.id %}?folio={{ next_folio }}">> {{ next_folio }}</a>
+                    {% endif %}             
+
+                    <br>
+
+                    <select id="feastSelect" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                        <option value="">Select a feast:</option>
+                        {% for folio, feast_id, feast_name in feasts_with_folios %}
+                            <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
+                        {% endfor %}
+                    </select>
+                    <br>
+                </small>
+            {% else %}
+                <small>Source contains no chants – <a href="{% url "chant-create" source.pk %}">Add new chant</a></small>
+            {% endif %}
+            {% comment %} render if the user has selected a specific folio {% endcomment %}
+            {% if feasts_current_folio %}
+                {% for feast, chants in feasts_current_folio %}
+                    <small>Folio: <b>{{ chant.folio }}</b> - Feast: <b title="{{ chant.feast.description }}">{{ feast.name }}</b></small>
+                    <table class="table table-sm small table-bordered">     
+                        {% for chant in chants %}
+                            <tr>
+                                <td class="h-25" style="width: 5%">
+                                    {{ chant.c_sequence }}
+                                </td>
+                                <td class="h-25" style="width: 20%">
+                                    <span title="{{ chant.office.description }}">
+                                        {{ chant.office.name|default_if_none:"" }}
+                                    </span>
+                                    <b title="{{ chant.genre.description }}">
+                                        {{ chant.genre.name|default_if_none:"" }}
+                                    </b>
+                                    {{ chant.position|default_if_none:"" }}
+                                </td>
+                                <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
+                                    <a href="{% url 'chant-detail' chant.id %}" target="_blank">
+                                        {{ chant.incipit|default_if_none:"" }}
+                                    </a>
+                                </td>
+                                <td class="h-25" style="width: 20%">
+                                    <a href="{{ chant.get_ci_url }}" target="_blank">
+                                        {{ chant.cantus_id|default_if_none:"" }}
+                                    </a>
+                                </td>
+                                <td class="h-25" style="width: 5%">
+                                    {{ chant.mode|default:"" }}
+                                </td>
+                                <td class="h-25" style="width: 10%">
+                                    <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&folio={{ chant.folio }}">
+                                        EDIT
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                {% endfor %}
+            {% comment %} render if the user has selected a specific feast {% endcomment %}
+            {% elif folios_current_feast %}
+                {% for folio, chants in folios_current_feast %}
+                    <small>Folio: <b>{{ folio }}</b> - Feast: <b title="{{ chant.feast.description }}">{{ chant.feast }}</b></small>
+                    <table class="table table-sm small table-bordered">     
+                        {% for chant in chants %}
+                            <tr>
+                                <td class="h-25" style="width: 5%">
+                                    {{ chant.c_sequence }}
+                                </td>
+                                <td class="h-25" style="width: 20%">
+                                    <span title="{{ chant.office.description }}">
+                                        {{ chant.office.name|default_if_none:"" }}
+                                    </span>
+                                    <b title="{{ chant.genre.description }}">
+                                        {{ chant.genre.name|default_if_none:"" }}
+                                    </b>
+                                    {{ chant.position|default_if_none:"" }}
+                                </td>
+                                <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0">
+                                    <a href="{% url 'chant-detail' chant.id %}" target="_blank">
+                                        {{ chant.incipit|default_if_none:"" }}
+                                    </a>
+                                </td>
+                                <td class="h-25" style="width: 20%">
+                                    <a href="{{ chant.get_ci_url }}" target="_blank">
+                                        {{ chant.cantus_id|default_if_none:"" }}
+                                    </a>
+                                </td>
+                                <td class="h-25" style="width: 5%">
+                                    {{ chant.mode|default:"" }}
+                                </td>
+                                <td class="h-25" style="width: 10%">
+                                    <a href="{% url 'source-edit-chants' source.id %}?pk={{ chant.pk }}&feast={{ chant.feast.id }}">
+                                        EDIT
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                {% endfor %}
+            {% endif %}
+        </div>    
+    </div>    
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/global_search_bar.html
+++ b/django/cantusdb_project/main_app/templates/global_search_bar.html
@@ -11,4 +11,4 @@
     </div>
 </form>
 <!--The chants returned by the ajax call go here-->
-<div id="chantsDiv" style="position:relative"></div>
+<div id="chantsDiv" style="position:absolute; z-index:1"></div>

--- a/django/cantusdb_project/main_app/templates/melody_search.html
+++ b/django/cantusdb_project/main_app/templates/melody_search.html
@@ -1,124 +1,125 @@
-{% extends "base.html" %}
-{% block content %}
+{% extends "base_page_with_side_cards.html" %}
+
+{% block title %}
 <title>Search by melody | Cantus Database</title>
+{% endblock %}
+
+{% block script %}
 <script src="/static/js/melody_search.js"></script>
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h3>Search by melody</h3>
-            <p>
-                This melody search provides results based on the Cantus Database chants.
-                <br>
-                For searching in chant melody catalogues 
-                go here: <a href="https://cantusindex.org/melody" target="_blank">Cantus Index Melody Search</a>.
-            </p>
+{% endblock %}
 
-            <div id="drawArea" class="text-truncate" style="font-size:0">
-                <img src="/static/melody search tool/1.jpg" alt="vopiano_clef">
-                <img id="1" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="2" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="3" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="4" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="5" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="6" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="7" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="8" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="9" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="10" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="11" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="12" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="13" src="/static/melody search tool/-.jpg" alt="dash">
-                <img id="14" src="/static/melody search tool/-.jpg" alt="dash">
-            </div>
-            <br>
-            <button id="deleteOne" type="button" class="btn btn-sm btn-outline-dark">Delete 1 note</button>
-            <button id="deleteAll" type="button" class="btn btn-sm btn-outline-dark">Delete all notes</button>
-            <span id="searchingPrompt" style="display: none; color: #922"><b>Updating search results...</b></span>
+{% block maincontent %}
+    <h3>Search by melody</h3>
+    <p>
+        This melody search provides results based on the Cantus Database chants.
+        <br>
+        For searching in chant melody catalogues 
+        go here: <a href="https://cantusindex.org/melody" target="_blank">Cantus Index Melody Search</a>.
+    </p>
 
-            <form method="get">
-                <div class="form-row">
-                    <div class="form-group m-1 col-sm">
-                        <label for="siglum"><small>Source siglum</small></label>
-                        {% if source %}
-                            <input type="text" class="form-control form-control-sm" name="siglum" value="{{ source.siglum }}" id="siglum">
-                        {% else %}
-                            <input type="text" class="form-control form-control-sm" name="siglum" value="{{ request.GET.siglum }}" id="siglum">
-                        {% endif %}
-                    </div>
-                    <div class="form-group m-1 col-sm">
-                        <label for="textSearch"><small>Text search</small></label>
-                        <input type="text" class="form-control form-control-sm" name="text" value="{{ request.GET.text }}" id="textSearch">
-                    </div>
-                    <div class="form-group m-1 col-sm">
-                        <label for="genre"><small>Genre</small></label>
-                        <input type="text" class="form-control form-control-sm" name="genre" value="{{ request.GET.genre }}" id="genre">
-                    </div>
-                    <div class="form-group m-1 col-sm">
-                        <label for="feast"><small>Feast</small></label>
-                        <input type="text" class="form-control form-control-sm" name="feast" value="{{ request.GET.feast }}" id="feast">
-                    </div>
-                    <div class="form-group m-1 col-sm">
-                        <label for="mode"><small>Mode</small></label>
-                        <input type="mode" class="form-control form-control-sm" name="mode" value="{{ request.GET.mode }}" id="mode">
-                    </div>
-                </div>
-
-                <div class="form-row">
-                    <div class="form-group m-1">
-                        <input type="radio" id="searchBegin" name="searchPosition" checked>
-                        <label for="search-begin">Search the beginning of the melody</label>
-                        <br>
-                        <input type="radio" id="searchAnywhere" name="searchPosition">
-                        <label for="search-anywhere">Search anywhere in the melody</label>
-                    </div>
-                    <div class="form-group m-1">
-                        <input type="radio" id="searchExact" name="transposition" checked>
-                        <label for="search-exact">Exact matches</label>
-                        <br>
-                        <input type="radio" id="searchTranspose" name="transposition">
-                        <label for="search-transposition">Exact matches + transpositions</label>
-                    </div>
-                </div>
-            </form>
-
-            {% if source %}
-                <b>Searching in source: <a href="{% url 'source-detail' source.id %}" target="_blank">{{ source.title }}</a></b>
-            {% endif %}
-
-            <div id="resultsDiv"></div>
-        </div>
-
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
-
-            <div class="card mb-3 w-100">
-
-                <div class="card-header">
-                    <b>Melody Search Tool</b>
-                </div>
-
-                <div class="card-body">
-                    <small>
-                        <ul>
-                            <li><b>Enter the melody shape by mouse clicks on the staff.</b></li>
-                            <li><b>Ignore the repeating notes - the system will not allow you to enter the same pitch twice.</b></li>
-                        </ul>
-                        <p>
-                            CANTUS Melody Search tool was developed by Jan Koláček and first used in the 
-                            <a href="http://globalchant.org/search.php" target="_blank">Global Chant Database</a>
-                        </p>
-                        <p>
-                            Volpiano font - Version 4.02 (© fawe, September 2011) Courtesy of David Hiley and his research team at the 
-                            Universität Regensburg. For more details, including information on the newest versions of this font, 
-                            please refer to <a href="http://www.fawe.de/volpiano/" target="_blank">http://www.fawe.de/volpiano/</a>.
-                        </p>
-                    </small>
-                </div>    
-
-            </div>
-        </div>
+    <div id="drawArea" class="text-truncate" style="font-size:0">
+        <img src="/static/melody search tool/1.jpg" alt="vopiano_clef">
+        <img id="1" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="2" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="3" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="4" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="5" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="6" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="7" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="8" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="9" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="10" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="11" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="12" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="13" src="/static/melody search tool/-.jpg" alt="dash">
+        <img id="14" src="/static/melody search tool/-.jpg" alt="dash">
     </div>
-</div>
+    <br>
+    <button id="deleteOne" type="button" class="btn btn-sm btn-outline-dark">Delete 1 note</button>
+    <button id="deleteAll" type="button" class="btn btn-sm btn-outline-dark">Delete all notes</button>
+    <span id="searchingPrompt" style="display: none; color: #922"><b>Updating search results...</b></span>
+
+    <form method="get">
+        <div class="form-row">
+            <div class="form-group m-1 col-sm">
+                <label for="siglum"><small>Source siglum</small></label>
+                {% if source %}
+                    <input type="text" class="form-control form-control-sm" name="siglum" value="{{ source.siglum }}" id="siglum">
+                {% else %}
+                    <input type="text" class="form-control form-control-sm" name="siglum" value="{{ request.GET.siglum }}" id="siglum">
+                {% endif %}
+            </div>
+            <div class="form-group m-1 col-sm">
+                <label for="textSearch"><small>Text search</small></label>
+                <input type="text" class="form-control form-control-sm" name="text" value="{{ request.GET.text }}" id="textSearch">
+            </div>
+            <div class="form-group m-1 col-sm">
+                <label for="genre"><small>Genre</small></label>
+                <input type="text" class="form-control form-control-sm" name="genre" value="{{ request.GET.genre }}" id="genre">
+            </div>
+            <div class="form-group m-1 col-sm">
+                <label for="feast"><small>Feast</small></label>
+                <input type="text" class="form-control form-control-sm" name="feast" value="{{ request.GET.feast }}" id="feast">
+            </div>
+            <div class="form-group m-1 col-sm">
+                <label for="mode"><small>Mode</small></label>
+                <input type="mode" class="form-control form-control-sm" name="mode" value="{{ request.GET.mode }}" id="mode">
+            </div>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group m-1">
+                <input type="radio" id="searchBegin" name="searchPosition" checked>
+                <label for="search-begin">Search the beginning of the melody</label>
+                <br>
+                <input type="radio" id="searchAnywhere" name="searchPosition">
+                <label for="search-anywhere">Search anywhere in the melody</label>
+            </div>
+            <div class="form-group m-1">
+                <input type="radio" id="searchExact" name="transposition" checked>
+                <label for="search-exact">Exact matches</label>
+                <br>
+                <input type="radio" id="searchTranspose" name="transposition">
+                <label for="search-transposition">Exact matches + transpositions</label>
+            </div>
+        </div>
+    </form>
+
+    {% if source %}
+        <b>Searching in source: <a href="{% url 'source-detail' source.id %}" target="_blank">{{ source.title }}</a></b>
+    {% endif %}
+
+    <div id="resultsDiv"></div>
+{% endblock %}
+
+{% block lowersidebar %}
+    <div class="search-bar mb-3">
+        {% include "global_search_bar.html" %}
+    </div>
+
+    <div class="card mb-3 w-100">
+
+        <div class="card-header">
+            <b>Melody Search Tool</b>
+        </div>
+
+        <div class="card-body">
+            <small>
+                <ul>
+                    <li><b>Enter the melody shape by mouse clicks on the staff.</b></li>
+                    <li><b>Ignore the repeating notes - the system will not allow you to enter the same pitch twice.</b></li>
+                </ul>
+                <p>
+                    CANTUS Melody Search tool was developed by Jan Koláček and first used in the 
+                    <a href="http://globalchant.org/search.php" target="_blank">Global Chant Database</a>
+                </p>
+                <p>
+                    Volpiano font - Version 4.02 (© fawe, September 2011) Courtesy of David Hiley and his research team at the 
+                    Universität Regensburg. For more details, including information on the newest versions of this font, 
+                    please refer to <a href="http://www.fawe.de/volpiano/" target="_blank">http://www.fawe.de/volpiano/</a>.
+                </p>
+            </small>
+        </div>    
+
+    </div>
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -1,344 +1,346 @@
-{% extends "base.html" %}
-{% block content %}
+{% extends "base_page_with_side_cards.html" %}
+{% block title %}
 {% load helper_tags %}
 <title>{{ source.title }} | Cantus Database</title>
+{% endblock %}
+
+{% block script %}
 <script src="/static/js/source_detail.js"></script>
+{% endblock %}
 
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <!--Display "submit success" message -->
-            {% if messages %}
-                <div class="alert alert-success alert-dismissible">
-                    {% for message in messages %}
-                        {{ message }}
-                    {% endfor %}
-                </div>
-            {% endif %}
-            <h3>{{ source.title }}</h3>
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
+</div>
+{% endblock %}
 
-            {% if user_can_edit_source %}
-                <p>
-                    View | <a href="{% url 'source-edit' source.id %}">Edit</a>
-                </p>
-            {% endif %}
+{% block maincontent %}
 
-            <dl>
-                {% if source.siglum %}
-                    <dt>Siglum</dt>
-                    <dd>{{ source.siglum }}</dd>
+<!--Display "submit success" message -->
+{% if messages %}
+    <div class="alert alert-success alert-dismissible">
+        {% for message in messages %}
+            {{ message }}
+        {% endfor %}
+    </div>
+{% endif %}
+<h3>{{ source.title }}</h3>
+
+{% if user_can_edit_source %}
+    <p>
+        View | <a href="{% url 'source-edit' source.id %}">Edit</a>
+    </p>
+{% endif %}
+
+<dl>
+    {% if source.siglum %}
+        <dt>Siglum</dt>
+        <dd>{{ source.siglum }}</dd>
+    {% endif %}
+
+    {% if source.summary %}
+        <dt>Summary</dt>
+        <dd>{{ source.summary }}</dd>
+    {% endif %}
+
+    {% if source.liturgical_occasions %}
+        <dt>Liturgical Occasions</dt>
+        <dd>{{ source.liturgical_occasions|linebreaks }}</dd>
+    {% endif %}
+
+    {% if source.description %}
+        <dt>Description</dt>
+        <dd>{{ source.description|safe|linebreaks }}</dd>
+    {% endif %}
+
+    {% if source.selected_bibliography %}
+        <dt>Selected Bibliography</dt>
+        <dd>{{ source.selected_bibliography|safe|linebreaks }}</dd>
+    {% endif %}
+
+    {% if source.indexing_notes %}
+        <dt>Notes on the Inventory</dt>
+        <dd>{{ source.indexing_notes|safe }}</dd>
+    {% endif %}
+
+    {% if source.other_editors.exists %}
+        <dt>Other Editors</dt>
+        <dd>
+            {% for editor in source.other_editors.all %}
+                {% if editor.full_name %}
+                    <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
+                {% else %}
+                    <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
                 {% endif %}
+            {% endfor %}
+        </dd>
+    {% endif %}
 
-                {% if source.summary %}
-                    <dt>Summary</dt>
-                    <dd>{{ source.summary }}</dd>
+    {% if source.full_text_entered_by.exists %}
+        <dt>Full Texts Entered by</dt>
+        <dd>
+            {% for editor in source.full_text_entered_by.all %}
+                {% if editor.full_name %}
+                    <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
+                {% else %}
+                    <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
                 {% endif %}
+            {% endfor %}
+        </dd>
+    {% endif %}
 
-                {% if source.liturgical_occasions %}
-                    <dt>Liturgical Occasions</dt>
-                    <dd>{{ source.liturgical_occasions|linebreaks }}</dd>
+    {% if source.melodies_entered_by.exists %}
+        <dt>Melodies Entered by</dt>
+        <dd>
+            {% for editor in source.melodies_entered_by.all %}
+                {% if editor.full_name %}
+                    <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
+                {% else %}
+                    <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
                 {% endif %}
+            {% endfor %}
+        </dd>
+    {% endif %}
 
-                {% if source.description %}
-                    <dt>Description</dt>
-                    <dd>{{ source.description|safe|linebreaks }}</dd>
-                {% endif %}
+    {% if source.complete_inventory is not None %}
+        <dt>Complete/Partial Inventory</dt>
+        <dd>{{ source.complete_inventory|yesno:"Complete Inventory,Partial Inventory" }}</dd>
+    {% endif %}
 
-                {% if source.selected_bibliography %}
-                    <dt>Selected Bibliography</dt>
-                    <dd>{{ source.selected_bibliography|safe|linebreaks }}</dd>
-                {% endif %}
+    {% if source.full_source is not None %}
+        <dt>Full Source/Fragment</dt>
+        <dd>{{ source.full_source|yesno:"Full Source,Fragment or Fragmented" }}</dd>
+    {% endif %}
 
-                {% if source.indexing_notes %}
-                    <dt>Notes on the Inventory</dt>
-                    <dd>{{ source.indexing_notes|safe }}</dd>
-                {% endif %}
+    {% if user.is_authenticated %}
+        <dt>Source Status</dt>
+        <dd>{{ source.published|yesno:"Published,Unpublished" }}</dd>
+    {% endif %}
+    
+    {% if source.fragmentarium_id is not None %}
+        <dt>Fragment ID</dt>
+        <dd>{{ source.fragmentarium_id }}</dd>
+    {% endif %}
 
-                {% if source.other_editors.exists %}
-                    <dt>Other Editors</dt>
-                    <dd>
-                        {% for editor in source.other_editors.all %}
-                            {% if editor.full_name %}
-                                <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
-                            {% else %}
-                                <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
-                            {% endif %}
-                        {% endfor %}
-                    </dd>
-                {% endif %}
+    {% if source.dact_id is not None %}
+        <dt>DACT ID</dt>
+        <dd>{{ source.dact_id }}</dd>
+    {% endif %}
+</dl>
 
-                {% if source.full_text_entered_by.exists %}
-                    <dt>Full Texts Entered by</dt>
-                    <dd>
-                        {% for editor in source.full_text_entered_by.all %}
-                            {% if editor.full_name %}
-                                <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
-                            {% else %}
-                                <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
-                            {% endif %}
-                        {% endfor %}
-                    </dd>
-                {% endif %}
+{% if sequences %}
+    <h4>Sequences in this source</h4>
+    <small>Displaying 1 - {{ sequences.count }} of {{ sequences.count }}</small>
+    <small>
+        <table class="table table-sm small table-bordered table-responsive">
+            <thead>
+                <tr>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">Siglum</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Text Incipit">Text&nbsp;Incipit</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Rubrics">Rubrics</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Analecta Hymnica">AH</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">Cantus&nbsp;ID</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Notes 1">Notes&nbsp;1</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Notes 2">Notes&nbsp;2</th>
+                    <th scope="col" class="text-wrap" style="text-align:center" title="Notes 3">Notes&nbsp;3</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for sequence in sequences %}
+                    <tr>
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a>
+                            <br>
+                            <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{% url 'sequence-detail' sequence.id %}" >{{ sequence.incipit|default:"" }}</a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.rubrics|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.analecta_hymnica|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
+                            <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.col1|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.col2|default:"" }}
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            {{ sequence.col3|default:"" }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </small>
+{% endif %}
+{% endblock %}
 
-                {% if source.melodies_entered_by.exists %}
-                    <dt>Melodies Entered by</dt>
-                    <dd>
-                        {% for editor in source.melodies_entered_by.all %}
-                            {% if editor.full_name %}
-                                <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
-                            {% else %}
-                                <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
-                            {% endif %}
-                        {% endfor %}
-                    </dd>
-                {% endif %}
-
-                {% if source.complete_inventory is not None %}
-                    <dt>Complete/Partial Inventory</dt>
-                    <dd>{{ source.complete_inventory|yesno:"Complete Inventory,Partial Inventory" }}</dd>
-                {% endif %}
-
-                {% if source.full_source is not None %}
-                    <dt>Full Source/Fragment</dt>
-                    <dd>{{ source.full_source|yesno:"Full Source,Fragment or Fragmented" }}</dd>
-                {% endif %}
-
-                {% if user.is_authenticated %}
-                    <dt>Source Status</dt>
-                    <dd>{{ source.published|yesno:"Published,Unpublished" }}</dd>
-                {% endif %}
-                
-                {% if source.fragmentarium_id is not None %}
-                    <dt>Fragment ID</dt>
-                    <dd>{{ source.fragmentarium_id }}</dd>
-                {% endif %}
-
-                {% if source.dact_id is not None %}
-                    <dt>DACT ID</dt>
-                    <dd>{{ source.dact_id }}</dd>
-                {% endif %}
-            </dl>
-
-            {% if sequences %}
-                <h4>Sequences in this source</h4>
-                <small>Displaying 1 - {{ sequences.count }} of {{ sequences.count }}</small>
-                <small>
-                    <table class="table table-sm small table-bordered table-responsive">
-                        <thead>
-                            <tr>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Siglum">Siglum</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Text Incipit">Text&nbsp;Incipit</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Rubrics">Rubrics</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Analecta Hymnica">AH</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Cantus ID">Cantus&nbsp;ID</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Notes 1">Notes&nbsp;1</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Notes 2">Notes&nbsp;2</th>
-                                <th scope="col" class="text-wrap" style="text-align:center" title="Notes 3">Notes&nbsp;3</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for sequence in sequences %}
-                                <tr>
-                                    <td class="text-wrap" style="text-align:center">
-                                        <a href="{% url 'source-detail' source.id %}" title="{{ source.title }}">{{ source.siglum }}</a>
-                                        <br>
-                                        <b>{{ sequence.folio }}</b>  {{ sequence.s_sequence }}
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        <a href="{% url 'sequence-detail' sequence.id %}" >{{ sequence.incipit|default:"" }}</a>
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        {{ sequence.rubrics|default:"" }}
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        {{ sequence.analecta_hymnica|default:"" }}
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        {% comment %} use `urlencode` filter because 1 chant and 2 sequences have forward slash in their cantus_id (data error) {% endcomment %}
-                                        <a href={% url 'chant-by-cantus-id' sequence.cantus_id|urlencode:"" %}>{{ sequence.cantus_id|default:"" }}</a>
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        {{ sequence.col1|default:"" }}
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        {{ sequence.col2|default:"" }}
-                                    </td>
-                                    <td class="text-wrap" style="text-align:center">
-                                        {{ sequence.col3|default:"" }}
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </small>
-            {% endif %}
+{% block lowersidebar %}
+    <div class="card mb-3 w-100">
+        <div class="card-header">
+            <h4>{{ source.siglum }}</h4>
         </div>
+        <div class="card-body">
+            <small>
+                {% if source.segment.id == 4063 %}
+                    {# all of the following are different ways to link to the Chant List page #}
+                    {# Since sources in the Bower segment contain no chants, the Chant List page #}
+                    {# is currently set up to raise a 404 if you try to access it for a source in #}
+                    {# the Bower segment. So, we need to display this section only for sources in #}
+                    {# the CANTUS segment #}
+                    <!--a small selector of all folios of this source-->
+                    <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
+                        <option value="">Select a folio:</option>
+                        {% for folio in folios %}
+                            <option value="{{ folio }}">{{ folio }}</option>
+                        {% endfor %}
+                    </select>                              
 
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
+                    <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                        <option value="">Select a feast:</option>
+                        {% for folio, feast_id, feast_name in feasts_with_folios %}
+                            <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
+                        {% endfor %}
+                    </select>
 
-            <div class="card mb-3 w-100">
-                <div class="card-header">
-                    <h4>{{ source.siglum }}</h4>
-                </div>
-                <div class="card-body">
-                    <small>
-                        {% if source.segment.id == 4063 %}
-                            {# all of the following are different ways to link to the Chant List page #}
-                            {# Since sources in the Bower segment contain no chants, the Chant List page #}
-                            {# is currently set up to raise a 404 if you try to access it for a source in #}
-                            {# the Bower segment. So, we need to display this section only for sources in #}
-                            {# the CANTUS segment #}
-                            <!--a small selector of all folios of this source-->
-                            <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
-                                <option value="">Select a folio:</option>
-                                {% for folio in folios %}
-                                    <option value="{{ folio }}">{{ folio }}</option>
-                                {% endfor %}
-                            </select>                              
-
-                            <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
-                                <option value="">Select a feast:</option>
-                                {% for folio, feast_id, feast_name in feasts_with_folios %}
-                                    <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
-                                {% endfor %}
-                            </select>
-
-                            <br>
-                            <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
-                        {% endif %}
-                        <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
-                        {% if source.exists_on_cantus_ultimus %}
-                            <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}" class="guillemet" target="_blank">View inventory with images</a>
-                        {% endif %}
-                        {% if source.image_link %}
-                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
-                        {% endif %}                          
-                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
-                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
-                    </small>
-                </div>    
-            </div>
-
-            <div class="card mb-3 w-100">
-                <div class="card-header">
-                    <small>
-                        <a href="{% url "source-list" %}?segment={{ source.segment.id }}">{{ source.segment.name }}</a>
-                    </small>
                     <br>
-                    <b>{{ source.siglum }}</b>
-                </div>
-                <div class=" card-body">
-                    <small>
-                        {% if source.provenance.name %}
-                            Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
-                            <br>
-                        {% endif %}
-                        {% if source.date %}
-                            Date: 
-                            {% for century in source.century.all %}
-                                <b><a href="{% url 'century-detail' century.id %}">
-                                    {{ century.name }}
-                                </a></b>
-                            {% endfor %}
-                            |
-                            <b>{{ source.date|default_if_none:"" }}</b>
-                            <br>
-                        {% endif %}
-                        {% if source.cursus %}
-                            Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
-                            <br>
-                        {% endif %}
-                        {% if source.notation.exists %}
-                            Notation: <b><a href="{% url 'notation-detail' source.notation.all.first.id %}">
-                                {{ source.notation.all.first.name }}
-                            </a></b>
-                            <br>
-                        {% endif %}
-                        {% if source.inventoried_by.exists %}
-                            Inventoried by:
-                            <ul>
-                                {% for editor in source.inventoried_by.all %}
-                                    <li>
-                                        {% if editor.full_name %}
-                                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
-                                        {% else %}
-                                            <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
-                                        {% endif %}
-                                        {{ editor.institution|default_if_none:"" }}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
-                        {% if source.proofreaders.exists %}
-                            Proofreader{{ source.proofreaders.all|pluralize }}:
-                            <br>
-                            <ul>
-                                {% for editor in source.proofreaders.all %}
-                                    <li>
-                                        {% if editor.full_name %}
-                                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
-                                        {% else %}
-                                            <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
-                                        {% endif %}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
-                        {{ source.indexing_notes|default_if_none:""|safe }}
-                        <br>
-                        {% with creator=source.created_by %}
-                            {% if creator %}
-                                {% if creator.full_name %}
-                                    Contributor: <a href={% url 'user-detail' creator.id %}><b>{{ creator.full_name }}</b></a>
+                    <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
+                {% endif %}
+                <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
+                {% if source.exists_on_cantus_ultimus %}
+                    <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}" class="guillemet" target="_blank">View inventory with images</a>
+                {% endif %}
+                {% if source.image_link %}
+                    <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
+                {% endif %}                          
+                <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
+                <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
+                <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
+                <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
+            </small>
+        </div>    
+    </div>
+
+    <div class="card mb-3 w-100">
+        <div class="card-header">
+            <small>
+                <a href="{% url "source-list" %}?segment={{ source.segment.id }}">{{ source.segment.name }}</a>
+            </small>
+            <br>
+            <b>{{ source.siglum }}</b>
+        </div>
+        <div class=" card-body">
+            <small>
+                {% if source.provenance.name %}
+                    Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
+                    <br>
+                {% endif %}
+                {% if source.date %}
+                    Date: 
+                    {% for century in source.century.all %}
+                        <b><a href="{% url 'century-detail' century.id %}">
+                            {{ century.name }}
+                        </a></b>
+                    {% endfor %}
+                    |
+                    <b>{{ source.date|default_if_none:"" }}</b>
+                    <br>
+                {% endif %}
+                {% if source.cursus %}
+                    Cursus: <b>{{ source.cursus|default_if_none:"" }}</b>
+                    <br>
+                {% endif %}
+                {% if source.notation.exists %}
+                    Notation: <b><a href="{% url 'notation-detail' source.notation.all.first.id %}">
+                        {{ source.notation.all.first.name }}
+                    </a></b>
+                    <br>
+                {% endif %}
+                {% if source.inventoried_by.exists %}
+                    Inventoried by:
+                    <ul>
+                        {% for editor in source.inventoried_by.all %}
+                            <li>
+                                {% if editor.full_name %}
+                                    <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
                                 {% else %}
-                                    Contributor: <a href={% url 'user-detail' creator.id %}><b>User {{ creator.id }}</b></a>
+                                    <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
                                 {% endif %}
-                            {% endif %}
-                        {% endwith %}
-                    </small>
-                </div>
-            </div>
-            {% if user_can_edit_chants %}
-                <div class="card w-100">
-                    <div class="card-header">
-                        Source edit options
-                        <br>
-                        <b>{{ source.siglum }}</b>
-                    </div>
-                    <div class=" card-body">
-                        <small>
-                            <ul>
-                                <li>
-                                    <a href="{% url "chant-create" source.id%}">Add new chant</a>
-                                </li>
-                                {% if source.chant_set.exists %}
-                                    <li>
-                                        <a href="{% url "source-edit-chants" source.pk %}">
-                                            Full text &amp; volpiano editor
-                                        </a>
-                                    </li>
+                                {{ editor.institution|default_if_none:"" }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if source.proofreaders.exists %}
+                    Proofreader{{ source.proofreaders.all|pluralize }}:
+                    <br>
+                    <ul>
+                        {% for editor in source.proofreaders.all %}
+                            <li>
+                                {% if editor.full_name %}
+                                    <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a><br>
+                                {% else %}
+                                    <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a><br>
                                 {% endif %}
-                                {% if user_can_edit_source %}
-                                    <li>
-                                        <a href="{% url "source-edit" source.id%}">Edit source description</a>
-                                    </li>
-                                {% endif %}
-                                {% if user_can_manage_source_editors %}
-                                    <li>
-                                        <a href={% url 'admin:main_app_source_change' source.id %}>Manage source editors</a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </small>
-                    </div>
-                </div>
-            {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {{ source.indexing_notes|default_if_none:""|safe }}
+                <br>
+                {% with creator=source.created_by %}
+                    {% if creator %}
+                        {% if creator.full_name %}
+                            Contributor: <a href={% url 'user-detail' creator.id %}><b>{{ creator.full_name }}</b></a>
+                        {% else %}
+                            Contributor: <a href={% url 'user-detail' creator.id %}><b>User {{ creator.id }}</b></a>
+                        {% endif %}
+                    {% endif %}
+                {% endwith %}
+            </small>
         </div>
     </div>
-</div>
+    {% if user_can_edit_chants %}
+        <div class="card w-100">
+            <div class="card-header">
+                Source edit options
+                <br>
+                <b>{{ source.siglum }}</b>
+            </div>
+            <div class=" card-body">
+                <small>
+                    <ul>
+                        <li>
+                            <a href="{% url "chant-create" source.id%}">Add new chant</a>
+                        </li>
+                        {% if source.chant_set.exists %}
+                            <li>
+                                <a href="{% url "source-edit-chants" source.pk %}">
+                                    Full text &amp; volpiano editor
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if user_can_edit_source %}
+                            <li>
+                                <a href="{% url "source-edit" source.id%}">Edit source description</a>
+                            </li>
+                        {% endif %}
+                        {% if user_can_manage_source_editors %}
+                            <li>
+                                <a href={% url 'admin:main_app_source_change' source.id %}>Manage source editors</a>
+                            </li>
+                        {% endif %}
+                    </ul>
+                </small>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -1,302 +1,305 @@
-{% extends "base.html" %}
+{% extends "base_page_with_side_cards.html" %}
 {% load static %}
-{% block content %}
+
+{% block title %}
 <title>{{ source.title }} | Cantus Database</title>
+{% endblock %}
+
+{% block script %}
 <script src="/static/js/source_detail.js"></script>
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ form.media }}
+{% endblock %}
 
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <!--Display form error message -->
-            {% if form.errors %}
-                <div class="alert alert-danger alert-dismissible">
-                    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                    {% for error in form.non_field_errors %}
-                        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                        {{ error }}
-                    {% endfor %}
-                    {% for field in form %}
-                        {% if field.errors %}
-                            <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-                            {{ field.label }}: {{ field.errors|striptags }}
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            {% endif %}
 
-            <h3><em>Edit Source</em> {{ source.title }}</h3>
-
-            <p>
-                <a href="{% url 'source-detail' source.id %}">View</a> | Edit
-            </p>
-
-            <form method="post" style="line-height: normal">{% csrf_token %}
-                <div class="form-row mb-3">
-
-                    <div class="form-group m-1 col-lg-9">
-                        <label for="{{ form.title.id_for_label }}">
-                            Full Source Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span>
-                        </label>
-                        {{ form.title }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-9">
-                        <label for="{{ form.siglum.id_for_label }}">
-                            Siglum:<span class="text-danger" title="This field is required">*</span>
-                        </label>
-                        {{ form.siglum }}
-                        <small>RISM-style siglum + Shelf-mark (e.g. GB-Ob 202).</small>
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-7">
-                        <label for="{{ form.provenance.id_for_label }}">
-                            Provenance (origin / history):
-                        </label>
-                        {{ form.provenance }}
-                        <small><br>If the origin is unknown, select a location where the source was used later in its lifetime and provide details in the "Provenance notes" field.</small>
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-7">
-                        {{ form.provenance_notes.label_tag }}
-                        {{ form.provenance_notes }}
-                        <small>More exact indication of the provenance (if necessary)</small>
-                    </div>
-                    <div class="form-group m-1 col-lg-4 ">
-                        <label for="{{ form.full_source.id_for_label }}">
-                            Full source / fragment:
-                        </label>
-                        {{ form.full_source }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.century.label_tag }}
-                        {{ form.century }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-7">
-                        {{ form.date.label_tag }}
-                        {{ form.date }}
-                        <small>Date of the source (e.g. "1200s", "1300-1350", etc.)</small>
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.cursus.label_tag }}
-                        {{ form.cursus }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.current_editors.label_tag }}
-                        {{ form.current_editors }}
-                    </div>
-                </div> 
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.melodies_entered_by.label_tag }}
-                        {{ form.melodies_entered_by }}
-                    </div>
-                </div>
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.inventoried_by.label_tag }}
-                        {{ form.inventoried_by }}
-                    </div>
-                </div>
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.full_text_entered_by.label_tag }}
-                        {{ form.full_text_entered_by }}
-                    </div>
-                </div>
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.proofreaders.label_tag }}
-                        {{ form.proofreaders }}
-                    </div>
-                </div>
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        {{ form.other_editors.label_tag }}
-                        {{ form.other_editors }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-5">
-                        <label for="{{ form.complete_inventory.id_for_label }}">
-                            Complete / partial inventory:
-                        </label>
-                        {{ form.complete_inventory }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
-                        {{ form.summary.label_tag }}
-                        {{ form.summary }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
-                        {{ form.liturgical_occasions.label_tag }}
-                        {{ form.liturgical_occasions }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
-                        {{ form.description.label_tag }}
-                        {{ form.description }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
-                        {{ form.selected_bibliography.label_tag }}
-                        {{ form.selected_bibliography }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
-                        {{ form.image_link.label_tag }}
-                        {{ form.image_link }}
-                        <small>HTTP link to the image gallery of the source.</small>
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-3">
-                        <label for="{{ form.fragmentarium_id.id_for_label }}">
-                            Fragmentarium ID:
-                        </label>
-                        {{ form.fragmentarium_id }}
-                    </div>
-                    <div class="form-group m-1 col-lg-3">
-                        <label for="{{ form.dact_id.id_for_label }}">
-                            DACT ID:
-                        </label>
-                        {{ form.dact_id }}
-                    </div>
-                </div>
-
-                <div class="form-row mb-3">
-                    <div class="form-group m-1 col-lg-12">
-                        <label for="{{ form.indexing_notes.id_for_label }}">
-                            Notes on the Inventory:
-                        </label>
-                        {{ form.indexing_notes }}
-                    </div>
-                </div>
-
-                <div class="form-row">
-                    <div class="form-group m-1 col-lg-1">
-                        <button type="submit" class="btn btn-dark btn-sm" id="btn-submit">Save</button>
-                    </div>
-                    <div class="form-group m-1 col-lg-2">
-                        <a href="{% url "source-delete" source.id %}" class="btn btn-danger btn-sm" id="btn-delete">Delete</a>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
-
-            <div class="card mb-3 w-100">
-                <div class="card-header">
-                    <h4>{{ source.siglum }}</h4>
-                </div>
-                <div class="card-body">
-                    <small>
-                        <!--a small selector of all folios of this source-->
-                        <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
-                            <option value="">Select a folio:</option>
-                            {% for folio in folios %}
-                                <option value="{{ folio }}">{{ folio }}</option>
-                            {% endfor %}
-                        </select>                              
-
-                        <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
-                            <option value="">Select a feast:</option>
-                            {% for folio, feast_id, feast_name in feasts_with_folios %}
-                                <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
-                            {% endfor %}
-                        </select>          
-
-                        <br>
-                        {% if source.segment.id == 4063 %}
-                            {# only display this link for sources in the CANTUS segment #}
-                            <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
-                        {% endif %}
-                        <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
-                        {% if source.exists_on_cantus_ultimus %}
-                            <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}" class="guillemet" target="_blank">View inventory with images</a>
-                        {% endif %}
-                        {% if source.image_link %}
-                            <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
-                        {% endif %}                         
-                        <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
-                        <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
-                        <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
-                        <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
-
-                    </small>
-                    {% if chants.exists %}
-                        <table class="table table-sm small table-bordered">
-                            <tbody>
-                                {% for chant in chants %}
-                                    <tr>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <small>{{ chant.c_sequence }}</small>
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <small>
-                                                {{ chant.office.name|default:"" }}
-                                                <br>
-                                                {{ chant.genre.name|default:"" }}
-                                                <br>
-                                                {{ chant.position|default:"" }}
-                                            </small>
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <small>{{ chant.incipit|default:"" }}</small>
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <small><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default:"" }}</a></small>
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <small>{{ chant.mode|default:"" }}</small>
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <button type="button" class="btn btn-dark btn-sm" id="editButton" name="{{ chant.pk }}">EDIT</button>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    {% endif %}        
-                </div>    
-            </div>    
-        </div>
-    </div>
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
 </div>
+{% endblock %}
+
+{% block maincontent %}
+    <!--Display form error message -->
+    {% if form.errors %}
+        <div class="alert alert-danger alert-dismissible">
+            <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+            {% for error in form.non_field_errors %}
+                <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                {{ error }}
+            {% endfor %}
+            {% for field in form %}
+                {% if field.errors %}
+                    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+                    {{ field.label }}: {{ field.errors|striptags }}
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    <h3><em>Edit Source</em> {{ source.title }}</h3>
+
+    <p>
+        <a href="{% url 'source-detail' source.id %}">View</a> | Edit
+    </p>
+
+    <form method="post" style="line-height: normal">{% csrf_token %}
+        <div class="form-row mb-3">
+
+            <div class="form-group m-1 col-lg-9">
+                <label for="{{ form.title.id_for_label }}">
+                    Full Source Identification (City, Archive, Shelf-mark):<span class="text-danger" title="This field is required">*</span>
+                </label>
+                {{ form.title }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-9">
+                <label for="{{ form.siglum.id_for_label }}">
+                    Siglum:<span class="text-danger" title="This field is required">*</span>
+                </label>
+                {{ form.siglum }}
+                <small>RISM-style siglum + Shelf-mark (e.g. GB-Ob 202).</small>
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-7">
+                <label for="{{ form.provenance.id_for_label }}">
+                    Provenance (origin / history):
+                </label>
+                {{ form.provenance }}
+                <small><br>If the origin is unknown, select a location where the source was used later in its lifetime and provide details in the "Provenance notes" field.</small>
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-7">
+                {{ form.provenance_notes.label_tag }}
+                {{ form.provenance_notes }}
+                <small>More exact indication of the provenance (if necessary)</small>
+            </div>
+            <div class="form-group m-1 col-lg-4 ">
+                <label for="{{ form.full_source.id_for_label }}">
+                    Full source / fragment:
+                </label>
+                {{ form.full_source }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.century.label_tag }}
+                {{ form.century }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-7">
+                {{ form.date.label_tag }}
+                {{ form.date }}
+                <small>Date of the source (e.g. "1200s", "1300-1350", etc.)</small>
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.cursus.label_tag }}
+                {{ form.cursus }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.current_editors.label_tag }}
+                {{ form.current_editors }}
+            </div>
+        </div> 
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.melodies_entered_by.label_tag }}
+                {{ form.melodies_entered_by }}
+            </div>
+        </div>
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.inventoried_by.label_tag }}
+                {{ form.inventoried_by }}
+            </div>
+        </div>
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.full_text_entered_by.label_tag }}
+                {{ form.full_text_entered_by }}
+            </div>
+        </div>
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.proofreaders.label_tag }}
+                {{ form.proofreaders }}
+            </div>
+        </div>
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                {{ form.other_editors.label_tag }}
+                {{ form.other_editors }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-5">
+                <label for="{{ form.complete_inventory.id_for_label }}">
+                    Complete / partial inventory:
+                </label>
+                {{ form.complete_inventory }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-12">
+                {{ form.summary.label_tag }}
+                {{ form.summary }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-12">
+                {{ form.liturgical_occasions.label_tag }}
+                {{ form.liturgical_occasions }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-12">
+                {{ form.description.label_tag }}
+                {{ form.description }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-12">
+                {{ form.selected_bibliography.label_tag }}
+                {{ form.selected_bibliography }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-12">
+                {{ form.image_link.label_tag }}
+                {{ form.image_link }}
+                <small>HTTP link to the image gallery of the source.</small>
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-3">
+                <label for="{{ form.fragmentarium_id.id_for_label }}">
+                    Fragmentarium ID:
+                </label>
+                {{ form.fragmentarium_id }}
+            </div>
+            <div class="form-group m-1 col-lg-3">
+                <label for="{{ form.dact_id.id_for_label }}">
+                    DACT ID:
+                </label>
+                {{ form.dact_id }}
+            </div>
+        </div>
+
+        <div class="form-row mb-3">
+            <div class="form-group m-1 col-lg-12">
+                <label for="{{ form.indexing_notes.id_for_label }}">
+                    Notes on the Inventory:
+                </label>
+                {{ form.indexing_notes }}
+            </div>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group m-1 col-lg-1">
+                <button type="submit" class="btn btn-dark btn-sm" id="btn-submit">Save</button>
+            </div>
+            <div class="form-group m-1 col-lg-2">
+                <a href="{% url "source-delete" source.id %}" class="btn btn-danger btn-sm" id="btn-delete">Delete</a>
+            </div>
+        </div>
+    </form>
+{% endblock %}
+
+{% block lowersidebar %}
+    <div class="card mb-3 w-100">
+        <div class="card-header">
+            <h4>{{ source.siglum }}</h4>
+        </div>
+        <div class="card-body">
+            <small>
+                <!--a small selector of all folios of this source-->
+                <select id="folioSelect" class="w-30" onchange="jumpToFolio({{ source.id }})">
+                    <option value="">Select a folio:</option>
+                    {% for folio in folios %}
+                        <option value="{{ folio }}">{{ folio }}</option>
+                    {% endfor %}
+                </select>                              
+
+                <select id="feastSelect" onchange="jumpToFeast({{ source.id }})" style="width: 200px;"> <!-- style attribute prevents select element from extending beyond left edge of div element -->
+                    <option value="">Select a feast:</option>
+                    {% for folio, feast_id, feast_name in feasts_with_folios %}
+                        <option value="{{ feast_id }}">{{ folio }} - {{ feast_name }}</option>
+                    {% endfor %}
+                </select>          
+
+                <br>
+                {% if source.segment.id == 4063 %}
+                    {# only display this link for sources in the CANTUS segment #}
+                    <a href="{% url "browse-chants" source.id %}" class="guillemet" target="_blank">View all chants</a>
+                {% endif %}
+                <a href="{% url "source-inventory" source.id %}" class="guillemet" target="_blank">View full inventory</a>
+                {% if source.exists_on_cantus_ultimus %}
+                    <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}" class="guillemet" target="_blank">View inventory with images</a>
+                {% endif %}
+                {% if source.image_link %}
+                    <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
+                {% endif %}                         
+                <a href="{% url "csv-export" source.id%}" class="guillemet" target="_blank" download="{{ source.id }}.csv">CSV export</a>
+                <a href="{% url "chant-search-ms" source.id %}" class="guillemet" target="_blank">Search chants in this source</a>
+                <a href="{% url "melody-search" %}?source={{ source.id }}"  class="guillemet" target="_blank">Search melodies in this source</a>
+                <a href="//cantusindex.org/analyse?src={{ source.id }}&db=CD" class="guillemet" target="_blank">Analyse this source (Cantus Analysis Tool)</a>
+
+            </small>
+            {% if chants.exists %}
+                <table class="table table-sm small table-bordered">
+                    <tbody>
+                        {% for chant in chants %}
+                            <tr>
+                                <td class="text-wrap" style="text-align:center">
+                                    <small>{{ chant.c_sequence }}</small>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <small>
+                                        {{ chant.office.name|default:"" }}
+                                        <br>
+                                        {{ chant.genre.name|default:"" }}
+                                        <br>
+                                        {{ chant.position|default:"" }}
+                                    </small>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <small>{{ chant.incipit|default:"" }}</small>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <small><a href="{{ chant.get_ci_url }}" target="_blank">{{ chant.cantus_id|default:"" }}</a></small>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <small>{{ chant.mode|default:"" }}</small>
+                                </td>
+                                <td class="text-wrap" style="text-align:center">
+                                    <button type="button" class="btn btn-dark btn-sm" id="editButton" name="{{ chant.pk }}">EDIT</button>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}        
+        </div>    
+    </div>    
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/user_source_list.html
+++ b/django/cantusdb_project/main_app/templates/user_source_list.html
@@ -1,95 +1,97 @@
-{% extends "base.html" %}
+{% extends "base_page_with_side_cards.html" %}
 {% load helper_tags %} {# for url_add_get_params #}
-{% block content %}
-<title>My Sources | Cantus Database</title>
-<div class="container">
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h3>My Sources</h3>
-            <a href="{% url "source-create" %}"><b>+ Add new source</b></a>
-            <table class="table table-sm small table-bordered">
-                <tbody>
-                    {% for source in page_obj %}
-                        <tr>
-                            <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0; text-align:center">
-                                <a href="{% url "source-detail" source.pk %}">
-                                    <b>{{ source.siglum }}</b>
-                                </a>
-                            </td>
-                            {% if source.chant_set.exists %}
-                                <td class="h-25" style="width: 30%; text-align:center">
-                                    <a href="{% url "source-edit-chants" source.pk %}">
-                                        Full text &amp; volpiano editor
-                                    </a>
-                                </td>
-                            {% else %}
-                            <td class="h-25" style="width: 30%; text-align:center" colspan="2">
-                                Source contains no chants –
-                                <a href="{% url "chant-create" source.pk %}">Add new chant</a> 
-                            </td> 
-                            {% endif %}
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% include "pagination.html" %}
-        </div>
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
-            <div class="card mb-3 w-100">
-                <div class="card-header">
-                    <h4>Sources created by user</h4>
-                </div>
-                <div class="card-body">
-                    <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
-                    <ul>
-                        {% for my_source in user_created_sources_page_obj %}
-                            <li>
-                                <a href="{% url "source-detail" my_source.pk %}">
-                                    <b> {{ my_source.siglum }}</b>
-                                </a>
-                                <br>
-                                <small>
-                                    <a href="{% url "source-detail" my_source.pk %}">
-                                        <b> {{ my_source.title }}</b>
-                                    </a>
-                                    <br>
-                                    <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
-                                        &plus; Add new chant
-                                    </a>
-                                    <br>
-                                    {% if my_source.chant_set.exists %}
-                                        <a href="{% url "source-edit-chants" my_source.pk %}">
-                                            &bull; Full text &amp; volpiano editor
-                                        </a>
-                                    {% endif %}
-                                </small>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                    <div class="pagination">
-                        <span class="step-links">
-                            {% if user_created_sources_page_obj.has_previous %}
-                                <a href="?{% url_add_get_params page2=1%}">&laquo;
-                                    first</a>
-                                <a href="?{% url_add_get_params page2=user_created_sources_page_obj.previous_page_number %}">previous</a>
-                            {% endif %}
-                            <span class="current">
-                                Page {{ user_created_sources_page_obj.number }} of {{ user_created_sources_page_obj.paginator.num_pages }}
-                            </span>
 
-                            {% if user_created_sources_page_obj.has_next %}
-                                <a href="?{% url_add_get_params page2=user_created_sources_page_obj.next_page_number %}">next</a>
-                                <a href="?{% url_add_get_params page2=user_created_sources_page_obj.paginator.num_pages %}">last
-                                    &raquo;</a>
-                            {% endif %}
-                        </span>
-                    </div>
-                </div>    
-            </div>    
-        </div>
-    </div>
+{% block title %}
+<title>My Sources | Cantus Database</title>
+{% endblock %}
+
+{% block uppersidebar %}
+<div class="search-bar mb-3">
+    {% include "global_search_bar.html" %}
 </div>
+{% endblock %}
+
+{% block maincontent %}
+    <h3>My Sources</h3>
+    <a href="{% url "source-create" %}"><b>+ Add new source</b></a>
+    <table class="table table-sm small table-bordered">
+        <tbody>
+            {% for source in page_obj %}
+                <tr>
+                    <td class="h-25" style="width: 40%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 0; text-align:center">
+                        <a href="{% url "source-detail" source.pk %}">
+                            <b>{{ source.siglum }}</b>
+                        </a>
+                    </td>
+                    {% if source.chant_set.exists %}
+                        <td class="h-25" style="width: 30%; text-align:center">
+                            <a href="{% url "source-edit-chants" source.pk %}">
+                                Full text &amp; volpiano editor
+                            </a>
+                        </td>
+                    {% else %}
+                    <td class="h-25" style="width: 30%; text-align:center" colspan="2">
+                        Source contains no chants –
+                        <a href="{% url "chant-create" source.pk %}">Add new chant</a> 
+                    </td> 
+                    {% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% include "pagination.html" %}
+{% endblock %}
+
+{% block lowersidebar %}
+    <div class="card mb-3 w-100">
+        <div class="card-header">
+            <h4>Sources created by user</h4>
+        </div>
+        <div class="card-body">
+            <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
+            <ul>
+                {% for my_source in user_created_sources_page_obj %}
+                    <li>
+                        <a href="{% url "source-detail" my_source.pk %}">
+                            <b> {{ my_source.siglum }}</b>
+                        </a>
+                        <br>
+                        <small>
+                            <a href="{% url "source-detail" my_source.pk %}">
+                                <b> {{ my_source.title }}</b>
+                            </a>
+                            <br>
+                            <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
+                                &plus; Add new chant
+                            </a>
+                            <br>
+                            {% if my_source.chant_set.exists %}
+                                <a href="{% url "source-edit-chants" my_source.pk %}">
+                                    &bull; Full text &amp; volpiano editor
+                                </a>
+                            {% endif %}
+                        </small>
+                    </li>
+                {% endfor %}
+            </ul>
+            <div class="pagination">
+                <span class="step-links">
+                    {% if user_created_sources_page_obj.has_previous %}
+                        <a href="?{% url_add_get_params page2=1%}">&laquo;
+                            first</a>
+                        <a href="?{% url_add_get_params page2=user_created_sources_page_obj.previous_page_number %}">previous</a>
+                    {% endif %}
+                    <span class="current">
+                        Page {{ user_created_sources_page_obj.number }} of {{ user_created_sources_page_obj.paginator.num_pages }}
+                    </span>
+
+                    {% if user_created_sources_page_obj.has_next %}
+                        <a href="?{% url_add_get_params page2=user_created_sources_page_obj.next_page_number %}">next</a>
+                        <a href="?{% url_add_get_params page2=user_created_sources_page_obj.paginator.num_pages %}">last
+                            &raquo;</a>
+                    {% endif %}
+                </span>
+            </div>
+        </div>    
+    </div>    
 {% endblock %}

--- a/django/cantusdb_project/static/js/search_bar.js
+++ b/django/cantusdb_project/static/js/search_bar.js
@@ -31,7 +31,7 @@ function globalSearch() {
         xhttp.onload = function () {
             const data = JSON.parse(this.response);
             // the results are to be displayed in a list-group
-            chantsDiv.innerHTML = `<div class="list-group" id="listBox" style="position:absolute; z-index:1"></div>`;
+            chantsDiv.innerHTML = `<div class="list-group" id="listBox"></div>`;
             const listBox = document.getElementById("listBox");
             // for every chant returned in the JSONResponse
             data.chants.map(chant => {

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -144,13 +144,6 @@
             }
         }
 
-        @media (min-width: 992px) { /* 992px = bootstrap large breakpoint */
-            .main-content {
-                margin-right: 16px;
-                
-            }
-        }
-
         @media (max-width: 992px) { /* 992px = bootstrap large breakpoint */
             .main-content {
                 margin-bottom: 16px;

--- a/django/cantusdb_project/templates/base_page_with_side_cards.html
+++ b/django/cantusdb_project/templates/base_page_with_side_cards.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block content %}
+{% block title %}
+{% endblock %}
+{% block script %}
+{% endblock %}
+
+<div class="container">
+    <div class="row d-lg-block">
+        <div class="col-lg-4 p-0 pl-lg-3 sidebar float-right">
+            {% block uppersidebar %}
+            {# Cards in this section will jump above the main content on small screens #}
+            {% endblock %}
+        </div>
+        <div class="p-3 col-lg-8 bg-white rounded main-content float-left mb-3">
+            {% block maincontent %}
+            {% endblock %}
+        </div>
+
+        <div class="col-lg-4 p-0 pl-lg-3 sidebar float-right">
+            {% block lowersidebar %}
+            {# Cards in this section will jump below the main content on small screens #}
+            {% endblock %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -1,158 +1,154 @@
-{% extends "base.html" %}
+{% extends "base_page_with_side_cards.html" %}
 {% load helper_tags %} {# for source_links, recent_articles, get_user_source_pagination, get_user_created_source_pagination #}
-{% block content %}
-<div class="container">
+{% block title %}
     <title>{{ flatpage.title }} | Cantus Database</title>
-    <div class="row">
-        <div class="p-3 col-lg-8 bg-white rounded main-content">
-            <h2>{{ flatpage.title }}</h2>
-            {{ flatpage.content }}
-        </div>
-        
-        <div class="col p-0 sidebar">
-            <div class="search-bar mb-3">
-                {% include "global_search_bar.html" %}
-            </div>
+{% endblock %}
 
-            <div class="card mt-3 w-100">
-                <div class="card-header">
-                    Jump to Source
-                </div>
-                <div class="card-body">
-                    <select name="sources" id="source-select" class="w-75" onchange="jumpSource()">
-                        <option value="none">-Browse sources-</option>
-                        {% source_links %}
-                    </select>
-                </div>
-
-                <script>
-                    function jumpSource() { 
-                        sourceLink = document.getElementById("source-select").options[document.getElementById("source-select").selectedIndex].value;
-                        fullLink = window.location.origin + '/' + sourceLink;
-                        window.location.assign(fullLink);
-                    }
-                </script>
-            </div>
-
-            {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
-                <div class="card mt-3 w-100">
-                    <div class="card-header">
-                        My Sources
-                    </div>
-                    {% get_user_source_pagination as user_sources_page_obj %}
-                    <div class="card-body">
-                        <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
-                        <ul>
-                            {% for my_source in user_sources_page_obj %}
-                                <li>
-                                    <a href="{% url "source-detail" my_source.pk %}">
-                                        <b> {{ my_source.siglum }}</b>
-                                    </a>
-                                    <br>
-                                    <small>
-                                        <a href="{% url "source-detail" my_source.pk %}">
-                                            <b> {{ my_source.title }}</b>
-                                        </a>
-                                        <br>
-                                        <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
-                                            &plus; Add new chant
-                                        </a>
-                                        <br>
-                                        {% if my_source.chant_set.all %}
-                                            <a href="{% url "source-edit-chants" my_source.pk %}">
-                                                &bull; Full text &amp; volpiano editor
-                                            </a>
-                                        {% endif %}
-                                    </small>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                        <div class="pagination">
-                            <span class="step-links">
-                                {% if user_sources_page_obj.has_previous %}
-                                    <a href="?{% url_add_get_params page=1%}">&laquo;
-                                        first</a>
-                                    <a href="?{% url_add_get_params page=user_sources_page_obj.previous_page_number %}">previous</a>
-                                {% endif %}
-                                <span class="current">
-                                    Page {{ user_sources_page_obj.number }} of {{ user_sources_page_obj.paginator.num_pages }}
-                                </span>
-
-                                {% if user_sources_page_obj.has_next %}
-                                    <a href="?{% url_add_get_params page=user_sources_page_obj.next_page_number %}">next</a>
-                                    <a href="?{% url_add_get_params page=user_sources_page_obj.paginator.num_pages %}">last
-                                        &raquo;</a>
-                                {% endif %}
-                            </span>
-                        </div>
-                    </div>    
-                </div>
-                <div class="mt-3"></div> {# for gap between "My sources" and "Sources created by user" cards #}
-                <div class="card mb-3 w-100">
-                    <div class="card-header">
-                        Sources created by user
-                    </div>
-                    {% get_user_created_source_pagination as user_created_sources_page_obj %}
-                    <div class="card-body">
-                        <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
-                        <ul>
-                            {% for my_source in user_created_sources_page_obj %}
-                                <li>
-                                    <a href="{% url "source-detail" my_source.pk %}">
-                                        <b> {{ my_source.siglum }}</b>
-                                    </a>
-                                    <br>
-                                    <small>
-                                        <a href="{% url "source-detail" my_source.pk %}">
-                                            <b> {{ my_source.title }}</b>
-                                        </a>
-                                        <br>
-                                        <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
-                                            &plus; Add new chant
-                                        </a>
-                                        <br>
-                                        {% if my_source.chant_set.all %}
-                                            <a href="{% url "source-edit-chants" my_source.pk %}">
-                                                &bull; Full text &amp; volpiano editor
-                                            </a>
-                                        {% endif %}
-                                    </small>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                        <div class="pagination">
-                            <span class="step-links">
-                                {% if user_created_sources_page_obj.has_previous %}
-                                    <a href="?{% url_add_get_params page2=1%}">&laquo;
-                                        first</a>
-                                    <a href="?{% url_add_get_params page2=user_created_sources_page_obj.previous_page_number %}">previous</a>
-                                {% endif %}
-                                <span class="current">
-                                    Page {{ user_created_sources_page_obj.number }} of {{ user_created_sources_page_obj.paginator.num_pages }}
-                                </span>
-
-                                {% if user_created_sources_page_obj.has_next %}
-                                    <a href="?{% url_add_get_params page2=user_created_sources_page_obj.next_page_number %}">next</a>
-                                    <a href="?{% url_add_get_params page2=user_created_sources_page_obj.paginator.num_pages %}">last
-                                        &raquo;</a>
-                                {% endif %}
-                            </span>
-                        </div>
-                    </div>    
-                </div>  
-            {% else %}
-                <div class="card mt-3 w-100">
-                    <div class="card-header">
-                        What's New
-                    </div>
-                    <div class="card-body">
-                        {% recent_articles %}
-                    </div>
-                </div>
-            {% endif %}
-        </div>
+{% block uppersidebar %}
+    <div class="search-bar mb-3">
+        {% include "global_search_bar.html" %}
     </div>
-</div>
+    <div class="card mb-3">
+        <div class="card-header">
+            Jump to Source
+        </div>
+        <div class="card-body">
+            <select name="sources" id="source-select" class="w-75" onchange="jumpSource()">
+                <option value="none">-Browse sources-</option>
+                {% source_links %}
+            </select>
+        </div>
 
+        <script>
+            function jumpSource() { 
+                sourceLink = document.getElementById("source-select").options[document.getElementById("source-select").selectedIndex].value;
+                fullLink = window.location.origin + '/' + sourceLink;
+                window.location.assign(fullLink);
+            }
+        </script>
+    </div>
+{% endblock %}
 
+{% block maincontent %}
+    <h2>{{ flatpage.title }}</h2>
+    {{ flatpage.content }}
+{% endblock %}
+
+{% block lowersidebar %}
+    {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
+        <div class="card w-100">
+            <div class="card-header">
+                My Sources
+            </div>
+            {% get_user_source_pagination as user_sources_page_obj %}
+            <div class="card-body">
+                <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
+                <ul>
+                    {% for my_source in user_sources_page_obj %}
+                        <li>
+                            <a href="{% url "source-detail" my_source.pk %}">
+                                <b> {{ my_source.siglum }}</b>
+                            </a>
+                            <br>
+                            <small>
+                                <a href="{% url "source-detail" my_source.pk %}">
+                                    <b> {{ my_source.title }}</b>
+                                </a>
+                                <br>
+                                <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
+                                    &plus; Add new chant
+                                </a>
+                                <br>
+                                {% if my_source.chant_set.all %}
+                                    <a href="{% url "source-edit-chants" my_source.pk %}">
+                                        &bull; Full text &amp; volpiano editor
+                                    </a>
+                                {% endif %}
+                            </small>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <div class="pagination">
+                    <span class="step-links">
+                        {% if user_sources_page_obj.has_previous %}
+                            <a href="?{% url_add_get_params page=1%}">&laquo;
+                                first</a>
+                            <a href="?{% url_add_get_params page=user_sources_page_obj.previous_page_number %}">previous</a>
+                        {% endif %}
+                        <span class="current">
+                            Page {{ user_sources_page_obj.number }} of {{ user_sources_page_obj.paginator.num_pages }}
+                        </span>
+
+                        {% if user_sources_page_obj.has_next %}
+                            <a href="?{% url_add_get_params page=user_sources_page_obj.next_page_number %}">next</a>
+                            <a href="?{% url_add_get_params page=user_sources_page_obj.paginator.num_pages %}">last
+                                &raquo;</a>
+                        {% endif %}
+                    </span>
+                </div>
+            </div>    
+        </div>
+        <div class="mt-3"></div> {# for gap between "My sources" and "Sources created by user" cards #}
+        <div class="card mb-3 w-100">
+            <div class="card-header">
+                Sources created by user
+            </div>
+            {% get_user_created_source_pagination as user_created_sources_page_obj %}
+            <div class="card-body">
+                <small><a href="{% url "source-create" %}"><b>+ Add new source</b></a></small>
+                <ul>
+                    {% for my_source in user_created_sources_page_obj %}
+                        <li>
+                            <a href="{% url "source-detail" my_source.pk %}">
+                                <b> {{ my_source.siglum }}</b>
+                            </a>
+                            <br>
+                            <small>
+                                <a href="{% url "source-detail" my_source.pk %}">
+                                    <b> {{ my_source.title }}</b>
+                                </a>
+                                <br>
+                                <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
+                                    &plus; Add new chant
+                                </a>
+                                <br>
+                                {% if my_source.chant_set.all %}
+                                    <a href="{% url "source-edit-chants" my_source.pk %}">
+                                        &bull; Full text &amp; volpiano editor
+                                    </a>
+                                {% endif %}
+                            </small>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <div class="pagination">
+                    <span class="step-links">
+                        {% if user_created_sources_page_obj.has_previous %}
+                            <a href="?{% url_add_get_params page2=1%}">&laquo;
+                                first</a>
+                            <a href="?{% url_add_get_params page2=user_created_sources_page_obj.previous_page_number %}">previous</a>
+                        {% endif %}
+                        <span class="current">
+                            Page {{ user_created_sources_page_obj.number }} of {{ user_created_sources_page_obj.paginator.num_pages }}
+                        </span>
+
+                        {% if user_created_sources_page_obj.has_next %}
+                            <a href="?{% url_add_get_params page2=user_created_sources_page_obj.next_page_number %}">next</a>
+                            <a href="?{% url_add_get_params page2=user_created_sources_page_obj.paginator.num_pages %}">last
+                                &raquo;</a>
+                        {% endif %}
+                    </span>
+                </div>
+            </div>    
+        </div>  
+    {% else %}
+        <div class="card">
+            <div class="card-header">
+                What's New
+            </div>
+            <div class="card-body">
+                {% recent_articles %}
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Closes #1419. Closes #849. Closes #909. This PR introduces some new styling for pages where we have a two-column layout with a wider left column that contains the main content of the page and then a smaller right "sidebar" with one or many cards. The current homepage, articles page, and chant detail page are good examples of this:

![image](https://github.com/DDMAL/CantusDB/assets/11023634/2e4684f9-c0d0-4d01-af28-7565e0c9893b)
![image](https://github.com/DDMAL/CantusDB/assets/11023634/369eacde-c347-425b-9d66-0d5ef3b28944)
![image](https://github.com/DDMAL/CantusDB/assets/11023634/4ef28428-509d-4abf-b48e-18208e493cf8)

This PR allows some upper portions of the sidebar to jump above the main content on a narrow window and the remainder to jump below the main content. The PR introduces this styling in a new template, `base_page_with_side_cards.html`, that other templates with this format can extend. This PR completes that refactoring for flat pages, pages in the `articles` app, and pages in `main_app`. Screenshots of the same three pages above with these styling changes are included here (in narrow format):

![image](https://github.com/DDMAL/CantusDB/assets/11023634/93b78723-045e-4c76-b9fa-1aa780319c17)
![image](https://github.com/DDMAL/CantusDB/assets/11023634/d4215c27-336f-4248-9224-2c1cb728d9d6)
![image](https://github.com/DDMAL/CantusDB/assets/11023634/a6993329-7cc0-47ab-a165-4293786ec05a)


Closes #1532. I found a bug whereby search results from the global search bar on dynamic pages (ie. pages that weren't flatpages) did not show beneath the search box. This PR changes some of the styling of used when populating those asynchronous search results. 

_Before_
![image](https://github.com/DDMAL/CantusDB/assets/11023634/167370a1-c94f-4897-9bea-8fd9cccdb177)

_After_
![image](https://github.com/DDMAL/CantusDB/assets/11023634/32350687-1493-4d01-9768-142f6e765995)
