### PR TITLE
Add command to reassign feast data and update chants

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
+++ b/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
@@ -2,16 +2,18 @@ from django.core.management.base import BaseCommand
 from main_app.models import Feast, Chant, Sequence
 
 
+FEAST_MAPPING = {
+    2456: 4474,
+    2094: 4475,
+}
+
+
 class Command(BaseCommand):
     help = "Reassign feasts and update chants accordingly"
 
     def handle(self, *args, **options):
-        feast_mapping = {
-            2456: 4474,
-            2094: 4475,
-        }
 
-        for old_feast_id, new_feast_id in feast_mapping.items():
+        for old_feast_id, new_feast_id in FEAST_MAPPING.items():
             try:
                 old_feast = Feast.objects.get(id=old_feast_id)
                 new_feast = Feast.objects.get(id=new_feast_id)

--- a/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
+++ b/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
@@ -1,0 +1,44 @@
+from django.core.management.base import BaseCommand
+from main_app.models import Feast, Chant
+
+
+class Command(BaseCommand):
+    help = "Reassign feasts and update chants accordingly"
+
+    def handle(self, *args, **options):
+        feast_mapping = {
+            2456: 4474,
+            2094: 4475,
+        }
+
+        for old_feast_id, new_feast_id in feast_mapping.items():
+            try:
+                old_feast = Feast.objects.get(id=old_feast_id)
+                new_feast = Feast.objects.get(id=new_feast_id)
+            except Feast.DoesNotExist as e:
+                self.stderr.write(self.style.ERROR(f"Feast not found: {e}"))
+                continue
+
+            # Transfer data (if necessary)
+            new_feast.name = new_feast.name or old_feast.name
+            new_feast.description = new_feast.description or old_feast.description
+            new_feast.feast_code = new_feast.feast_code or old_feast.feast_code
+            new_feast.notes = new_feast.notes or old_feast.notes
+            new_feast.month = new_feast.month or old_feast.month
+            new_feast.day = new_feast.day or old_feast.day
+            new_feast.save()
+
+            # Reassign chants and sequences
+            chants_updated = Chant.objects.filter(feast=old_feast).update(
+                feast=new_feast
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Reassigned {chants_updated} chants from feast {old_feast_id} to {new_feast_id}"
+                )
+            )
+
+            old_feast.delete()
+            self.stdout.write(self.style.SUCCESS(f"Deleted old feast {old_feast_id}"))
+
+        self.stdout.write(self.style.SUCCESS("Feast reassignment complete."))

--- a/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
+++ b/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from main_app.models import Feast, Chant
+from main_app.models import Feast, Chant, Sequence
 
 
 class Command(BaseCommand):
@@ -27,16 +27,26 @@ class Command(BaseCommand):
             new_feast.month = new_feast.month or old_feast.month
             new_feast.day = new_feast.day or old_feast.day
 
-            # Call save method to update 'prefix' field
+            # Calling save method will update 'prefix' field
             new_feast.save()
 
-            # Reassign chants and sequences
+            # Reassign chants
             chants_updated = Chant.objects.filter(feast=old_feast).update(
                 feast=new_feast
             )
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Reassigned {chants_updated} chants from feast {old_feast_id} to {new_feast_id}"
+                )
+            )
+
+            # Reassign sequences
+            sequences_updated = Sequence.objects.filter(feast=old_feast).update(
+                feast=new_feast
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Reassigned {sequences_updated} sequences from feast {old_feast_id} to {new_feast_id}"
                 )
             )
 

--- a/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
+++ b/django/cantusdb_project/main_app/management/commands/reassign_feasts.py
@@ -26,6 +26,8 @@ class Command(BaseCommand):
             new_feast.notes = new_feast.notes or old_feast.notes
             new_feast.month = new_feast.month or old_feast.month
             new_feast.day = new_feast.day or old_feast.day
+
+            # Call save method to update 'prefix' field
             new_feast.save()
 
             # Reassign chants and sequences

--- a/django/cantusdb_project/main_app/models/feast.py
+++ b/django/cantusdb_project/main_app/models/feast.py
@@ -17,7 +17,6 @@ class Feast(BaseModel):
         blank=True, null=True, validators=[MinValueValidator(1), MaxValueValidator(31)]
     )
 
-    # the `prefix` field can be automatically populated by running `python manage.py add_prefix`
     prefix = models.CharField(max_length=2, blank=True, null=True, editable=False)
 
     class Meta:


### PR DESCRIPTION
Adds a management command that will transfer data between feasts and update chants accordingly.

- Ensure data from old feasts are transferred to new feasts
- Update chants and sequences to use new feast IDs
- Delete old feasts after reassignment

Towards #1560, once we run the command on production we can close the issue.