### PR TITLE
Source detail: Change Fragmentarium ID display

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -126,8 +126,8 @@
     {% endif %}
     
     {% if source.fragmentarium_id is not None %}
-        <dt>Fragment ID</dt>
-        <dd>{{ source.fragmentarium_id }}</dd>
+        <dt>Fragmentarium ID</dt>
+        <dd><a href="https://fragmentarium.ms/overview/{{ source.fragmentarium_id }}">{{ source.fragmentarium_id }}</a></dd>
     {% endif %}
 
     {% if source.dact_id is not None %}


### PR DESCRIPTION
Changes the displayed field name: `Fragment ID` -> `Fragmentarium ID`

Makes the `fragmentarium_id` contents into a link to the record on Fragmentarium.

Closes #1700 