### PR TITLE
Create partial database backup for RISM

### DIFF
--- a/postgres/postgres_backup.sh
+++ b/postgres/postgres_backup.sh
@@ -3,4 +3,12 @@
 # Script backs up the Cantus Database in a compressed SQL file
 
 mkdir -p /var/lib/postgresql/backups
+# Create a full DB backup for recovery purposes
 pg_dump cantusdb -U cantusdb | gzip > /var/lib/postgresql/backups/$1
+
+
+# Create a partial DB backup for RISM purposes on Mondays
+DAY_OF_WEEK=$(date "+%u")
+if [ $DAY_OF_WEEK -eq 1 ]; then
+    pg_dump -U cantusdb -d cantusdb -T 'auth*' -T 'users*' -T 'reversion*' | gzip > /var/lib/postgresql/backups/cantusdb_rism_export.sql.gz
+fi


### PR DESCRIPTION
Adds functionality to `db_backup.sh` and `postgres_backup.sh` to create a weekly backup of some tables in the database for RISM's use. user, auth, and reversion tables are not included.

The backup is added to the backup directory (defined in ansible deployment) in the `rism` subdirectory.

Closes #1587 