### PR TITLE
Remove "no results" messages on default chant search page

### DIFF
--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -3,6 +3,9 @@
 {% block title %}<title>Search Chants | Cantus Database</title>{% endblock %}
 {% block scripts %}<script src="/static/js/chant_search.js"></script>{% endblock %}
 {% block header %}<h3>Search Chants</h3>{% endblock %}
+{% block results_count %}
+    {% if not query_empty %}{{ block.super }}{% endif %}
+{% endblock %}
 {% block list_filter_form %}
     {% if source %}
         <p>
@@ -340,4 +343,7 @@
             </tbody>
         </table>
     </div>
+{% endblock %}
+{% block no_results_msg %}
+    {% if not query_empty %}{{ block.super }}{% endif %}
 {% endblock %}

--- a/django/cantusdb_project/main_app/templates/filterable_table_with_search_bar.html
+++ b/django/cantusdb_project/main_app/templates/filterable_table_with_search_bar.html
@@ -1,8 +1,10 @@
 {% extends "single_column_with_search_bar.html" %}
 {% load humanize %}
 {# A template for use with list pages. The template introduces the following blocks:
+    - results_count: a block for the object count displayed beneath the header
     - list_filter_form: a block for the form displayed above the table that powers list/table filtering
     - list_table: a block for the table that displays the list
+    - no_results_msg: a block for the message displayed when no results are found
     A header block is inherited from `single_column_with_search_bar.html` and is displayed alongside
     global search bar at the top of the page.
     This template also handles display of an object count shown beneath the header: "Displaying x-y of N
@@ -12,11 +14,13 @@
     Pagination is included at the bottom of the page if results span more than one page.
 #}
 {% block maincontent %}
-    <div class="row">
-        <p class="col small mx-0">
-            Displaying {{ page_obj.start_index|intcomma }}-{{ page_obj.end_index|intcomma }} of <b>{{ page_obj.paginator.count|intcomma }}</b> {{ view.context_object_name }}.
-        </p>
-    </div>
+    {% block results_count %}
+        <div class="row">
+            <p class="col small mx-0">
+                Displaying {{ page_obj.start_index|intcomma }}-{{ page_obj.end_index|intcomma }} of <b>{{ page_obj.paginator.count|intcomma }}</b> {{ view.context_object_name }}.
+            </p>
+        </div>
+    {% endblock %}
     <div class="row mb-3">
         <div class="col">
             {% block list_filter_form %}{% endblock %}
@@ -31,7 +35,9 @@
     {% else %}
         <div class="row mt-4">
             <div class="col">
-                <p class="text-center">No {{ view.context_object_name }} found.</p>
+                {% block no_results_msg %}
+                    <p class="text-center">No {{ view.context_object_name }} found.</p>
+                {% endblock %}
             </div>
         </div>
     {% endif %}

--- a/django/cantusdb_project/main_app/templates/filterable_table_with_search_bar.html
+++ b/django/cantusdb_project/main_app/templates/filterable_table_with_search_bar.html
@@ -9,7 +9,7 @@
     [object type]". Views using this template must pass a `Page` object as `page_obj` in the context (this 
     happens by default in views with a `MultipleObjectMixin`). The template uses the `context_object_name`
     attribute of the view to determine the object type to display in this object count.
-    Pagination is included at the bottom of the page, except if no results are found.
+    Pagination is included at the bottom of the page if results span more than one page.
 #}
 {% block maincontent %}
     <div class="row">
@@ -35,7 +35,7 @@
             </div>
         </div>
     {% endif %}
-    {% if page_obj.paginator.num_pages > 1 %}
+    {% if is_paginated %}
         <div class="row mb-2">
             <div class="col">{% include "pagination.html" %}</div>
         </div>

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -455,6 +455,7 @@ class ChantSearchView(ListView):
         context["services"] = (
             Service.objects.all().order_by("name").values("id", "name")
         )
+        context["query_empty"] = False if self.request.GET else True
         context["order"] = self.request.GET.get("order")
         context["sort"] = self.request.GET.get("sort")
 

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -19,7 +19,10 @@ services:
     restart: always
     depends_on:
       - postgres
-    command: [ "python", "manage.py", "runserver_plus", "0:8000", "--nopin" ]
+    command: [ "python", "-Xfrozen_modules=off", "-m", "debugpy", "--listen", "0.0.0.0:3000", "manage.py", "runserver_plus", "0:8000", "--nopin" ]
+    ports:
+      - 3000:3000
+      - 5678:5678
 
   nginx:
     build:


### PR DESCRIPTION
Closes #1748.

Also, I add some additional parameters to the `docker-compose-development.yml` file for a VSCode debugging configuration. These won't affect default behaviour.