### PR TITLE
fix(institution detail): Show alternate ID's on new lines

### DIFF
--- a/django/cantusdb_project/main_app/templates/institution_detail.html
+++ b/django/cantusdb_project/main_app/templates/institution_detail.html
@@ -1,65 +1,89 @@
 {% extends "single_column_with_search_bar.html" %}
-
 {% block title %}
-
 {% endblock %}
-
 {% block header %}
-    <h3>{{ institution.name }} {% if institution.siglum %}({{ institution.siglum }}){% endif %}</h3>
-    <h4>{% if institution.city %}{{ institution.city }}{% else %}[No City]{% endif %}, {{ institution.country }}</h4>
+    <h3>
+        {{ institution.name }}
+        {% if institution.siglum %}
+            ({{ institution.siglum }})
+        {% endif %}
+    </h3>
+    <h4>
+        {% if institution.city %}
+            {{ institution.city }}
+        {% else %}
+            [No City]
+        {% endif %}
+        , {{ institution.country }}
+    </h4>
 {% endblock %}
 {% block maincontent %}
     {% if institution_authorities %}
         <hr />
-        <div class="row">
-            <div class="col">
-                {% for authority in institution_authorities %}
+        {% for authority in institution_authorities %}
+            <div class="row">
+                <div class="col">
                     View this institution in <a href="{{ authority.1 }}">{{ authority.0 }}</a>
-                {% endfor %}
+                </div>
             </div>
-        </div>
+        {% endfor %}
     {% endif %}
     <hr />
     <div class="row">
         {% if num_cantus_sources > 0 %}
-        <div class="col">
-            <h5>Cantus Database</h5>
-            <table class="table table-bordered table-sm small">
-                <thead>
-                    <tr>
-                        <th>Sources</th>
-                    </tr>
-                </thead>
-                <tbody>
-                {% for source in cantus_sources %}
-                    <tr>
-                        <td>
-                            <a href="{% url "source-detail" source.id %}"><b>{{ source.shelfmark }}{% if source.name %} ("{{ source.name }}"){% endif %}</b></a>
-                        </td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% endif %}
-    
-        {% if num_bower_sources > 0 %}
             <div class="col">
-                <h5>Clavis Sequentiarum (Sequence Database by Calvin Bower)</h5>
+                <h5>
+                    Cantus Database
+                </h5>
                 <table class="table table-bordered table-sm small">
                     <thead>
-                    <tr>
-                        <th>Sources</th>
-                    </tr>
+                        <tr>
+                            <th>
+                                Sources
+                            </th>
+                        </tr>
                     </thead>
                     <tbody>
-                    {% for source in bower_sources %}
+                        {% for source in cantus_sources %}
+                            <tr>
+                                <td>
+                                    <a href="{% url "source-detail" source.id %}"><b>{{ source.shelfmark }}
+                                        {% if source.name %}
+                                            ("{{ source.name }}")
+                                        {% endif %}
+                                    </b></a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+        {% if num_bower_sources > 0 %}
+            <div class="col">
+                <h5>
+                    Clavis Sequentiarum (Sequence Database by Calvin Bower)
+                </h5>
+                <table class="table table-bordered table-sm small">
+                    <thead>
                         <tr>
-                            <td>
-                                <a href="{% url "source-detail" source.id %}"><b>{{ source.shelfmark }}{% if source.name %} ("{{ source.name }}"){% endif %}</b></a>
-                            </td>
+                            <th>
+                                Sources
+                            </th>
                         </tr>
-                    {% endfor %}
+                    </thead>
+                    <tbody>
+                        {% for source in bower_sources %}
+                            <tr>
+                                <td>
+                                    <a href="{% url "source-detail" source.id %}"><b>{{ source.shelfmark }}
+                                        {% if source.name %}
+                                            ("{{ source.name }}")
+                                        {% endif %}
+                                    </b></a>
+                                </td>
+                            </tr>
+                        {% endfor %}
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Improves formatting for institutions with multiple institution identifiers. Closes #1684.

_Old institution page_

![image](https://github.com/user-attachments/assets/1ac2a23b-1635-4517-a8d5-eaf81a15e6a1)

_New institution page_
![image](https://github.com/user-attachments/assets/9c4f46ba-940f-4fb8-a0a9-9a54a623b9b9)

