### PR TITLE
fix(chant detail): show nearby chants/feasts in correct order

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -133,13 +133,15 @@ def get_chants_with_feasts(
     chants_in_folio: QuerySet[Chant],
 ) -> list[tuple[Optional[Feast], list[Chant]]]:
     """
-    Takes a queryset of chants and returns a nested list
-    nested list of the following format:
+    Takes a queryset of chants and returns a list
+    of tuples in the following format:
     [
-      [feast_id_1, [chant, chant, ...]],
-      [feast_id_2, [chant, chant, ...]],
+      (feast_id_1, [chant, chant, ...]),
+      (feast_id_2, [chant, chant, ...]),
       ...
-    ]. The queryset of chants should have the related feast object prefetched.
+    ].
+
+    The queryset of chants should have the related feast object prefetched.
     """
 
     feasts_chants = defaultdict(list)


### PR DESCRIPTION
Removes superfluous queryset + adds docstring to `get_chants_with_feasts` function.

Closes #1682.

Screenshot with new order on righthand side:
![image](https://github.com/user-attachments/assets/ee48c868-cb57-43b1-83fe-44257825651f)
