### PR TITLE
Commands: fix `remap_user_ids` and add `map_cantus_ids`

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/map_cantus_ids.py
+++ b/django/cantusdb_project/main_app/management/commands/map_cantus_ids.py
@@ -1,0 +1,46 @@
+"""
+This is a (potentially temporary) command to change one Cantus ID to another
+Cantus ID. For the moment (October 2024), Cantus Index and Cantus Database are
+working out some issues in the process of merging Cantus ID's, so this command
+gives us a more fine-grained (but more general than changing them all manually)
+approach to changing Cantus ID's.
+"""
+
+from django.core.management.base import BaseCommand
+import reversion  # type: ignore[import-untyped]
+
+from main_app.models import Chant
+
+
+class Command(BaseCommand):
+    help = "Change one Cantus ID to another Cantus ID."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "old_cantus_id",
+            type=str,
+            help="The Cantus ID to change.",
+        )
+        parser.add_argument(
+            "new_cantus_id",
+            type=str,
+            help="The Cantus ID to change to.",
+        )
+
+    def handle(self, *args, **options):
+        old_cantus_id = options["old_cantus_id"]
+        new_cantus_id = options["new_cantus_id"]
+        with reversion.create_revision():
+            chants = Chant.objects.filter(cantus_id=old_cantus_id)
+            num_chants = chants.count()
+            for chant in chants.iterator(chunk_size=1_000):
+                chant.cantus_id = new_cantus_id
+                chant.save()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Changed {old_cantus_id} to {new_cantus_id} in {num_chants} chants."
+                )
+            )
+            reversion.set_comment(
+                f"Changed Cantus ID: {old_cantus_id} to {new_cantus_id}"
+            )


### PR DESCRIPTION
"Fixes" `remap_user_ids` command by:
- reducing the number of sources and chants through which the command iterates by filtering all sources and chants to only those created by the relevant users (those who need to be mapped)
- using the `iterator` QuerySet method to manage memory use
- combining all of these changes into a reversion so that this change shows in the object's history
Fixes is in scare quotes because I'm not 100% sure what the original issue was, but given the length of time the previous version had to run, I suspect something failed halfway through and because they were not contained in a transaction (as they now will be with the "reversion") the halfway-done mapping was not rolled back.

Adds the `map_cantus_ids" command which can be used to bulk-change one Cantus ID to another. As noted in the command docstring, this is a potentially temporary command that is (at this point) only going to be used for #1661, since this functionality should be taken care of by a functioning Cantus ID merge process.

#1661 should be closed once this is run on production with the appropriate Cantus ID arguments.

#1165 and #1657 should be closed once this is run in production.