### PR TITLE
Create page for bulk adding of image links to source chants

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -7,8 +7,8 @@ from django.db.models import Q
 from django.contrib.admin.widgets import (
     FilteredSelectMultiple,
 )
-from django.forms.widgets import CheckboxSelectMultiple
-from dal import autocomplete
+from django.forms.widgets import CheckboxSelectMultiple, HiddenInput
+from dal import autocomplete  # type: ignore[import-untyped]
 from volpiano_display_utilities.cantus_text_syllabification import syllabify_text
 from volpiano_display_utilities.latin_word_syllabification import LatinError
 from .models import (
@@ -934,3 +934,36 @@ class AdminUserChangeForm(forms.ModelForm):
             'using <a href="../password/">this form</a>.'
         )
     )
+
+
+class ImageLinkForm(forms.Form):
+    """
+    Subclass of Django's Form class that creates the form we use for
+    adding image links to chants in a source.
+
+    Initialize the Form with a field for every folio in the source,
+    passed as the "initial" parameter, which is a dictionary with a key
+    for every folio and a blank value.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        initial = kwargs.get("initial")
+        if initial:
+            for folio in initial:
+                self.fields[folio] = forms.CharField(
+                    widget=HiddenInput(attrs={"class": "img-link-input"}),
+                    required=False,
+                )
+
+    def save(self, source: Source) -> None:
+        """
+        Save the image links to the database.
+
+        Args:
+            source: The source to which the image links belong.
+        """
+        cleaned_data = self.cleaned_data
+        for folio, image_link in cleaned_data.items():
+            if image_link != "":
+                source.chant_set.filter(folio=folio).update(image_link=image_link)

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -182,7 +182,7 @@ def user_can_view_user_detail(viewing_user: User, user: User) -> bool:
     return viewing_user.is_authenticated or user.is_indexer
 
 
-def user_can_manage_source_editors(user: User) -> bool:
+def user_can_manage_source_editors(user: Union[User, AnonymousUser]) -> bool:
     """
     Checks if the user has permission to change the editors assigned to a Source.
     Used in SourceDetailView.

--- a/django/cantusdb_project/main_app/templates/source_add_image_links.html
+++ b/django/cantusdb_project/main_app/templates/source_add_image_links.html
@@ -1,0 +1,133 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}
+    <title>Add Image Links to Source: {{ source.short_heading }}</title>
+{% endblock %}
+{% block scripts %}
+    <script src="{% static 'js/source_add_image_links.js' %}"></script>
+    <link rel="stylesheet" href="{% static 'css/source_add_image_links.css' %}" />
+{% endblock %}
+{% block content %}
+    <div class="container bg-white rounded">
+        <div class="row mt-4">
+            <div class="col">
+                <h4>
+                    Add Image Links to Source: <a href="{% url 'source-detail' source.id %}">{{ source.heading }}</a>
+                </h4>
+                <p class="small pt-3">
+                    Use this form to add image links from a csv file to the chants in this source. The csv file should
+                    contain two columns. The first column should be the folio on which the chant appears, matching the values
+                    of the "folio" field in the source inventory. The second column should be a url to an image of the chant,
+                    including the scheme (e.g., "https://") and domain. An optional header may be included.
+                </p>
+                <p class="small">
+                    The following checks will be performed on the csv file before it is uploaded:
+                </p>
+                <ol class="small">
+                    <li>A check that an image link is defined for every folio in the source.</li>
+                    <li>
+                        A check that image links are not defined for any folios that do not exist in the source.
+                    </li>
+                    <li>
+                        A check that no folios are duplicated in the file (e.g., a single
+                        folio does not have two image links defined).
+                    </li>
+                    <li>
+                        A check that either no image links are duplicated (every folio has a
+                        unique image link) or every image link is the same (image links to
+                        individual folios are not available).
+                    </li>
+                </ol>
+                <p class="small">
+                    Note: Files that fail these checks may still be uploaded but are provided as a simple
+                    validation for the user. For example, if a folio appears multiple times in the csv,
+                    the image link appearing last in the csv will be used. Sometimes, a mapping that fails
+                    these checks might be correct, such as when images show two facing folios.
+                </p>
+            </div>
+        </div>
+        <label for="imgLinksCSV" class="form-label">
+            Select CSV file containing image links
+        </label>
+        <div class="row mb-4">
+            <div class="col-4">
+                <input class="form-control form-control-sm"
+                       id="imgLinksCSV"
+                       type="file"
+                       accept=".csv" />
+                <form id="imgLinkForm" method="post">
+                    {% csrf_token %}
+                    {{ form }}
+                </form>
+            </div>
+            <div class="col">
+                <button id="imgLinkFormSubmitBtn"
+                        class="btn btn-sm btn-primary"
+                        form="imgLinkForm"
+                        type="submit">Save Image Links</button>
+            </div>
+        </div>
+        <div id="csvTestingDiv" class="row" hidden>
+            <div class="col-auto">
+                <table class="table table-sm table-borderless csv-testing-table small">
+                    <tbody>
+                        <tr>
+                            <td class="csv-testing-table-test">All image links provided</td>
+                            <td class="csv-testing-table-icon">
+                                <i id="folioCompletenessIcon"></i>
+                            </td>
+                            <td>
+                                <div id="folioCompletenessInstances" class="csv-testing-table-instances"></div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="csv-testing-table-test">Extra folios in CSV</td>
+                            <td class="csv-testing-table-icon">
+                                <i id="extraFoliosIcon"></i>
+                            </td>
+                            <td>
+                                <div id="extraFoliosInstances" class="csv-testing-table-instances"></div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Duplicate folios</td>
+                            <td class="csv-testing-table-icon">
+                                <i id="folioDuplicationIcon"></i>
+                            </td>
+                            <td>
+                                <div id="folioDuplicationInstances" class="csv-testing-table-instances"></div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Duplicate image links</td>
+                            <td class="csv-testing-table-icon">
+                                <i id="imageLinkDuplicationIcon"></i>
+                            </td>
+                            <td>
+                                <div id="imageLinkDuplicationInstances"
+                                     class="csv-testing-table-instances"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div id="csvPreviewDiv" hidden>
+            <h6>CSV Preview</h6>
+            <div id="csvPreviewDiv" class="row justify-content-center">
+                <div class="col-auto csv-preview-table">
+                    <table class="table table-sm table-bordered small">
+                        <thead>
+                            <tr>
+                                <th class="text-center img-link-preview-cell">Folio</th>
+                                <th class="text-center img-link-preview-cell">Image Link</th>
+                            </tr>
+                        </thead>
+                        <tbody id="csvPreviewBody">
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -26,6 +26,7 @@ from main_app.tests.make_fakes import (
     add_accents_to_string,
 )
 from main_app.tests.mixins import HTMLContentsTestMixin
+from users.models import User
 
 # Create a Faker instance with locale set to Latin
 faker = Faker("la")
@@ -1198,3 +1199,114 @@ class SourceListViewTest(TestCase):
             self.assertEqual(
                 list(reversed(expected_source_order)), list(response_sources_reverse)
             )
+
+
+class SourceAddImageLinksViewTest(TestCase):
+    auth_user: User
+    non_auth_user: User
+    source: Source
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        user_model = get_user_model()
+        cls.auth_user = user_model.objects.create(
+            email="authuser@test.com", password="12345", is_staff=True
+        )
+        cls.non_auth_user = user_model.objects.create(
+            email="nonauthuser@test.com", password="12345", is_staff=False
+        )
+        cls.source = make_fake_source(published=True)
+        for folio in ["001r", "001v", "003", "004A"]:
+            make_fake_chant(source=cls.source, folio=folio, image_link=None)
+        # Make a second chant for one of the folios, with an existing image link.
+        # We'll update this image_link in the process.
+        make_fake_chant(
+            source=cls.source, folio="001v", image_link="https://i-already-exist.com"
+        )
+        # Make a final chant for a different folio with an existing image link. We
+        # won't update this image_link in the process.
+        make_fake_chant(
+            source=cls.source, folio="004B", image_link="https://i-already-exist.com/2"
+        )
+
+    def test_permissions(self) -> None:
+        with self.subTest("Test unauthenticated user"):
+            response = self.client.get(
+                reverse("source-add-image-links", args=[self.source.id])
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertRedirects(
+                response,
+                f"{reverse('login')}?next={reverse('source-add-image-links', args=[self.source.id])}",
+                status_code=302,
+                target_status_code=200,
+            )
+            response = self.client.post(
+                reverse("source-add-image-links", args=[self.source.id])
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertRedirects(
+                response,
+                f"{reverse('login')}?next={reverse('source-add-image-links', args=[self.source.id])}",
+                status_code=302,
+                target_status_code=200,
+            )
+        with self.subTest("Test non-staff user"):
+            self.client.force_login(self.non_auth_user)
+            response = self.client.get(
+                reverse("source-add-image-links", args=[self.source.id])
+            )
+            self.assertEqual(response.status_code, 403)
+            response = self.client.post(
+                reverse("source-add-image-links", args=[self.source.id])
+            )
+            self.assertEqual(response.status_code, 403)
+        with self.subTest("Test staff user"):
+            self.client.force_login(self.auth_user)
+            response = self.client.get(
+                reverse("source-add-image-links", args=[self.source.id])
+            )
+            self.assertEqual(response.status_code, 200)
+            # Post redirect is tested in the `test_form` method
+
+    def test_form(self) -> None:
+        with self.subTest("Test form fields"):
+            self.client.force_login(self.auth_user)
+            response = self.client.get(
+                reverse("source-add-image-links", args=[self.source.id])
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertTemplateUsed(response, "source_add_image_links.html")
+            form = response.context["form"]
+            self.assertListEqual(
+                list(form.fields.keys()), ["001r", "001v", "003", "004A", "004B"]
+            )
+        with self.subTest("Test form submission"):
+            response = self.client.post(
+                reverse("source-add-image-links", args=[self.source.id]),
+                {
+                    "001r": "https://example.com/001r",
+                    "001v": "https://example.com/001v",
+                    "004A": "https://example.com/004A",
+                },
+            )
+            self.assertRedirects(
+                response,
+                reverse("source-detail", args=[self.source.id]),
+                status_code=302,
+                target_status_code=200,
+            )
+        with self.subTest("Test saved data"):
+            chants_001r = Chant.objects.filter(source=self.source, folio="001r").all()
+            self.assertEqual(len(chants_001r), 1)
+            self.assertEqual(chants_001r[0].image_link, "https://example.com/001r")
+            chants_001v = Chant.objects.filter(source=self.source, folio="001v").all()
+            self.assertEqual(len(chants_001v), 2)
+            for chant in chants_001v:
+                self.assertEqual(chant.image_link, "https://example.com/001v")
+            chants_003 = Chant.objects.filter(source=self.source, folio="003").all()
+            self.assertEqual(len(chants_003), 1)
+            self.assertIsNone(chants_003[0].image_link)
+            chants_004B = Chant.objects.filter(source=self.source, folio="004B").all()
+            self.assertEqual(len(chants_004B), 1)
+            self.assertEqual(chants_004B[0].image_link, "https://i-already-exist.com/2")

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -85,6 +85,7 @@ from main_app.views.source import (
     SourceListView,
     SourceDeleteView,
     SourceInventoryView,
+    SourceAddImageLinksView,
 )
 from main_app.views.user import (
     CustomLogoutView,
@@ -363,6 +364,11 @@ urlpatterns = [
         "source/<int:pk>/delete",
         SourceDeleteView.as_view(),
         name="source-delete",
+    ),
+    path(
+        "source/<int:source_id>/add-image-links",
+        SourceAddImageLinksView.as_view(),
+        name="source-add-image-links",
     ),
     # melody
     path(

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -6,7 +6,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q, Prefetch, Value
 from django.db.models import QuerySet
-from django.http import HttpResponseRedirect, Http404
+from django.http import HttpResponseRedirect, Http404, HttpResponse, HttpRequest
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.generic import (
@@ -16,12 +16,14 @@ from django.views.generic import (
     UpdateView,
     DeleteView,
     TemplateView,
+    FormView,
 )
-
+from django.views.generic.detail import SingleObjectMixin
 from main_app.forms import (
     SourceCreateForm,
     SourceEditForm,
     SourceBrowseChantsProofreadForm,
+    ImageLinkForm,
 )
 from main_app.models import (
     Century,
@@ -39,11 +41,10 @@ from main_app.permissions import (
     user_can_view_source,
     user_can_manage_source_editors,
     user_can_proofread_source,
-)
-from main_app.views.chant import (
-    get_feast_selector_options,
     user_can_edit_chants_in_source,
 )
+
+from main_app.views.chant import get_feast_selector_options
 
 CANTUS_SEGMENT_ID = 4063
 BOWER_SEGMENT_ID = 4064
@@ -248,7 +249,7 @@ class SourceDetailView(DetailView):
         return context
 
 
-class SourceListView(ListView):  # type: ignore
+class SourceListView(ListView):
     model = Source
     paginate_by = 100
     context_object_name = "sources"
@@ -554,3 +555,46 @@ class SourceInventoryView(TemplateView):
         context["chants"] = queryset
 
         return context
+
+
+class SourceAddImageLinksView(UserPassesTestMixin, SingleObjectMixin, FormView):  # type: ignore
+    template_name = "source_add_image_links.html"
+    pk_url_kwarg = "source_id"
+    queryset = Source.objects.select_related("holding_institution")
+    context_object_name = "source"
+    form_class = ImageLinkForm
+    object: Source
+    http_method_names = ["get", "post"]
+
+    def test_func(self) -> bool:
+        return user_can_manage_source_editors(self.request.user)
+
+    def get_success_url(self) -> str:
+        return reverse("source-detail", args=[self.object.id])
+
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.object = self.get_object()
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.object = self.get_object()
+        return super().post(request, *args, **kwargs)
+
+    def get_initial(self) -> dict[str, Any]:
+        """
+        Set the initial data required by the ImageLinkForm
+        on GET requests.
+        """
+        folios: QuerySet[Chant, Optional[str]] = (
+            self.object.chant_set.values_list("folio", flat=True)
+            .distinct()
+            .order_by("folio")
+        )
+        return {folio: "" for folio in folios if folio}
+
+    def form_valid(self, form: ImageLinkForm) -> HttpResponseRedirect:
+        """
+        Save the image links to the database.
+        """
+        form.save(self.object)
+        return HttpResponseRedirect(self.get_success_url())

--- a/django/cantusdb_project/static/css/source_add_image_links.css
+++ b/django/cantusdb_project/static/css/source_add_image_links.css
@@ -1,0 +1,27 @@
+td.img-link-preview-cell {
+    padding-left: 4rem;
+    padding-right: 4rem;
+}
+
+.csv-testing-table {
+    table-layout: fixed;
+    width: 100%;
+}
+
+.csv-testing-table-test {
+    width: 30%;
+}
+
+.csv-testing-table-icon {
+    width: 15%;
+}
+
+.csv-testing-table-instances {
+    max-height: 5em;
+    overflow-y: scroll;
+}
+
+.csv-preview-table {
+    max-height: 50em;
+    overflow-y: scroll;
+}

--- a/django/cantusdb_project/static/js/source_add_image_links.js
+++ b/django/cantusdb_project/static/js/source_add_image_links.js
@@ -1,0 +1,147 @@
+function addPreviewTableRow(tableBody, folio, imageLink) {
+    // Add a row to the preview table with the folio and image link.
+    const tr = document.createElement('tr');
+    const tdFolio = document.createElement('td');
+    tdFolio.textContent = folio;
+    tdFolio.classList.add('img-link-preview-cell');
+    tr.appendChild(tdFolio);
+    const tdLink = document.createElement('td');
+    const a = document.createElement('a');
+    a.href = imageLink;
+    a.textContent = imageLink;
+    a.target = '_blank';
+    tdLink.appendChild(a);
+    tdLink.classList.add('img-link-preview-cell');
+    tr.appendChild(tdLink);
+    tableBody.appendChild(tr);
+};
+
+function getFormImgLinkInputs(form) {
+    // Get all the input elements in the form that have the 
+    // 'img-link-input' class and return them as a map of the form
+    // {folio: inputElement}.
+    const imgLinkInputs = form.getElementsByClassName('img-link-input');
+    const imgLinkMap = {};
+    for (let i = 0; i < imgLinkInputs.length; i++) {
+        const folio = imgLinkInputs[i].name;
+        imgLinkMap[folio] = imgLinkInputs[i];
+    }
+    return imgLinkMap;
+};
+
+
+function parseAndPreviewImageLinkCSV(csv, imgLinkInputs) {
+    // Parse the passed CSV file and display it in a table. 
+    // Return two arrays: one with the folios and one with the image links
+    // for use in testing functions.
+    const rows = csv.split('\n');
+    const columns = rows[0].split(',');
+    // Check if a header row is present, by checking whether
+    // the second column is a URL
+    const start = columns[1].startsWith('http') ? 0 : 1;
+    const tableBody = document.getElementById('csvPreviewBody');
+    // Clear the table and fill in the new data
+    // using this rough CSV parser. Note that since this
+    // function is meant to be used by just a few administrators,
+    // we aren't going to worry too much about parsing edge cases. 
+    // For example, note that we just parse at the first comma to split
+    // columns.
+    tableBody.innerHTML = '';
+    const parsedCSV = [];
+    for (let i = start; i < rows.length; i++) {
+        const row = rows[i];
+        let [folio, imageLink] = row.split(',', 2);
+        folio = folio.trim();
+        imageLink = imageLink.trim();
+        addPreviewTableRow(tableBody, folio, imageLink);
+        const folioInput = imgLinkInputs[folio];
+        if (folioInput) {
+            folioInput.value = imageLink;
+        }
+        parsedCSV.push({ "folio": folio, "imageLink": imageLink });
+    }
+    document.getElementById("csvPreviewDiv").hidden = false;
+    return parsedCSV;
+}
+
+function getFoliosAtDuplicatedValues(array) {
+    // Given an array of objects with imageLink and folio keys,
+    // parsed from the CSV file, return an array of folios that have
+    // been duplicated and an array of folios that have duplicated image links.
+    const folioCounts = {};
+    const imageLinkCounts = {};
+    for (let i = 0; i < array.length; i++) {
+        const folio = array[i].folio;
+        const imageLink = array[i].imageLink;
+        folioCounts[folio] = (folioCounts[folio] || 0) + 1;
+        imageLinkCounts[imageLink] = (imageLinkCounts[imageLink] || 0) + 1;
+    }
+    const folioDuplicates = Object.keys(folioCounts).filter(folio => folioCounts[folio] > 1);
+    const imageLinkDuplicates = Object.keys(imageLinkCounts).filter(imageLink => imageLinkCounts[imageLink] > 1);
+    const folioWImageDuplicates = [];
+    for (let i = 0; i < array.length; i++) {
+        if (imageLinkDuplicates.includes(array[i].imageLink)) {
+            folioWImageDuplicates.push(array[i].folio);
+        }
+    }
+    return [folioDuplicates.sort(), folioWImageDuplicates.sort()];
+}
+
+function displayCheckResults(checkName, failingFolios, error_message, success_message = '') {
+    const iconCell = document.getElementById(`${checkName}Icon`);
+    const instancesCell = document.getElementById(`${checkName}Instances`);
+    if (failingFolios.length === 0) {
+        iconCell.className = 'bi bi-check-circle-fill text-success';
+        instancesCell.textContent = success_message;
+    } else {
+        iconCell.className = 'bi bi-exclamation-circle-fill text-warning';
+        instancesCell.textContent = `${error_message}: ${failingFolios.join(', ')}`;
+    }
+};
+
+function csvLoadCallback(csv) {
+    // Callback function for when a CSV file is loaded.
+    // Parse the CSV file and display it in the table,
+    // then run checks for completeness and uniqueness.
+    const imgLinkInputs = getFormImgLinkInputs(document.getElementById('imgLinkForm'));
+    const sourceFolios = Object.keys(imgLinkInputs);
+    const parsedCSV = parseAndPreviewImageLinkCSV(csv, imgLinkInputs);
+    const [dupFolios, foliosWDupImageLinks] = getFoliosAtDuplicatedValues(parsedCSV);
+    // Display duplicated folios, if they exist.
+    displayCheckResults('folioDuplication', dupFolios, "The following folios are duplicated in the CSV");
+    // Check whether there are any folios in the source that are not in the CSV
+    // Display these folios with missing Links in the preview table.
+    const csvFolios = parsedCSV.map(x => x.folio);
+    const missingLinks = sourceFolios.filter(folio => !csvFolios.includes(folio));
+    displayCheckResults('folioCompleteness', missingLinks, "Image links missing for the following folios");
+    // Check whether there are any folios in the CSV that are not in the source
+    // Display these folios as extra folios in the preview table.
+    const extraFolios = csvFolios.filter(folio => !sourceFolios.includes(folio));
+    displayCheckResults('extraFolios', extraFolios.sort(), "The following folios do not exist in the source");
+    // We expect one of two cases for the value of image links:
+    // 1. All image links are identical
+    // 2. All image links are unique
+    // Note that a mapping might be valid that does not conform to these cases
+    // (for example, if every image link shows two facing folios). In that case, the
+    // check will fail and we rely on the administrator to check the data.
+    if (foliosWDupImageLinks.length === csvFolios.length) {
+        displayCheckResults('imageLinkDuplication', [], "", "All image links identical");
+    } else {
+        displayCheckResults('imageLinkDuplication', foliosWDupImageLinks, "Image links duplicated on the following subset of folios", "No image links duplicated");
+    }
+    document.getElementById('csvTestingDiv').hidden = false;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    // Add listener to the file input field to parse and display the CSV file
+    document.getElementById('imgLinksCSV').addEventListener('change', function (e) {
+        const file = e.target.files[0];
+        const reader = new FileReader();
+        reader.onload = function (e) {
+            const csv = e.target.result;
+            csvLoadCallback(csv);
+        };
+        reader.readAsText(file);
+    });
+}
+);

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,13 +19,13 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "astroid"
-version = "3.3.5"
+version = "3.3.6"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
 python-versions = ">=3.9.0"
 files = [
-    {file = "astroid-3.3.5-py3-none-any.whl", hash = "sha256:a9d1c946ada25098d790e079ba2a1b112157278f3fb7e718ae6a9252f5835dc8"},
-    {file = "astroid-3.3.5.tar.gz", hash = "sha256:5cfc40ae9f68311075d27ef68a4841bdc5cc7f6cf86671b49f00607d30188e2d"},
+    {file = "astroid-3.3.6-py3-none-any.whl", hash = "sha256:db676dc4f3ae6bfe31cda227dc60e03438378d7a896aec57422c95634e8d722f"},
+    {file = "astroid-3.3.6.tar.gz", hash = "sha256:6aaea045f938c735ead292204afdb977a36e989522b7833ef6fea94de743f442"},
 ]
 
 [package.dependencies]
@@ -325,6 +325,21 @@ jsbeautifier = "*"
 six = ">=1.13.0"
 
 [[package]]
+name = "debugpy"
+version = "1.8.5+3.ga2f80817"
+description = "An implementation of the Debug Adapter Protocol for Python"
+optional = false
+python-versions = ">=3.8"
+files = []
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/microsoft/debugpy"
+reference = "a2f80817a168e1ed6cc60b4f1c70fdb24e40bca5"
+resolved_reference = "a2f80817a168e1ed6cc60b4f1c70fdb24e40bca5"
+
+[[package]]
 name = "dill"
 version = "0.3.9"
 description = "serialize all of Python"
@@ -451,30 +466,27 @@ django = ">=3.2"
 
 [[package]]
 name = "django-stubs"
-version = "5.0.0"
+version = "5.1.1"
 description = "Mypy stubs for Django"
 optional = false
 python-versions = ">=3.8"
-files = []
-develop = false
+files = [
+    {file = "django_stubs-5.1.1-py3-none-any.whl", hash = "sha256:c4dc64260bd72e6d32b9e536e8dd0d9247922f0271f82d1d5132a18f24b388ac"},
+    {file = "django_stubs-5.1.1.tar.gz", hash = "sha256:126d354bbdff4906c4e93e6361197f6fbfb6231c3df6def85a291dae6f9f577b"},
+]
 
 [package.dependencies]
 asgiref = "*"
 django = "*"
-django-stubs-ext = ">=5.0.0"
+django-stubs-ext = ">=5.1.1"
 tomli = {version = "*", markers = "python_version < \"3.11\""}
 types-PyYAML = "*"
 typing-extensions = ">=4.11.0"
 
 [package.extras]
-compatible-mypy = ["mypy (>=1.10.0,<1.11.0)"]
+compatible-mypy = ["mypy (>=1.12,<1.14)"]
+oracle = ["oracledb"]
 redis = ["redis"]
-
-[package.source]
-type = "git"
-url = "https://github.com/typeddjango/django-stubs.git"
-reference = "4a5b0656be5ccfb961e4e32f4a99756eaf57bb1d"
-resolved_reference = "4a5b0656be5ccfb961e4e32f4a99756eaf57bb1d"
 
 [[package]]
 name = "django-stubs-ext"
@@ -1335,13 +1347,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "six"
-version = "1.16.0"
+version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -1357,13 +1369,13 @@ files = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.2"
+version = "0.5.3"
 description = "A non-validating SQL parser."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sqlparse-0.5.2-py3-none-any.whl", hash = "sha256:e99bc85c78160918c3e1d9230834ab8d80fc06c59d03f8db2618f65f65dda55e"},
-    {file = "sqlparse-0.5.2.tar.gz", hash = "sha256:9e37b35e16d1cc652a2545f0997c1deb23ea28fa1f3eefe609eee3063c3b105f"},
+    {file = "sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"},
+    {file = "sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"},
 ]
 
 [package.extras]
@@ -1627,4 +1639,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "aded95a6c34c3601d2711f58e8a581c013aec5ce88ab3c1604a4323baa34e764"
+content-hash = "cee0547c269afa5e969c061cfbb0ee4842015f1df6103055baadfa89edf814d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,14 @@ black = "^24.4.1"
 mypy = "^1.10.0"
 pylint = "^3.3.0"
 pylint-django = "^2.5.5"
-django-stubs = {git = "https://github.com/typeddjango/django-stubs.git", rev = "4a5b0656be5ccfb961e4e32f4a99756eaf57bb1d"}
+django-stubs = "^5.1.1"
 django-extensions = "^3.2.3"
 werkzeug = "^3.0.6"
 types-requests = "^2.32.0.20240712"
 djlint = "^1.36.3"
 beautifulsoup4 = "^4.12.3"
 lxml = "^5.3.0"
+debugpy = { git = "https://github.com/microsoft/debugpy", rev = "a2f80817a168e1ed6cc60b4f1c70fdb24e40bca5"}
 
 
 [build-system]


### PR DESCRIPTION
Adds a new view to update image links on chants in a source based on a csv.

The changes to the `Chant` model made by this view are not captured in the `Revision` (i.e. as part of the object history). The fundamental issue is that saving every `Chant` in a `Source` (a requirement for a version to be saved) takes too long to keep the user waiting. We might eventually use some sort of task management to handle this, but for now, we don't create the revisions.

Screenshot of new `add-image-links` page:
![image](https://github.com/user-attachments/assets/32b198f9-e10b-481c-887f-a79d6ef94bfc)

Or, the same page with a different set of image links:
![image](https://github.com/user-attachments/assets/bea6a126-46b1-43d6-953c-52a613a71062)

Closes #940.

Makes updates/additions to some development dependencies. `django-stubs` is updated and `debugpy` (to serve applications on a debug server that can connect to VSCode's debug functionality) is added.