### PR TITLE
Further fixes for institution migration

### DIFF
--- a/django/cantusdb_project/main_app/admin/source.py
+++ b/django/cantusdb_project/main_app/admin/source.py
@@ -28,7 +28,7 @@ class SourceAdmin(BaseModelAdmin):
         "id",
         "provenance_notes",
     )
-    readonly_fields = READ_ONLY + (
+    readonly_fields = ("title", "siglum") + READ_ONLY + (
         "number_of_chants",
         "number_of_melodies",
         "date_created",

--- a/django/cantusdb_project/main_app/management/commands/migrate_records.py
+++ b/django/cantusdb_project/main_app/management/commands/migrate_records.py
@@ -188,21 +188,25 @@ class Command(BaseCommand):
 
                 institution = Institution.objects.create(**iobj)
 
+                rism_id = None
                 if source.id not in bad_siglum and siglum not in private_collections:
                     rism_id = get_rism_id(siglum)
-                    if rism_id:
-                        print(
-                            self.style.SUCCESS(
-                                f"Adding {rism_id} to the identifiers for {siglum}"
-                            )
-                        )
+                elif siglum == "XX-NN":
+                    rism_id = "institutions/51003803"
 
-                        instid = InstitutionIdentifier.objects.create(
-                            identifier=rism_id,
-                            identifier_type=ExternalIdentifiers.RISM,
-                            institution=institution,
+                if rism_id:
+                    print(
+                        self.style.SUCCESS(
+                            f"Adding {rism_id} to the identifiers for {siglum}"
                         )
-                        instid.save()
+                    )
+
+                    instid = InstitutionIdentifier.objects.create(
+                        identifier=rism_id,
+                        identifier_type=ExternalIdentifiers.RISM,
+                        institution=institution,
+                    )
+                    instid.save()
 
                 created_institutions[siglum] = institution
 


### PR DESCRIPTION
This PR introduces a couple small changes in support of the institution migration. 

 - Makes "title" and "siglum" read-only for sources. Since these are no longer used they should not be edited, but there was a request to keep them around for a while. Setting them to read-only in the admin interface removes all practical methods of adding or editing these fields until they are dropped entirely.
 - Makes a small adjustment to the migration script to add a RISM id to the "XX-NN" institution (Unknown). 