### PR TITLE
Temporarily turn off volpiano display for MS 73

### DIFF
--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -88,7 +88,8 @@
                         <td class="text-wrap">
                             <a href="{% url 'chant-detail' chant.id %}"><b>{{ chant.incipit|default:"" }}</b></a>
                             <p>{{ chant.manuscript_full_text_std_spelling|default:"" }}<br>
-                            {% if chant.volpiano %}
+                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
+                            {% if chant.volpiano and chant.source.id != 680970 %}
                                 <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
                             {% endif %}
                             </p>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -240,8 +240,9 @@
             <dt>Full text as in Source (source spelling)</dt>
             <dd>{{ chant.manuscript_full_text }}</dd>
         {% endif %}
-
-        {% if chant.volpiano %}
+ 
+        <!-- See #1635. Temporarily disable volpiano display for this source. -->
+        {% if chant.volpiano and chant.source.id != 680970 %} 
             <dt>Volpiano</dt>
             <dd>
                 <p style="font-family: volpiano; font-size:36px">{{ chant.volpiano }}</p>
@@ -253,7 +254,8 @@
             <dd>{{ chant.indexing_notes }}</dd>
         {% endif %}
 
-        {% if chant.volpiano %}
+        <!-- See #1635. Temporarily disable volpiano display for this source. -->
+        {% if chant.volpiano and chant.source.id != 680970 %}
             <div class="row">
                 <div class="col">
                     <dt>Melody with text</dt>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -240,6 +240,8 @@
                 </thead>
                 <tbody>
                     {% for chant in chants %}
+                    <!-- See #1635. Temporarily disable volpiano display for this source. -->
+                        {% if chant.source.id != 680970 or melodies != "true" %}
                         <tr>
                             {% if not source %}
                             <td class="text-wrap" style="text-align:left">
@@ -297,7 +299,8 @@
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                {% if chant.volpiano %}
+                                <!-- See #1635. Temporarily disable volpiano display for this source. -->
+                                {% if chant.volpiano and chant.source.id !=  680970 %}
                                     <span title="Chant record has Volpiano melody">♫</span>
                                 {% endif %}
                             </td>
@@ -307,6 +310,7 @@
                                 {% endif %}
                             </td>
                         </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -130,7 +130,8 @@
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                            {% if source.number_of_melodies %}
+                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
+                            {% if source.number_of_melodies and source.id !=  680970 %}
                                 <br>/ {{ source.number_of_melodies }}
                             {% endif %}
                         </td>

--- a/django/cantusdb_project/main_app/views/api.py
+++ b/django/cantusdb_project/main_app/views/api.py
@@ -281,17 +281,21 @@ def ajax_melody_search(request):
         chants = chants.filter(feast__name__icontains=feast_name)
     if mode:
         chants = chants.filter(mode__icontains=mode)
-
-    result_values = chants.order_by("id").values(
-        "id",
-        "source__holding_institution__siglum",
-        "source__shelfmark",
-        "folio",
-        "incipit",
-        "genre__name",
-        "feast__name",
-        "mode",
-        "volpiano",
+    # See #1635 re the following source exclusion. Temporarily disable volpiano display for this source.
+    result_values = (
+        chants.exclude(source__id=680970)
+        .order_by("id")
+        .values(
+            "id",
+            "source__holding_institution__siglum",
+            "source__shelfmark",
+            "folio",
+            "incipit",
+            "genre__name",
+            "feast__name",
+            "mode",
+            "volpiano",
+        )
     )
     # convert queryset to a list of dicts because QuerySet is not JSON serializable
     # the above constructed queryset will be evaluated here

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -367,6 +367,9 @@ class ChantSearchView(ListView):
         if search_position:
             search_parameters.append(f"position={search_position}")
         search_melodies: Optional[str] = self.request.GET.get("melodies")
+        # This was added to context so that we could implement #1635 and can be
+        # removed once that is undone.
+        context["melodies"] = search_melodies
         if search_melodies:
             search_parameters.append(f"melodies={search_melodies}")
         search_bar: Optional[str] = self.request.GET.get("search_bar")
@@ -652,6 +655,12 @@ class ChantSearchMSView(ListView):
     def get_queryset(self) -> QuerySet:
         # If the "apply" button hasn't been clicked, return empty queryset
         if not self.request.GET:
+            return Chant.objects.none()
+        # See #1635 re the following source exclusion. Temporarily disable volpiano display for this source.
+        if (
+            self.request.GET.get("melodies") == "true"
+            and self.kwargs["source_pk"] == 680970
+        ):
             return Chant.objects.none()
 
         # Create a Q object to filter the QuerySet of Chants


### PR DESCRIPTION
Closes #1635.

Changes are made to the following pages (in either templates, views, or both):
- chant detail
- global chant search
- ms chant search
- source chant browse
- source list
- melody search (global and source-specific)