### PR TITLE
Fixed: A follow-up to the source rework

### DIFF
--- a/django/cantusdb_project/main_app/admin/chant.py
+++ b/django/cantusdb_project/main_app/admin/chant.py
@@ -8,10 +8,13 @@ from main_app.models import Chant
 @admin.register(Chant)
 class ChantAdmin(BaseModelAdmin):
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("source__holding_institution", "genre", "office")
+
     @admin.display(description="Source Siglum")
     def get_source_siglum(self, obj):
         if obj.source:
-            return obj.source.siglum
+            return obj.source.short_heading
 
     list_display = (
         "incipit",
@@ -50,4 +53,4 @@ class ChantAdmin(BaseModelAdmin):
         "source",
         "feast",
     )
-    ordering = ("source__siglum",)
+    ordering = ("source__holding_institution__siglum", "source__shelfmark")

--- a/django/cantusdb_project/main_app/admin/sequence.py
+++ b/django/cantusdb_project/main_app/admin/sequence.py
@@ -7,10 +7,13 @@ from main_app.models import Sequence
 
 @admin.register(Sequence)
 class SequenceAdmin(BaseModelAdmin):
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("source__holding_institution", "genre", "office")
+
     @admin.display(description="Source Siglum")
     def get_source_siglum(self, obj):
         if obj.source:
-            return obj.source.siglum
+            return obj.source.short_heading
 
     search_fields = (
         "title",
@@ -24,7 +27,11 @@ class SequenceAdmin(BaseModelAdmin):
         "is_last_chant_in_feast",
         "visible_status",
     )
-    list_display = ("incipit", "get_source_siglum", "genre")
+    list_display = (
+        "incipit",
+        "get_source_siglum",
+        "genre"
+    )
     list_filter = (
         "genre",
         "office",
@@ -34,5 +41,5 @@ class SequenceAdmin(BaseModelAdmin):
         "feast",
     )
     readonly_fields = READ_ONLY + ("incipit",)
-    ordering = ("source__siglum",)
+    ordering = ("source__holding_institution__siglum", "source__shelfmark")
     form = AdminSequenceForm

--- a/django/cantusdb_project/main_app/admin/source.py
+++ b/django/cantusdb_project/main_app/admin/source.py
@@ -22,8 +22,6 @@ class SourceAdmin(BaseModelAdmin):
 
     # These search fields are also available on the user-source inline relationship in the user admin page
     search_fields = (
-        "siglum",
-        "title",
         "shelfmark",
         "holding_institution__siglum",
         "holding_institution__name",
@@ -52,9 +50,7 @@ class SourceAdmin(BaseModelAdmin):
 
     list_display = (
         "shelfmark",
-        # "title",
         "holding_institution",
-        # "siglum",
         "id",
     )
 
@@ -68,7 +64,7 @@ class SourceAdmin(BaseModelAdmin):
         "holding_institution__is_private_collector",
     )
 
-    ordering = ("siglum",)
+    ordering = ("holding_institution__siglum", "shelfmark")
 
     form = AdminSourceForm
 

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -453,7 +453,7 @@ class SequenceEditForm(forms.ModelForm):
         model = Sequence
         fields = [
             "title",
-            "siglum",
+            # "siglum",
             "incipit",
             "folio",
             "s_sequence",
@@ -472,7 +472,7 @@ class SequenceEditForm(forms.ModelForm):
         ]
         widgets = {
             "title": TextInputWidget(),
-            "siglum": TextInputWidget(),
+            # "siglum": TextInputWidget(),
             "incipit": TextInputWidget(),
             "folio": TextInputWidget(),
             "s_sequence": TextInputWidget(),

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -3,12 +3,12 @@ from typing import Union, Optional
 
 from django import template
 from django.core.paginator import Paginator
-from django.db.models import Q, Prefetch
+from django.db.models import Q
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 
 from articles.models import Article
-from main_app.models import Source, Chant
+from main_app.models import Source
 
 register = template.Library()
 

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -3,12 +3,12 @@ from typing import Union, Optional
 
 from django import template
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Q, Prefetch
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 
 from articles.models import Article
-from main_app.models import Source
+from main_app.models import Source, Chant
 
 register = template.Library()
 
@@ -129,6 +129,15 @@ def has_group(user, group_name):
     return user.groups.filter(name=group_name).exists()
 
 
+@register.filter(name="in_groups")
+def in_groups(user, groups: str) -> bool:
+    """
+    Takes a comma-separated string of group names and returns True if the user is in those groups.
+    """
+    grouplist = groups.split(",")
+    return user.groups.filter(name__in=grouplist).exists()
+
+
 @register.filter(name='split')
 @stringfilter
 def split(value: str, key: str) -> list[str]:
@@ -144,8 +153,16 @@ def get_user_source_pagination(context):
         Source.objects.filter(
             Q(current_editors=context["user"]) | Q(created_by=context["user"])
         )
+        .select_related("holding_institution")
         .order_by("-date_updated")
         .distinct()
+        .only("id",
+              "holding_institution__id",
+              "holding_institution__city",
+              "holding_institution__siglum",
+              "holding_institution__name",
+              "holding_institution__is_private_collector",
+              "shelfmark")
     )
     paginator = Paginator(user_created_sources, 6)
     page_number = context["request"].GET.get("page")
@@ -157,8 +174,16 @@ def get_user_source_pagination(context):
 def get_user_created_source_pagination(context):
     user_created_sources = (
         Source.objects.filter(created_by=context["user"])
+        .select_related("holding_institution")
         .order_by("-date_created")
         .distinct()
+        .only("id",
+              "holding_institution__id",
+              "holding_institution__city",
+              "holding_institution__siglum",
+              "holding_institution__name",
+              "holding_institution__is_private_collector",
+              "shelfmark")
     )
     paginator = Paginator(user_created_sources, 6)
     page_number = context["request"].GET.get("page2")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -99,6 +99,7 @@ def get_feast_selector_options(source: Source) -> list[tuple[str, int, str]]:
     """
     folios_feasts_iter: Iterator[tuple[Optional[str], int, str]] = (
         source.chant_set.exclude(feast=None)
+        .select_related("feast", "genre", "office")
         .values_list("folio", "feast_id", "feast__name")
         .order_by("folio", "c_sequence")
         .iterator()
@@ -258,7 +259,7 @@ class ChantByCantusIDView(ListView):
         # "chant" objects this forces us to do something special on the template to render correct
         # absolute url for sequences
         queryset = chant_set.union(sequence_set)
-        queryset = queryset.order_by("siglum")
+        queryset = queryset.order_by("source__holding_institution__siglum")
         return queryset
 
     def get_context_data(self, **kwargs):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -37,6 +37,9 @@ from main_app.views.chant import (
     user_can_edit_chants_in_source,
 )
 
+CANTUS_SEGMENT_ID = 4063
+BOWER_SEGMENT_ID = 4064
+
 
 class SourceBrowseChantsView(ListView):
     """The view for the `Browse Chants` page.
@@ -98,7 +101,17 @@ class SourceBrowseChantsView(ListView):
 
     def get_context_data(self, **kwargs):
         context: dict = super().get_context_data(**kwargs)
-        # these are needed in the selectors on the left side of the page
+        source_id: int = self.kwargs.get(self.pk_url_kwarg)
+        source: Source = get_object_or_404(Source, id=source_id)
+        if source.segment_id != CANTUS_SEGMENT_ID:
+            # the chant list ("Browse Chants") page should only be visitable
+            # for sources in the CANTUS Database segment, as sources in the Bower
+            # segment contain no chants
+            raise Http404()
+
+        context["source"] = source
+
+    # these are needed in the selectors on the left side of the page
         context["feasts"] = Feast.objects.all().order_by("name")
         context["genres"] = Genre.objects.all().order_by("name")
 
@@ -106,7 +119,7 @@ class SourceBrowseChantsView(ListView):
 
         # sources in the Bower Segment contain only Sequences and no Chants,
         # so they should not appear among the list of sources
-        cantus_segment: QuerySet[Segment] = Segment.objects.get(id=4063)
+        cantus_segment: QuerySet[Segment] = Segment.objects.get(id=CANTUS_SEGMENT_ID)
 
         # to be displayed in the "Source" dropdown in the form
         sources: QuerySet[Source] = (cantus_segment.source_set
@@ -115,16 +128,6 @@ class SourceBrowseChantsView(ListView):
         if not display_unpublished:
             sources = sources.filter(published=True)
         context["sources"] = sources
-
-        source_id: int = self.kwargs.get(self.pk_url_kwarg)
-        source: Source = get_object_or_404(Source, id=source_id)
-        if source not in sources:
-            # the chant list ("Browse Chants") page should only be visitable
-            # for sources in the CANTUS Database segment, as sources in the Bower
-            # segment contain no chants
-            raise Http404()
-
-        context["source"] = source
 
         user = self.request.user
         context["user_can_edit_chant"] = user_can_edit_chants_in_source(user, source)
@@ -181,7 +184,7 @@ class SourceDetailView(DetailView):
 
         context = super().get_context_data(**kwargs)
 
-        if source.segment and source.segment_id == 4064:
+        if source.segment and source.segment_id == BOWER_SEGMENT_ID:
             # if this is a sequence source
             sequences = source.sequence_set.select_related("genre", "office")
             context["sequences"] = sequences.order_by("s_sequence")
@@ -405,7 +408,7 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         source = self.get_object()
         context = super().get_context_data(**kwargs)
 
-        if source.segment and source.segment.id == 4064:
+        if source.segment and source.segment.id == BOWER_SEGMENT_ID:
             # if this is a sequence source
             context["sequences"] = source.sequence_set.order_by("s_sequence")
             context["folios"] = (
@@ -468,7 +471,7 @@ class SourceInventoryView(TemplateView):
             raise PermissionDenied
 
         # 4064 is the id for the sequence database
-        if source.segment.id == 4064:
+        if source.segment.id == BOWER_SEGMENT_ID:
             queryset = (
                 source.sequence_set.annotate(record_type=Value("sequence"))
                 .order_by("s_sequence")

--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -418,7 +418,7 @@
                     </div>
                     <div class="col-md-4" id="login">
                         {% if not request.user.is_anonymous %}
-                            {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
+                            {% if request.user|in_groups:"contributor,editor,project manager" %}
                                 <h5>Admin Navigation</h5>
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item p-0">

--- a/django/cantusdb_project/templates/flatpages/default.html
+++ b/django/cantusdb_project/templates/flatpages/default.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block lowersidebar %}
-    {% if request.user|has_group:"contributor" or request.user|has_group:"editor" or request.user|has_group:"project manager" %}
+    {% if request.user|in_groups:"contributor,editor,project manager" %}
         <div class="card w-100">
             <div class="card-header">
                 My Sources
@@ -47,19 +47,19 @@
                     {% for my_source in user_sources_page_obj %}
                         <li>
                             <a href="{% url "source-detail" my_source.pk %}">
-                                <b> {{ my_source.siglum }}</b>
+                                <b> {{ my_source.short_heading }}</b>
                             </a>
                             <br>
                             <small>
                                 <a href="{% url "source-detail" my_source.pk %}">
-                                    <b> {{ my_source.title }}</b>
+                                    <b> {{ my_source.heading }}</b>
                                 </a>
                                 <br>
                                 <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
                                     &plus; Add new chant
                                 </a>
                                 <br>
-                                {% if my_source.chant_set.all %}
+                                {% if my_source.chant_set.exists %}
                                     <a href="{% url "source-edit-chants" my_source.pk %}">
                                         &bull; Full text &amp; volpiano editor
                                     </a>
@@ -100,19 +100,19 @@
                     {% for my_source in user_created_sources_page_obj %}
                         <li>
                             <a href="{% url "source-detail" my_source.pk %}">
-                                <b> {{ my_source.siglum }}</b>
+                                <b> {{ my_source.short_heading }}</b>
                             </a>
                             <br>
                             <small>
                                 <a href="{% url "source-detail" my_source.pk %}">
-                                    <b> {{ my_source.title }}</b>
+                                    <b> {{ my_source.heading }}</b>
                                 </a>
                                 <br>
                                 <a href="{% url "chant-create" my_source.pk %}" style="display: inline-block; margin-top:5px;">
                                     &plus; Add new chant
                                 </a>
                                 <br>
-                                {% if my_source.chant_set.all %}
+                                {% if my_source.chant_set.exists %}
                                     <a href="{% url "source-edit-chants" my_source.pk %}">
                                         &bull; Full text &amp; volpiano editor
                                     </a>

--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -11,7 +11,7 @@ from main_app.forms import AdminUserChangeForm
 class SourceInline(admin.TabularInline):
     model = Source.current_editors.through
     raw_id_fields = ["source"]
-    ordering = ("source__siglum",)
+    ordering = ("holding_institution__siglum",)
     verbose_name_plural = "Sources assigned to User"
 
 


### PR DESCRIPTION
This is a follow-up on the source / institution re-work. 

 - There were a few places where the source siglum was still being used, so I fixed this. I'll keep looking. 
 - Optimized some admin queryset with select_related
 - The check for what groups a user was in was triggering several SQL queries. A new template filter was added that takes a comma-separated string and uses that in a single `filter()` query.
 - The source browse chants view was doing a lot of work before a simple check that would trigger a 404. This check was moved up and simplified (It no longer checks the queryset with `in` but just checks the segment id matches the expected one).
 - The pagination custom tags were also slowing down the page loads, so they were optimized as well. 