### PR TITLE
Make "Country" and "Source" columns sortable on Source List page

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% load helper_tags %}
+
 
 {% block title %}
     <title>Browse Sources | Cantus Database</title>
@@ -76,8 +78,8 @@
         <table class="table table-sm small table-bordered table-responsive">
             <thead>
                 <tr>
-                    <th scope="col" class="text-wrap" style="text-align:center">Country</th>
-                    <th scope="col" class="text-wrap" style="text-align:center">Source</th>
+                    {% sortable_header request "country" %}
+                    {% sortable_header request "heading" "Source" %}
                     <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
@@ -90,9 +92,9 @@
                         <td class="text-wrap" style="text-align:center">
                             <b>{{ source.holding_institution.country }}</b>
                         </td>
-                        <td class="text-wrap" style="text-align:center" title="{{ source.title }}">
+                        <td class="text-wrap" style="text-align:center" title="{{ source.heading }}">
                             <a href="{% url 'source-detail' source.id %}">
-                                <b>{{ source.title|truncatechars_html:100 }}</b>
+                                <b>{{ source.heading|truncatechars_html:100 }}</b>
                             </a>
                         </td>
                         <td class="text-wrap" style="text-align:center" title="{{ source.summary|default:""|truncatechars_html:500 }}">

--- a/django/cantusdb_project/main_app/templates/tag_templates/sortable_header.html
+++ b/django/cantusdb_project/main_app/templates/tag_templates/sortable_header.html
@@ -1,0 +1,11 @@
+<th scope="col" class="text-wrap" style="text-align:center" title="{{ column_name }}">
+    {% if attr_is_currently_ordering %}
+        {% if current_sort_param == "desc" %}
+            <a href="{{ url_wo_sort_params }}&order={{ order_attribute }}&sort=asc">{{ column_name }}</a> ▼
+        {% else %}
+            <a href="{{ url_wo_sort_params }}&order={{ order_attribute }}&sort=desc">{{ column_name }}</a> ▲
+        {% endif %}
+    {% else %}
+        <a href="{{ url_wo_sort_params }}&order={{ order_attribute }}&sort=asc">{{ column_name }}</a>
+    {% endif %}
+</th>


### PR DESCRIPTION
Closes #1217 by making the source list page sortable by the "country" and "source" (city + institution + siglum) columns.

Additionally, this PR adds the `sortable_header` template tag. This tag renders a column header for a sortable column, reducing the need to repeat this construction multiple times in the `source_list` and other templates. This template tag can be reused in any template where we sort by column headers (I'm thinking here especially of the Chant Search table; I've made #1593 for this). 

Finally, makes some minor code cleanliness changes to the SourceList view: annotates function return type and makes use of the assignment operator to reduce the number of statements in the `get_queryset` view.