### PR TITLE
Remove error from queryset on `MelodySearchView`

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -553,9 +553,9 @@ class MelodySearchView(TemplateView):
         context = super().get_context_data(**kwargs)
         # if searching in a specific source, pass the source into context
         if self.request.GET.get("source"):
-            context["source"] = Source.objects.get(
-                id=self.request.GET.get("source")
-            ).select_related("holding_institution", "feast", "service", "genre")
+            context["source"] = Source.objects.select_related(
+                "holding_institution"
+            ).get(id=self.request.GET.get("source"))
         return context
 
 


### PR DESCRIPTION
Closes #1646. The `.select_related` method is a QuerySet method, so must be used before `.get`. The feast, service, and genre parameters to the `select_related` method were invalid.