### PR TITLE
Change help text for `date` field on source edit page

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -108,7 +108,7 @@
             <div class="form-group m-1 col-lg-7">
                 {{ form.date.label_tag }}
                 {{ form.date }}
-                <small>Date of the source (e.g. "1200s", "1300-1350", etc.)</small>
+                <small>{{ form.date.help_text }}</small>
             </div>
         </div>
 


### PR DESCRIPTION
While testing the staging server I noticed #1602, this PR fixes #1602.