### PR TITLE
Create JSON endpoint for `Service` and `Genre` list and detail views

### DIFF
--- a/django/cantusdb_project/main_app/mixins.py
+++ b/django/cantusdb_project/main_app/mixins.py
@@ -1,0 +1,59 @@
+from typing import Any
+from django.http.response import JsonResponse, HttpResponse
+from django.http.request import HttpRequest
+from django.core.exceptions import ImproperlyConfigured
+from django.template.response import TemplateResponse
+
+
+class JSONResponseMixin:
+    """
+    Mixin to negotiate content type. Designed for use with
+    DetailView and ListView classes only.
+
+    If the request contains an `Accept` header with the value
+    `application/json`, the response will be a JSON object.
+    Otherwise, the response will render the HTML template as
+    usual.
+
+    The parent view must define an attribute "json_fields" that
+    lists the fields to be included in the JSON response.
+    """
+
+    def render_to_response(
+        self, context: dict[Any, Any], **response_kwargs: dict[Any, Any]
+    ) -> HttpResponse:
+        """
+        Returns a JSON response if the request accepts JSON.
+        Otherwise, returns the default response.
+        """
+        try:
+            request: HttpRequest = self.request  # type: ignore[attr-defined]
+        except AttributeError as exc:
+            raise ImproperlyConfigured(
+                "A JSONResponseMixin must be used with a DetailView or ListView."
+            ) from exc
+        try:
+            json_fields = self.json_fields  # type: ignore[attr-defined]
+        except AttributeError as exc:
+            raise ImproperlyConfigured(
+                "A JSONResponseMixin must define a json_fields attribute."
+            ) from exc
+        if "application/json" in request.META.get("HTTP_ACCEPT", ""):
+            obj = context.get("object")
+            if obj:
+                obj_json = {}
+                for field in json_fields:
+                    obj_json[field] = getattr(obj, field)
+                return JsonResponse({obj.get_verbose_name(): obj_json})
+            q_s = context["object_list"].values(*json_fields)
+            q_s_name = str(q_s.model.get_verbose_name_plural())
+            return JsonResponse({q_s_name: list(q_s)})
+        try:
+            template_response: TemplateResponse = super().render_to_response(  # type: ignore[misc]
+                context, **response_kwargs
+            )
+        except AttributeError as exc:
+            raise ImproperlyConfigured(
+                "A JSONResponseMixin must be used with a DetailView or ListView."
+            ) from exc
+        return template_response

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -251,14 +251,22 @@ def make_fake_feast() -> Feast:
     return feast
 
 
-def make_fake_genre(name=None) -> Genre:
+def make_fake_genre(
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    mass_office: Optional[str] = None,
+) -> Genre:
     """Generates a fake Genre object."""
     if name is None:
         name = faker.lexify("???")
+    if description is None:
+        description = faker.sentence()
+    if mass_office is None:
+        mass_office = random.choice(["Mass", "Office", "Mass, Office", "Old Hispanic"])
     genre = Genre.objects.create(
         name=name,
-        description=faker.sentence(),
-        mass_office=random.choice(["Mass", "Office", "Mass, Office", "Old Hispanic"]),
+        description=description,
+        mass_office=mass_office,
     )
     return genre
 

--- a/django/cantusdb_project/main_app/views/genre.py
+++ b/django/cantusdb_project/main_app/views/genre.py
@@ -1,19 +1,21 @@
 from django.views.generic import DetailView, ListView
-from extra_views import SearchableListMixin
 from main_app.models import Genre
+from main_app.mixins import JSONResponseMixin
 
 
-class GenreDetailView(DetailView):
+class GenreDetailView(JSONResponseMixin, DetailView):
     model = Genre
     context_object_name = "genre"
     template_name = "genre_detail.html"
+    json_fields = ["id", "name", "description", "mass_office"]
 
 
-class GenreListView(SearchableListMixin, ListView):
+class GenreListView(JSONResponseMixin, ListView):
     model = Genre
     paginate_by = 100
     context_object_name = "genres"
     template_name = "genre_list.html"
+    json_fields = ["id", "name", "description", "mass_office"]
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/django/cantusdb_project/main_app/views/service.py
+++ b/django/cantusdb_project/main_app/views/service.py
@@ -1,17 +1,20 @@
 from django.views.generic import DetailView, ListView
 
 from main_app.models import Service
+from main_app.mixins import JSONResponseMixin
 
 
-class ServiceDetailView(DetailView):
+class ServiceDetailView(JSONResponseMixin, DetailView):
     model = Service
     context_object_name = "service"
     template_name = "service_detail.html"
+    json_fields = ["id", "name", "description"]
 
 
-class ServiceListView(ListView):
+class ServiceListView(JSONResponseMixin, ListView):
     model = Service
     queryset = Service.objects.order_by("name")
     paginate_by = 100
     context_object_name = "services"
     template_name = "service_list.html"
+    json_fields = ["id", "name", "description"]


### PR DESCRIPTION
Returns JSON responses to requests to `Service` and `Genre` urls if the request's `Accept` header is `application/json`.

Implements a new class `JSONResponseMixin` that handles the content negotiation according to the `Accept` header. Classes inheriting from this mixin should define a `json_fields` attribute that lists the fields on the model that should be returned in the JSON response.

JSON responses are in the form of a object with a key being the model name (singular, in the case of a `DetailView` and plural in the case of a `ListView` -- this matches the CantusDB standard for urls).

For example, a request to `/services` with `Accept: application/json` will return:

```
{
  services : [
    { object with json_fields for service 1 },
    {  object with json_fields for service 2 },
  ]
}
```

A request to `/service/1234` with `Accept: application/json` will return:

```
{
  service : { object with json_fields for service 1 }
}
```

The PR also adds appropriate tests for the `GenreDetail`, `GenreList`, `ServiceDetail`, and `ServiceList` views. These tests weren't really making use of Django's `TestCase` functionality for setting up test data, so I did some refactoring there too. 

Finally, the `GenreListView` was inheriting from a `SearchableListMixin` but was not making use of that mixin's functionality (the filtering for that view was implemented in the overwritten `get_queryset` method), so I removed that inheritance. 

Closes #1609.