### PR TITLE
Escape special characters in suggested chant data

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -314,10 +314,10 @@
                                     value="{{ suggestion.cantus_id }}"
                                     title="{{ suggestion.cantus_id }}"
                                     onclick='autoFillSuggestedChant(
-                                        "{{ suggestion.genre_name }}",
+                                        "{{ suggestion.genre_name | escapejs }}",
                                         {{ suggestion.genre_id | default_if_none:"null" }},
-                                        "{{ suggestion.cantus_id }}",
-                                        "{{ suggestion.fulltext }}"
+                                        "{{ suggestion.cantus_id | escapejs }}",
+                                        "{{ suggestion.fulltext | escapejs }}"
                                     )'
                                 >
                                 <strong>{{ suggestion.genre_name }}</strong> - <span title="{{ suggestion.fulltext }}">{{ suggestion.incipit }}</span> (<strong>{{ suggestion.occurrences }}x</strong>)<br>


### PR DESCRIPTION
This PR addresses an issue where the 'onclick' event for suggested chant buttons was not being triggered due to unescaped special characters in the data. By using the `escapejs` filter, we ensure that special characters in the strings passed to the JavaScript function are properly escaped, preventing any JavaScript errors.

Fixes #1554 