### PR TITLE
Adjust sortable columns for source list page (based on email feedback)

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -88,7 +88,8 @@
             <thead>
                 <tr>
                     {% sortable_header request "country" %}
-                    {% sortable_header request "heading" "Source" %}
+                    {% sortable_header request "city_institution" "City + Institution" %}
+                    {% sortable_header request "source" "Source" %}
                     <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
                     <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
@@ -101,9 +102,14 @@
                         <td class="text-wrap" style="text-align:center">
                             <b>{{ source.holding_institution.country }}</b>
                         </td>
-                        <td class="text-wrap" style="text-align:center" title="{{ source.heading }}">
+                        <td class="text-wrap" style="text-align:center">
                             <a href="{% url 'source-detail' source.id %}">
-                                <b>{{ source.heading|truncatechars_html:100 }}</b>
+                                <b>{{ source.holding_institution.city }}, {{ source.holding_institution.name }}</b>
+                            </a>
+                        </td>
+                        <td class="text-wrap" style="text-align:center">
+                            <a href="{% url 'source-detail' source.id %}">
+                                <b>{{ source.short_heading|truncatechars_html:100 }}</b>
                             </a>
                         </td>
                         <td class="text-wrap" style="text-align:center" title="{{ source.summary|default:""|truncatechars_html:500 }}">

--- a/django/cantusdb_project/main_app/tests/test_views.py
+++ b/django/cantusdb_project/main_app/tests/test_views.py
@@ -4694,6 +4694,79 @@ class SourceListViewTest(TestCase):
         response = self.client.get(reverse("source-list"), {"general": search_term})
         self.assertIn(source, response.context["sources"])
 
+    def test_ordering(self) -> None:
+        """
+        Order is currently available by country, city + institution name (parameter:
+        "city_institution"), and siglum + shelfmark. Siglum + shelfmark is the default.
+        """
+        # Create a bunch of sources
+        sources = []
+        for _ in range(10):
+            sources.append(make_fake_source())
+        # Default ordering is by siglum and shelfmark, ascending
+        with self.subTest("Default ordering"):
+            response = self.client.get(reverse("source-list"))
+            response_sources = response.context["sources"]
+            expected_source_order = sorted(
+                sources,
+                key=lambda source: (
+                    source.holding_institution.siglum,
+                    source.shelfmark,
+                ),
+            )
+            self.assertEqual(
+                list(expected_source_order),
+                list(response_sources),
+            )
+            response_reverse = self.client.get(reverse("source-list"), {"sort": "desc"})
+            response_sources_reverse = response_reverse.context["sources"]
+            self.assertEqual(
+                list(reversed(expected_source_order)),
+                list(response_sources_reverse),
+            )
+        with self.subTest("Order by country, ascending"):
+            response = self.client.get(reverse("source-list"), {"order": "country"})
+            response_sources = response.context["sources"]
+            expected_source_order = sorted(
+                sources, key=lambda source: source.holding_institution.country
+            )
+            self.assertEqual(
+                list(expected_source_order),
+                list(response_sources),
+            )
+            response_reverse = self.client.get(
+                reverse("source-list"), {"order": "country", "sort": "desc"}
+            )
+            response_sources_reverse = response_reverse.context["sources"]
+            self.assertEqual(
+                list(reversed(expected_source_order)),
+                list(response_sources_reverse),
+            )
+        with self.subTest("Order by city and institution name, ascending"):
+            response = self.client.get(
+                reverse("source-list"), {"order": "city_institution"}
+            )
+            response_sources = response.context["sources"]
+            expected_source_order = sorted(
+                sources,
+                key=lambda source: (
+                    source.holding_institution.city,
+                    source.holding_institution.name,
+                ),
+            )
+            self.assertEqual(
+                list(expected_source_order),
+                list(response_sources),
+            )
+            response_reverse = self.client.get(
+                reverse("source-list"), {"order": "city_institution", "sort": "desc"}
+            )
+            response_sources_reverse = response_reverse.context["sources"]
+            self.assertEqual(
+                list(reversed(expected_source_order)),
+                list(response_sources_reverse),
+            )
+
 
 class SourceCreateViewTest(TestCase):
     @classmethod

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -348,10 +348,10 @@ class SourceListView(ListView):  # type: ignore
             q_obj_filter &= indexing_search_q
 
         order_param = self.request.GET.get("order")
-        order_fields = ["siglum"]
+        order_fields = ["holding_institution__siglum", "shelfmark"]
         if order_param == "country":
             order_fields.insert(0, "holding_institution__country")
-        if order_param == "heading":
+        elif order_param == "city_institution":
             order_fields.insert(0, "holding_institution__city")
             order_fields.insert(1, "holding_institution__name")
         if self.request.GET.get("sort") == "desc":


### PR DESCRIPTION
Makes some changes to the columns for institution and source identification on the source list page. 

Columns "country", "city + institution", and "source" are sortable and contain the holding institution country, the holding institution city and name, and the holding institution siglum and source shelfmark respectively. 

![image](https://github.com/user-attachments/assets/b317099f-b11a-484a-b1f5-0ca07a71c865)

Also adds tests for ordering of the source list page.

Closes #1616 