### PR TITLE
Display chant.project on Chant Detail page where it exists

### DIFF
--- a/django/cantusdb_project/main_app/models/project.py
+++ b/django/cantusdb_project/main_app/models/project.py
@@ -13,4 +13,4 @@ class Project(BaseModel):
     name = models.CharField(max_length=63)
 
     def __str__(self):
-        return f"{self.name} ({self.id})"
+        return f"{self.name}"

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -65,6 +65,13 @@
                     <dd>{{ chant.c_sequence }}</dd>
                 </div>
             {% endif %}
+
+            {% if chant.project %}
+                <div class="form-group col-6">
+                    <dt>Project</dt>
+                    <dd>{{ chant.project }}</dd>
+                </div>
+            {% endif %}
         </div>
         
         <div class="form-row">

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -186,7 +186,7 @@ class ChantDetailView(DetailView):
     def get_queryset(self) -> QuerySet:
         qs = super().get_queryset()
         return qs.select_related(
-            "source__holding_institution", "service", "genre", "feast"
+            "source__holding_institution", "service", "genre", "feast", "project"
         )
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Closes #1594.

Screenshot of chant detail page with chant project.

<img width="764" alt="image" src="https://github.com/user-attachments/assets/2911a568-1732-49cb-9fdb-d053db69df7f">
