### PR TITLE
New: Add source key filter to chants

### DIFF
--- a/django/cantusdb_project/main_app/admin/chant.py
+++ b/django/cantusdb_project/main_app/admin/chant.py
@@ -1,8 +1,18 @@
 from django.contrib import admin
 
 from main_app.admin.base_admin import EXCLUDE, READ_ONLY, BaseModelAdmin
+from main_app.admin.filters import InputFilter
 from main_app.forms import AdminChantForm
 from main_app.models import Chant
+
+
+class SourceKeyFilter(InputFilter):
+    parameter_name = "source_id"
+    title = "Source ID"
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(source_id=self.value())
 
 
 @admin.register(Chant)
@@ -30,11 +40,13 @@ class ChantAdmin(BaseModelAdmin):
         "incipit",
         "cantus_id",
         "id",
+        "source__holding_institution__siglum"
     )
 
     readonly_fields = READ_ONLY + ("incipit",)
 
     list_filter = (
+        SourceKeyFilter,
         "genre",
         "office",
     )


### PR DESCRIPTION
This small change adds a text input filter to the chants for the source primary key. This allows chants to be filtered by source in the list.