### PR TITLE
Display all source centuries

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -249,15 +249,13 @@
                     Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{source.provenance.name}}</a></b>
                     <br>
                 {% endif %}
-                {% if source.date %}
+                {% if source.date or source.century %}
                     Date: 
-                    {% for century in source.century.all %}
-                        <b><a href="{% url 'century-detail' century.id %}">
-                            {{ century.name }}
-                        </a></b>
-                    {% endfor %}
+                    {% join_absolute_url_links source.century.all 'name' '/' %}
+                    {% if source.date %} 
                     |
                     <b>{{ source.date|default_if_none:"" }}</b>
+                    {% endif %}
                     <br>
                 {% endif %}
                 {% if source.cursus %}

--- a/django/cantusdb_project/main_app/templates/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_list.html
@@ -126,8 +126,8 @@
                             {{ source.summary|default:""|truncatechars_html:120 }}
                         </td>
                         <td class="text-wrap" style="text-align:center">
-                            {% if source.century.exists %}
-                                <b><a href="{% url 'century-detail' source.century.first.id %}">{{ source.century.first.name }}</a></b><br>
+                            {% if source.century %}
+                                {% join_absolute_url_links source.century.all 'name' '/' %}<br>
                             {% endif %}
                             {% if source.provenance %}
                                 <a href="{% url 'provenance-detail' source.provenance.id %}">{{ source.provenance.name }}</a>

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -1,5 +1,5 @@
 import calendar
-from typing import Union, Optional, Any
+from typing import Union, Optional
 
 from django import template
 from django.core.paginator import Paginator
@@ -7,9 +7,11 @@ from django.db.models import Q
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 from django.http import HttpRequest
+from django.utils.html import format_html_join
 
 from articles.models import Article
 from main_app.models import Source
+from main_app.models import BaseModel
 
 register = template.Library()
 
@@ -243,3 +245,22 @@ def sortable_header(
         "current_sort_param": current_sort_param,
         "url_wo_sort_params": url_wo_sort_params,
     }
+
+
+@register.simple_tag(takes_context=False)
+def join_absolute_url_links(
+    objects: list[BaseModel], display_attr: str, sep: str
+) -> str:
+    """
+    Takes a series of objects and returns an html string of
+    links to their absolute urls (i.e. their detail page).
+
+    Additional parameters:
+        display_attr: the attribute of the object to display in the link
+        sep: the separator between links
+    """
+    return format_html_join(
+        sep,
+        '<b><a href="{0}">{1}</a></b>',
+        ((obj.get_absolute_url(), getattr(obj, display_attr)) for obj in objects),
+    )


### PR DESCRIPTION
Adds a template tag `join_absolute_url_links` to create a list of links to object detail pages.

Uses this tag to display multiple centuries when a source has multiple centuries on the source list and source detail pages.