### PR TITLE
Fix `FieldError` on admin user change page

### DIFF
--- a/django/cantusdb_project/users/admin.py
+++ b/django/cantusdb_project/users/admin.py
@@ -11,7 +11,7 @@ from main_app.forms import AdminUserChangeForm
 class SourceInline(admin.TabularInline):
     model = Source.current_editors.through
     raw_id_fields = ["source"]
-    ordering = ("holding_institution__siglum",)
+    ordering = ("source__holding_institution__siglum",)
     verbose_name_plural = "Sources assigned to User"
 
 


### PR DESCRIPTION
Resolves #1597. Fixes a relational field reference issue, ensuring that the query can correctly order by the `siglum` of the `holding_institution` related to the `source`.