### PR TITLE
Add quoted search functionality on browse sources page

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -1006,7 +1006,15 @@ class SourceListViewTest(TestCase):
             published=True,
         )
         search_term = get_random_search_term(source.shelfmark)
+
+        # Partial matching
         response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Exact matching
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.shelfmark}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
         # Test that postgres searches unaccented version of title
@@ -1014,7 +1022,9 @@ class SourceListViewTest(TestCase):
         accented_title = add_accents_to_string(unaccented_title)
         source.title = accented_title
         source.save()
-        response = self.client.get(reverse("source-list"), {"general": search_term})
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.title}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
     def test_search_by_shelfmark(self):
@@ -1023,7 +1033,15 @@ class SourceListViewTest(TestCase):
             published=True, shelfmark="title", holding_institution=hinst
         )
         search_term = get_random_search_term(source.shelfmark)
+
+        # Partial matching
         response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Exact matching
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.shelfmark}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
         # Test that postgres searches unaccented version of shelfmark
@@ -1031,7 +1049,9 @@ class SourceListViewTest(TestCase):
         accented_siglum = add_accents_to_string(unaccented_siglum)
         source.siglum = accented_siglum
         source.save()
-        response = self.client.get(reverse("source-list"), {"general": search_term})
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.siglum}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
     def test_search_by_description(self):
@@ -1041,15 +1061,25 @@ class SourceListViewTest(TestCase):
             shelfmark="title",
         )
         search_term = get_random_search_term(source.description)
+
+        # Partial matching
         response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Exact matching
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.description}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
         # Test that postgres searches unaccented version of description
         unaccented_description = source.description
         accented_description = add_accents_to_string(unaccented_description)
-        source.title = accented_description
+        source.description = accented_description
         source.save()
-        response = self.client.get(reverse("source-list"), {"general": search_term})
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.description}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
     def test_search_by_summary(self):
@@ -1059,15 +1089,25 @@ class SourceListViewTest(TestCase):
             shelfmark="title",
         )
         search_term = get_random_search_term(source.summary)
+
+        # Partial matching
         response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Exact matching
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.summary}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
         # Test that postgres searches unaccented version of summary
         unaccented_summary = source.summary
         accented_summary = add_accents_to_string(unaccented_summary)
-        source.title = accented_summary
+        source.summary = accented_summary
         source.save()
-        response = self.client.get(reverse("source-list"), {"general": search_term})
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.summary}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
     def test_search_by_indexing_notes(self):
@@ -1078,24 +1118,41 @@ class SourceListViewTest(TestCase):
             shelfmark="title",
         )
         search_term = get_random_search_term(source.indexing_notes)
+
+        # Partial matching
         response = self.client.get(reverse("source-list"), {"indexing": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Exact matching
+        response = self.client.get(
+            reverse("source-list"), {"indexing": f'"{source.indexing_notes}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
         # Test that postgres searches unaccented version of indexing_notes
         unaccented_indexing_notes = source.indexing_notes
         accented_indexing_notes = add_accents_to_string(unaccented_indexing_notes)
-        source.shelfmark = accented_indexing_notes
+        source.indexing_notes = accented_indexing_notes
         source.save()
-        response = self.client.get(reverse("source-list"), {"general": search_term})
+        response = self.client.get(
+            reverse("source-list"), {"indexing": f'"{source.indexing_notes}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_name(self) -> None:
+    def test_search_by_name(self):
         source = make_fake_source(
             name=faker.sentence(), published=True, shelfmark="title"
         )
-        # We know source.name is not None because it was just set
-        search_term = get_random_search_term(source.name)  # type: ignore[arg-type]
+        search_term = get_random_search_term(source.name)
+
+        # Partial matching
         response = self.client.get(reverse("source-list"), {"general": search_term})
+        self.assertIn(source, response.context["sources"])
+
+        # Exact matching
+        response = self.client.get(
+            reverse("source-list"), {"general": f'"{source.name}"'}
+        )
         self.assertIn(source, response.context["sources"])
 
     def test_ordering(self) -> None:

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -999,7 +999,7 @@ class SourceListViewTest(TestCase):
             self.assertNotIn(manuscript_source, sources)
             self.assertIn(print_source, sources)
 
-    def test_search_by_title(self):
+    def test_search_by_title(self) -> None:
         """The "general search" field searches in `title`, `shelfmark`, `description`, and `summary`"""
         source = make_fake_source(
             shelfmark=faker.sentence(),
@@ -1027,7 +1027,7 @@ class SourceListViewTest(TestCase):
         )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_shelfmark(self):
+    def test_search_by_shelfmark(self) -> None:
         hinst = make_fake_institution(name="Fake Institution", siglum="FA-Ke")
         source = make_fake_source(
             published=True, shelfmark="title", holding_institution=hinst
@@ -1054,7 +1054,7 @@ class SourceListViewTest(TestCase):
         )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_description(self):
+    def test_search_by_description(self) -> None:
         source = make_fake_source(
             description=faker.sentence(),
             published=True,
@@ -1082,7 +1082,7 @@ class SourceListViewTest(TestCase):
         )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_summary(self):
+    def test_search_by_summary(self) -> None:
         source = make_fake_source(
             summary=faker.sentence(),
             published=True,
@@ -1110,7 +1110,7 @@ class SourceListViewTest(TestCase):
         )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_indexing_notes(self):
+    def test_search_by_indexing_notes(self) -> None:
         """The "indexing notes" field searches in `indexing_notes` and indexer/editor related fields"""
         source = make_fake_source(
             indexing_notes=faker.sentence(),
@@ -1139,7 +1139,7 @@ class SourceListViewTest(TestCase):
         )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_name(self):
+    def test_search_by_name(self) -> None:
         source = make_fake_source(
             name=faker.sentence(), published=True, shelfmark="title"
         )

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -1139,7 +1139,7 @@ class SourceListViewTest(TestCase):
         )
         self.assertIn(source, response.context["sources"])
 
-    def test_search_by_name(self):
+    def test_search_by_name(self) -> None:
         source = make_fake_source(
             name=faker.sentence(), published=True, shelfmark="title"
         )

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -331,7 +331,9 @@ class SourceListView(ListView):  # type: ignore
             # field, allowing for a more flexible search, and a field needs
             # to match only one of the terms
             for term in general_search_terms:
-                holding_institution_q |= Q(holding_institution__name__icontains=term)
+                holding_institution_q |= Q(
+                    holding_institution__name__unaccent__icontains=term
+                )
                 holding_institution_city_q |= Q(
                     holding_institution__city__icontains=term
                 )

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -319,7 +319,7 @@ class SourceListView(ListView):  # type: ignore
                 r'"(.*?)"', general_str
             )  # Extract terms in quotes
             unquoted_terms = re.findall(
-                r"\b[\w-]+\b", re.sub(r'"(.*?)"', "", general_str)
+                r"\b[\w,-.]+\b", re.sub(r'"(.*?)"', "", general_str)
             )
 
             # We need a Q Object for each field we're gonna look into
@@ -342,25 +342,27 @@ class SourceListView(ListView):  # type: ignore
                     holding_institution__name__unaccent__icontains=term
                 )
                 holding_institution_city_q |= Q(
-                    holding_institution__city__icontains=term
+                    holding_institution__city__unaccent__icontains=term
                 )
                 shelfmark_q |= Q(shelfmark__unaccent__icontains=term)
                 siglum_q |= Q(holding_institution__siglum__unaccent__icontains=term)
                 description_q |= Q(description__unaccent__icontains=term)
                 summary_q |= Q(summary__unaccent__icontains=term)
-                name_q |= Q(name__icontains=term)
+                name_q |= Q(name__unaccent__icontains=term)
 
             # Add quoted terms to the Q object with exact matching (iexact)
             for term in quoted_terms:
                 holding_institution_q |= Q(
                     holding_institution__name__unaccent__iexact=term
                 )
-                holding_institution_city_q |= Q(holding_institution__city__iexact=term)
+                holding_institution_city_q |= Q(
+                    holding_institution__city__unaccent__iexact=term
+                )
                 shelfmark_q |= Q(shelfmark__unaccent__iexact=term)
                 siglum_q |= Q(holding_institution__siglum__unaccent__iexact=term)
                 description_q |= Q(description__unaccent__iexact=term)
                 summary_q |= Q(summary__unaccent__iexact=term)
-                name_q |= Q(name__iexact=term)
+                name_q |= Q(name__unaccent__iexact=term)
 
             # Combine all Q objects with OR
             general_search_q = (

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -354,16 +354,16 @@ class SourceListView(ListView):
             # Add quoted terms to the Q object with exact matching (iexact)
             for term in quoted_terms:
                 holding_institution_q |= Q(
-                    holding_institution__name__unaccent__iexact=term
+                    holding_institution__name__unaccent__icontains=term
                 )
                 holding_institution_city_q |= Q(
-                    holding_institution__city__unaccent__iexact=term
+                    holding_institution__city__unaccent__icontains=term
                 )
-                shelfmark_q |= Q(shelfmark__unaccent__iexact=term)
-                siglum_q |= Q(holding_institution__siglum__unaccent__iexact=term)
-                description_q |= Q(description__unaccent__iexact=term)
-                summary_q |= Q(summary__unaccent__iexact=term)
-                name_q |= Q(name__unaccent__iexact=term)
+                shelfmark_q |= Q(shelfmark__unaccent__icontains=term)
+                siglum_q |= Q(holding_institution__siglum__unaccent__icontains=term)
+                description_q |= Q(description__unaccent__icontains=term)
+                summary_q |= Q(summary__unaccent__icontains=term)
+                name_q |= Q(name__unaccent__icontains=term)
 
             # Combine all Q objects with OR
             general_search_q = (

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from django.contrib import messages
@@ -310,8 +311,17 @@ class SourceListView(ListView):  # type: ignore
             q_obj_filter &= Q(production_method=production_method)
 
         if general_str := self.request.GET.get("general"):
-            # Strip spaces at the beginning and end. Then make list of terms split on spaces
-            general_search_terms = general_str.strip(" ").split(" ")
+            # Strip spaces at the beginning and end
+            general_str = general_str.strip()
+
+            # Use regex to extract quoted and unquoted terms
+            quoted_terms = re.findall(
+                r'"(.*?)"', general_str
+            )  # Extract terms in quotes
+            unquoted_terms = re.findall(
+                r"\b[\w-]+\b", re.sub(r'"(.*?)"', "", general_str)
+            )
+
             # We need a Q Object for each field we're gonna look into
             shelfmark_q = Q()
             siglum_q = Q()
@@ -326,11 +336,8 @@ class SourceListView(ListView):  # type: ignore
             # provenance_q = Q()
             summary_q = Q()
 
-            # For each term, add it to the Q object of each field with an OR operation.
-            # We split the terms so that the words can be separated in the actual
-            # field, allowing for a more flexible search, and a field needs
-            # to match only one of the terms
-            for term in general_search_terms:
+            # Add unquoted terms to the Q object with partial matching (icontains)
+            for term in unquoted_terms:
                 holding_institution_q |= Q(
                     holding_institution__name__unaccent__icontains=term
                 )
@@ -342,13 +349,20 @@ class SourceListView(ListView):  # type: ignore
                 description_q |= Q(description__unaccent__icontains=term)
                 summary_q |= Q(summary__unaccent__icontains=term)
                 name_q |= Q(name__icontains=term)
-                # provenance_q |= Q(provenance__name__icontains=term)
-            # All the Q objects are put together with OR.
-            # The end result is that at least one term has to match in at least one
-            # field
-            # general_search_q = (
-            #     title_q | siglum_q | description_q | provenance_q
-            # )
+
+            # Add quoted terms to the Q object with exact matching (iexact)
+            for term in quoted_terms:
+                holding_institution_q |= Q(
+                    holding_institution__name__unaccent__iexact=term
+                )
+                holding_institution_city_q |= Q(holding_institution__city__iexact=term)
+                shelfmark_q |= Q(shelfmark__unaccent__iexact=term)
+                siglum_q |= Q(holding_institution__siglum__unaccent__iexact=term)
+                description_q |= Q(description__unaccent__iexact=term)
+                summary_q |= Q(summary__unaccent__iexact=term)
+                name_q |= Q(name__iexact=term)
+
+            # Combine all Q objects with OR
             general_search_q = (
                 shelfmark_q
                 | siglum_q
@@ -358,6 +372,8 @@ class SourceListView(ListView):  # type: ignore
                 | holding_institution_city_q
                 | name_q
             )
+
+            # Apply the general search Q object to the filter
             q_obj_filter &= general_search_q
 
         # For the indexing notes search we follow the same procedure as above but with


### PR DESCRIPTION
Fixed some bugs in the search functionality on the Browse Sources page by adding support for quoted phrase matching, allowing exact matches for phrases (e.g., "North Vancouver"). 

Enabled unaccented search terms to match fields with or without accents, applying both partial (icontains) and exact (iexact) matching logic across key fields like institution name, city, shelfmark, and more. 

Updated the query logic to handle quoted and unquoted terms separately using regex for better granularity and consistency.

Added tests for these changes.

Resolves #1632. We should proceed with #435 as part of a more robust fix for these types of issues.