### PR TITLE
Update nginx configuration and switch to `runserver_plus` in devcontainer setup

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf.development
+++ b/config/nginx/conf.d/cantusdb.conf.development
@@ -10,7 +10,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
-        proxy_intercept_errors on;
+        proxy_intercept_errors off;
     }
 
     location /static {

--- a/docker-compose-dev-containers.yml
+++ b/docker-compose-dev-containers.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - postgres
     working_dir: /code/cantusdb_project/django/cantusdb_project
-    command: [ "python", "manage.py", "runserver", "0:8000" ]
+    command: [ "python", "manage.py", "runserver_plus", "0:8000" ]
 
   nginx:
     build:


### PR DESCRIPTION
This change disables nginx's error page interception for the development environment configuration file to ensure that Django's debug pages are displayed correctly when `DEBUG` is set to True. I think that this change was introduced as part of #1530 which should be done instead on the `cantusdb.conf` file on the production server. (Related: #1598)

Replaced `runserver` with `runserver_plus` in the Docker Compose configuration for the development container. 