### PR TITLE
Display additional chant fields on Chant Detail page when they exist

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -175,6 +175,23 @@
             {% endif %}
         </div>
 
+        <div class="row">
+            {% if chant.liturgical_function %}
+            <div class="col">
+                <dt>Liturgical Function</dt>
+                <dd>{{ chant.get_liturgical_function_display }}</dd>
+            </div>
+            {% endif %}
+
+            {% if chant.polyphony %}
+                <div class="col">
+                    <dt>Polyphony</dt>
+                    <dd>{{ chant.get_polyphony_display }}</dd>
+                </div>
+            {% endif %}
+
+        </div>
+
         {% if chant.manuscript_full_text_std_spelling %}
             <dt>Full text as in Source (standardized spelling)</dt>
             <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -192,6 +192,38 @@
 
         </div>
 
+        {% if project == "Benedicamus Domino" %}
+            <div class = "row">
+                {% if chant.later_addition %}
+                    <div class = "col">
+                        <dt>Later Addition</dt>
+                        <dd>{{ chant.later_addition }}</dd>
+                    </div>
+                {% endif %}
+                {% if chant.rubrics %}
+                    <div class = "col">
+                        <dt>Rubrics</dt>
+                        <dd>{{ chant.rubrics }}</dd>
+                    </div>
+                {% endif %}
+            </div>
+
+            <div class = "row">
+                {% if chant.cm_melody_id %}
+                    <div class = "col">
+                        <dt>Corpus Monodicum Melody ID</dt>
+                        <dd>{{ chant.cm_melody_id }}</dd>
+                    </div>
+                {% endif %}
+                {% if chant.incipit_of_refrain %}
+                    <div class = "col">
+                        <dt>Incipit of Refrain</dt>
+                        <dd>{{ chant.incipit_of_refrain }}</dd>
+                    </div>
+                {% endif %}
+            </div>
+        {% endif %}
+
         {% if chant.manuscript_full_text_std_spelling %}
             <dt>Full text as in Source (standardized spelling)</dt>
             <dd>{{ chant.manuscript_full_text_std_spelling }}</dd>

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -191,7 +191,7 @@ class ChantDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        chant = self.get_object()
+        chant = context["chant"]
         user = self.request.user
         source = chant.source
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -212,6 +212,9 @@ class ChantDetailView(DetailView):
             )
             context["syllabized_text_with_melody"] = text_and_mel
 
+        if project := chant.project:
+            context["project"] = project.name
+
         # some chants don't have a source, for those chants, stop here without further calculating
         # other context variables
         if not chant.source:


### PR DESCRIPTION
This PR updates the chant detail page to include additional fields added for the Benedicamus Domino project (#1473). These include:
- polyphony (any chant, not just BD-project chants, may have this field filled)
- liturgical function (any chant, not just BD-project chants, may have this field filled)
- later addition
- incipit of refrain
- rubrics
- cm melody id

Screenshots for these cases below.

Additionally, in profiling the chant detail page, I discovered our view was making a duplicate query. I've refactored the view code to eliminate this duplicate.

_Chant detail page for chant with polyphony and function fields filled_

<img width="764" alt="image" src="https://github.com/user-attachments/assets/3469c6cc-ae0f-475a-8784-55c5664b0113">

_Chant detail page for chant in Benedicamus Domino project_

<img width="762" alt="image" src="https://github.com/user-attachments/assets/96670c64-6fe3-493a-9baa-5a011eeca2b6">


Closes #1495. Closes #1496.