### PR TITLE
Add country filter to source list page

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -43,6 +43,15 @@
         </div>
         <div class="form-row form-row align-items-end">
             <div class="form-group m-1 col-lg">
+                <label for="countryFilter"><small>Country</small></label>
+                <select id="countryFilter" name="country" class="form-control custom-select custom-select-sm">
+                    <option value="">- Any -</option>
+                    {% for country in countries %}
+                        <option value="{{ country }}">{{ country }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group m-1 col-lg">
                 <label for="provenanceFilter"><small>Provenance (origin/history)</small></label>
                 <select id="provenanceFilter" name="provenance" class="form-control custom-select custom-select-sm">
                     <option value="">- Any -</option>

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4424,7 +4424,7 @@ class SourceListViewTest(TestCase):
         self.assertNotIn(private_source, sources)
 
     def test_filter_by_segment(self):
-        """The source list can be filtered by `segment`, `provenance`, `century`, and `full_source`"""
+        """The source list can be filtered by `segment`, `country`, `provenance`, `century`, and `full_source`"""
         cantus_segment = make_fake_segment(name="cantus")
         clavis_segment = make_fake_segment(name="clavis")
         chant_source = make_fake_source(
@@ -4449,6 +4449,46 @@ class SourceListViewTest(TestCase):
         sources = response.context["sources"]
         self.assertIn(seq_source, sources)
         self.assertNotIn(chant_source, sources)
+
+    def test_filter_by_country(self):
+        hold_inst_austria = make_fake_institution(country="Austria")
+        hold_inst_germany = make_fake_institution(country="Germany")
+        austria_source = make_fake_source(
+            holding_institution=hold_inst_austria,
+            published=True,
+            shelfmark="source from Austria",
+        )
+        germany_source = make_fake_source(
+            holding_institution=hold_inst_germany,
+            published=True,
+            shelfmark="source from Germany",
+        )
+        no_country_source = make_fake_source(
+            holding_institution=None,
+            published=True,
+            shelfmark="source with no country",
+        )
+
+        # Display sources from Austria only
+        response = self.client.get(reverse("source-list"), {"country": "Austria"})
+        sources = response.context["sources"]
+        self.assertIn(austria_source, sources)
+        self.assertNotIn(germany_source, sources)
+        self.assertNotIn(no_country_source, sources)
+
+        # Display sources from Germany only
+        response = self.client.get(reverse("source-list"), {"country": "Germany"})
+        sources = response.context["sources"]
+        self.assertIn(germany_source, sources)
+        self.assertNotIn(austria_source, sources)
+        self.assertNotIn(no_country_source, sources)
+
+        # Display sources with no country filter (all published sources)
+        response = self.client.get(reverse("source-list"))
+        sources = response.context["sources"]
+        self.assertIn(austria_source, sources)
+        self.assertIn(germany_source, sources)
+        self.assertIn(no_country_source, sources)
 
     def test_filter_by_provenance(self):
         aachen = make_fake_provenance()

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -27,6 +27,7 @@ from main_app.models import (
     Provenance,
     Segment,
     Source,
+    Institution,
 )
 from main_app.permissions import (
     user_can_create_sources,
@@ -218,6 +219,11 @@ class SourceListView(ListView):  # type: ignore
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
+        context["countries"] = (
+            Institution.objects.values_list("country", flat=True)
+            .distinct()
+            .order_by("country")
+        )
         context["provenances"] = (
             Provenance.objects.all().order_by("name").values("id", "name")
         )
@@ -236,6 +242,9 @@ class SourceListView(ListView):  # type: ignore
             q_obj_filter = Q()
         else:
             q_obj_filter = Q(published=True)
+
+        if country_name := self.request.GET.get("country"):
+            q_obj_filter &= Q(holding_institution__country__icontains=country_name)
 
         if century_id := self.request.GET.get("century"):
             century_name = Century.objects.get(id=century_id).name

--- a/django/cantusdb_project/static/js/source_list.js
+++ b/django/cantusdb_project/static/js/source_list.js
@@ -2,6 +2,7 @@ window.addEventListener("load", function () {
     // Make sure the select components keep their values across multiple GET requests
     // so the user can "drill down" on what they want
     const segmentFilter = document.getElementById("segmentFilter");
+    const countryFilter = document.getElementById("countryFilter")
     const provenanceFilter = document.getElementById("provenanceFilter");
     const centuryFilter = document.getElementById("centuryFilter");
     const fullSourceFilter = document.getElementById("fullSourceFilter");
@@ -9,6 +10,9 @@ window.addEventListener("load", function () {
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has("segment")) {
         segmentFilter.value = urlParams.get("segment");
+    }
+    if (urlParams.has("country")) {
+        countryFilter.value = urlParams.get("country");
     }
     if (urlParams.has("provenance")) {
         provenanceFilter.value = urlParams.get("provenance");


### PR DESCRIPTION
This PR adds the country filter drop down to the 'Browse Sources' page.

- view: add 'countries' context and add country filter to query object filter
- html: add countryFilter dropdown to 'Browse Sources' page
- js: ensure countryFilter persists across multiple GET requests
- test: add tests for country filter

Resolves #1583
![Screenshot 2024-08-19 at 12 14 10 PM](https://github.com/user-attachments/assets/12db515a-f809-4e99-bdf8-dfc1171dc1e1)
