### PR TITLE
Temporarily turn off text validation

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -89,13 +89,14 @@ class CantusDBLatinField(forms.CharField):
 
     def validate(self, value):
         super().validate(value)
-        if value:
-            try:
-                syllabify_text(value)
-            except LatinError as err:
-                raise forms.ValidationError(str(err))
-            except ValueError as exc:
-                raise forms.ValidationError("Invalid characters in text.") from exc
+        # Temporarily turn off validation; see #1674
+        # if value:
+        #     try:
+        #         syllabify_text(value)
+        #     except LatinError as err:
+        #         raise forms.ValidationError(str(err))
+        #     except ValueError as exc:
+        #         raise forms.ValidationError("Invalid characters in text.") from exc
 
 
 class CantusDBSyllabifiedLatinField(forms.CharField):
@@ -107,11 +108,12 @@ class CantusDBSyllabifiedLatinField(forms.CharField):
 
     def validate(self, value):
         super().validate(value)
-        if value:
-            try:
-                syllabify_text(value, text_presyllabified=True)
-            except ValueError as exc:
-                raise forms.ValidationError("Invalid characters in text.") from exc
+        # Temporarily turn off validation; see #1674
+        # if value:
+        #     try:
+        #         syllabify_text(value, text_presyllabified=True)
+        #     except ValueError as exc:
+        #         raise forms.ValidationError("Invalid characters in text.") from exc
 
 
 class StyledChoiceField(forms.ChoiceField):

--- a/django/cantusdb_project/main_app/templates/chant_create.html
+++ b/django/cantusdb_project/main_app/templates/chant_create.html
@@ -291,7 +291,7 @@
 {% block lowersidebar %}
     <div class="card w-100 mb-3">
         <div class="card-header">
-            <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.siglum }}</a></h5>
+            <h5><a id="source" href="{% url 'source-detail' source.id %}">{{ source.short_heading }}</a></h5>
         </div>
     </div>
 

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -250,7 +250,7 @@
 {% block lowersidebar %}
     <div class="card mb-3 w-100">
         <div class="card-header">
-            <h4>{{ source.siglum }}</h4>
+            <h4>{{ source.short_heading }}</h4>
         </div>
         <div class="card-body">
             <small>

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -3,6 +3,7 @@ Test views in views/chant.py
 """
 
 from unittest.mock import patch
+from unittest import skip
 import random
 from typing import ClassVar
 
@@ -322,6 +323,7 @@ class SourceEditChantsViewTest(TestCase):
         chant.refresh_from_db()
         self.assertIs(chant.manuscript_full_text_std_proofread, True)
 
+    @skip("Temporarily disabled due to #1674")
     def test_invalid_text(self) -> None:
         """
         The user should not be able to create a chant with invalid text
@@ -3000,6 +3002,7 @@ class ChantCreateViewTest(TestCase):
             )
             self.assertIsNone(response_after_rare_chant.context["suggested_chants"])
 
+    @skip("Temporarily disabled due to #1674")
     def test_invalid_text(self) -> None:
         """
         The user should not be able to create a chant with invalid text


### PR DESCRIPTION
See #1674.

Also, removes two more places where templates were using the `source.siglum`.