### PR TITLE
Fix `TypeError` when using CI json-cid endpoint

### DIFF
--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -112,11 +112,10 @@ def get_suggested_fulltext(cantus_id: str) -> Optional[str]:
         # mostly, in case of a timeout within get_json_from_ci_api
         return None
 
-    try:
-        suggested_fulltext = json_response["info"]["field_full_text"]
-    except (KeyError, TypeError):
+    info: Optional[dict] = json_response.get("info", {})
+    if not isinstance(info, dict):
         return None
-
+    suggested_fulltext: Optional[str] = info.get("field_full_text")
     return suggested_fulltext
 
 

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -112,11 +112,8 @@ def get_suggested_fulltext(cantus_id: str) -> Optional[str]:
         # mostly, in case of a timeout within get_json_from_ci_api
         return None
 
-    info: Optional[dict] = json_response.get("info", {})
-    if not isinstance(info, dict):
-        return None
-    suggested_fulltext: Optional[str] = info.get("field_full_text")
-    return suggested_fulltext
+    info: Optional[dict] = json_response.get("info", {}) or {}
+    return info.get("field_full_text")
 
 
 def get_merged_cantus_ids() -> Optional[list[Optional[dict]]]:

--- a/django/cantusdb_project/cantusindex.py
+++ b/django/cantusdb_project/cantusindex.py
@@ -114,7 +114,7 @@ def get_suggested_fulltext(cantus_id: str) -> Optional[str]:
 
     try:
         suggested_fulltext = json_response["info"]["field_full_text"]
-    except KeyError:
+    except (KeyError, TypeError):
         return None
 
     return suggested_fulltext

--- a/django/cantusdb_project/main_app/admin/source.py
+++ b/django/cantusdb_project/main_app/admin/source.py
@@ -20,7 +20,9 @@ class IdentifiersInline(admin.TabularInline):
     extra = 0
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related("source__holding_institution")
+        return (
+            super().get_queryset(request).select_related("source__holding_institution")
+        )
 
 
 @admin.register(Source)
@@ -38,7 +40,7 @@ class SourceAdmin(BaseModelAdmin):
         "id",
         "provenance_notes",
         "name",
-        "identifiers__identifier"
+        "identifiers__identifier",
     )
     readonly_fields = (
         ("title", "siglum")

--- a/django/cantusdb_project/main_app/models/source_identifier.py
+++ b/django/cantusdb_project/main_app/models/source_identifier.py
@@ -1,9 +1,10 @@
 from django.db import models
 
+
 class SourceIdentifier(models.Model):
     class Meta:
         verbose_name = "Source Identifier"
-        ordering = ('type',)
+        ordering = ("type",)
 
     OTHER = 1
     OLIM = 2
@@ -11,18 +12,18 @@ class SourceIdentifier(models.Model):
     RISM_ONLINE = 4
 
     IDENTIFIER_TYPES = (
-        (OTHER, 'Other catalogues'),
-        (OLIM, 'olim (Former shelfmark)'),
-        (ALTN, 'Alternative names'),
-        (RISM_ONLINE, "RISM Online")
+        (OTHER, "Other catalogues"),
+        (OLIM, "olim (Former shelfmark)"),
+        (ALTN, "Alternative names"),
+        (RISM_ONLINE, "RISM Online"),
     )
 
     identifier = models.CharField(max_length=255)
     type = models.IntegerField(choices=IDENTIFIER_TYPES)
     note = models.TextField(blank=True, null=True)
-    source = models.ForeignKey("Source",
-                               related_name="identifiers",
-                               on_delete=models.CASCADE)
+    source = models.ForeignKey(
+        "Source", related_name="identifiers", on_delete=models.CASCADE
+    )
 
     def __str__(self):
         return f"{self.identifier}"


### PR DESCRIPTION
This pull request fixes a `TypeError` in the` get_suggested_fulltext` function by adding exception handling for `TypeError`.

Previously, the function raised a `TypeError` when attempting to access a key in json_response that was `None` for chants that don't have a full text.

Also adds some black formatting changes.

Fixes #1690 