### PR TITLE
Create bulk chant edit function

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -214,7 +214,7 @@ class ChantCreateForm(forms.ModelForm):
         help_text="Binding order",
     )
 
-    c_sequence = forms.CharField(
+    c_sequence = forms.IntegerField(
         required=True,
         widget=TextInputWidget,
         help_text="Each folio starts with '1'.",
@@ -441,7 +441,7 @@ class ChantEditForm(forms.ModelForm):
         help_text="Binding order",
     )
 
-    c_sequence = forms.CharField(
+    c_sequence = forms.IntegerField(
         required=True,
         widget=TextInputWidget,
         help_text="Each folio starts with '1'.",

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -984,3 +984,55 @@ class ImageLinkForm(forms.Form):
         for folio, image_link in cleaned_data.items():
             if image_link != "":
                 source.chant_set.filter(folio=folio).update(image_link=image_link)
+
+class BrowseChantsBulkEditForm(forms.ModelForm):
+    class Meta:
+        model = Chant
+        fields = [
+            "id",
+            "folio",
+            "c_sequence",
+            "manuscript_full_text_std_spelling",
+            "feast",
+            "service",
+            "genre",
+            "position",
+            "cantus_id",
+            "mode",
+        ]
+        widgets = {
+            "id": HiddenInput(),
+            "feast": autocomplete.ModelSelect2(url="feast-autocomplete"),
+            "service": autocomplete.ModelSelect2(url="service-autocomplete"),
+            "genre": autocomplete.ModelSelect2(url="genre-autocomplete"),
+            "position": TextInputWidget(),
+            "cantus_id": TextInputWidget(),
+            "mode": TextInputWidget(),
+        }
+
+    folio = forms.CharField(
+        required=True,
+        widget=TextInputWidget,
+    )
+
+    c_sequence = forms.IntegerField(
+        required=True,
+        widget=TextInputWidget,
+    )
+
+    manuscript_full_text_std_spelling = CantusDBLatinField(
+        widget=TextAreaWidget,
+        required=True,
+    )
+
+
+BrowseChantsBulkEditFormset = forms.inlineformset_factory(
+    Source,
+    Chant,
+    form=BrowseChantsBulkEditForm,
+    extra=0,
+    max_num=100,
+    can_delete=False,
+    can_order=False,
+    edit_only=True,
+)

--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -1,10 +1,33 @@
 {% extends "base_page_with_side_cards.html" %}
+{% load static %}
 {% block title %}<title>Browse Chants | Cantus Database</title>{% endblock %}
-{% block scripts %}<script src="/static/js/chant_list.js"></script>{% endblock %}
+{% block scripts %}
+    <script src="/static/js/chant_list.js"></script>
+    <script type="text/javascript"
+            src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+    <link rel="stylesheet"
+          href="{% static 'css/browse_chants_bulk_edit.css' %}" />
+    {{ bulk_edit_formset.media }}
+    {{ user_can_edit_chant|json_script:"data-user-can-edit-chants" }}
+{% endblock %}
 {% block uppersidebar %}
     <div class="search-bar mb-3">{% include "global_search_bar.html" %}</div>
 {% endblock %}
 {% block maincontent %}
+    <!--Display messages -->
+    {% for message in messages %}
+        <div class="alert {{ message.tags }} alert-dismissible" role="alert">
+            <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
+            {{ message }}
+        </div>
+    {% endfor %}
+    <!--Display form error message -->
+    {% if bulk_edit_formset.errors %}
+        <div class="alert alert-danger alert-dismissible">
+            <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
+            {% for error in bulk_edit_formset.errors %}<div>{{ error }}</div>{% endfor %}
+        </div>
+    {% endif %}
     <h3>Browse Chants</h3>
     <span class="small">Displaying {{ page_obj.start_index }}-{{ page_obj.end_index }} of <b>{{ page_obj.paginator.count }}</b> chants.</span>
     <form method="get">
@@ -18,7 +41,8 @@
                         class="form-control form-control-sm form-select form-select-sm">
                     {% comment %} <option value="">- Any -</option> {% endcomment %}
                     {% for source_obj in sources %}
-                        <option value="{{ source_obj.id }}"{% if source_obj.id == source.id %} selected {% endif %}>{{ source_obj.short_heading }}</option>
+                        <option value="{{ source_obj.id }}"
+                                {% if source_obj.id == source.id %}selected{% endif %}>{{ source_obj.short_heading }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -85,9 +109,21 @@
             </fieldset>
         {% endif %}
     </form>
+    {% if user_can_edit_chant %}
+        <div class="text-end mb-3">
+            <button id="bulkChantEditToggle" type="button" class="btn btn-sm btn-primary">
+                Bulk Edit Chants
+            </button>
+            <button id="bulkChantEditSubmit"
+                    type="submit"
+                    form="bulkChantEditForm"
+                    class="btn btn-sm btn-dark d-none">Save Changes</button>
+        </div>
+    {% endif %}
     {% with exists_on_cantus_ultimus=source.exists_on_cantus_ultimus %}
         {% if chants %}
-            <table class="table table-responsive table-sm table-bordered small">
+            <table id="chantDisplayTable"
+                   class="table table-responsive table-sm table-bordered small">
                 <thead>
                     <tr>
                         <th scope="col" class="text-wrap" title="Folio">Folio</th>
@@ -164,9 +200,48 @@
                     {% endfor %}
                 </tbody>
             </table>
-            <div class="small">
-                {% include "pagination.html" %}
-            </div>
+            {% if user_can_edit_chant %}
+                <form id="bulkChantEditForm" class="d-none" method="post">
+                    {% csrf_token %}
+                    {{ bulk_edit_formset.management_form }}
+                    <div class="table-responsive">
+                        <table class="table table-sm table-bordered small edit-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col" class="sm-edit-col" title="Folio">Folio</th>
+                                    <th scope="col" class="sm-edit-col" title="Sequence">Seq.</th>
+                                    <th scope="col" class="full-text-edit-col" title="Full text">
+                                        Full text (Standard Spelling)
+                                    </th>
+                                    <th scope="col" class="autocomplete-edit-col" title="Feast">Feast</th>
+                                    <th scope="col" class="autocomplete-edit-col" title="Service">Service</th>
+                                    <th scope="col" class="autocomplete-edit-col" title="Genre">Genre</th>
+                                    <th scope="col" class="sm-edit-col" title="Position">Position</th>
+                                    <th scope="col" class="med-edit-col" title="Cantus ID">CantusID</th>
+                                    <th scope="col" class="sm-edit-col" title="Mode">Mode</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for form in bulk_edit_formset %}
+                                    <tr>
+                                        {{ form.id }}
+                                        <td class="text-wrap text-center">{{ form.folio }}</td>
+                                        <td class="text-wrap text-center">{{ form.c_sequence }}</td>
+                                        <td class="text-wrap">{{ form.manuscript_full_text_std_spelling }}</td>
+                                        <td class="text-wrap text-center">{{ form.feast }}</td>
+                                        <td class="text-wrap text-center">{{ form.service }}</td>
+                                        <td class="text-wrap text-center">{{ form.genre }}</td>
+                                        <td class="text-wrap text-center">{{ form.position }}</td>
+                                        <td class="text-wrap text-center">{{ form.cantus_id }}</td>
+                                        <td class="text-wrap text-center">{{ form.mode }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </form>
+            {% endif %}
+            <div class="small">{% include "pagination.html" %}</div>
         {% else %}
             No chants found.
         {% endif %}

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -26,7 +26,7 @@ from main_app.tests.make_fakes import (
     add_accents_to_string,
 )
 from main_app.tests.mixins import HTMLContentsTestMixin
-from users.models import User
+from main_app.forms import BrowseChantsBulkEditFormset
 
 # Create a Faker instance with locale set to Latin
 faker = Faker("la")
@@ -467,6 +467,12 @@ class SourceInventoryViewTest(HTMLContentsTestMixin, TestCase):
 
 
 class SourceBrowseChantsViewTest(TestCase):
+    contrib_group: Group
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.contrib_group = Group.objects.create(name="contributor")
+
     def test_url_and_templates(self):
         cantus_segment = make_fake_segment(id=4063)
         source = make_fake_source(segment=cantus_segment)
@@ -488,7 +494,8 @@ class SourceBrowseChantsViewTest(TestCase):
         response_2 = self.client.get(
             reverse("browse-chants", args=[unpublished_source.id])
         )
-        self.assertEqual(response_2.status_code, 403)
+        # For unauthenticated user, redirects to login page
+        self.assertEqual(response_2.status_code, 302)
 
     def test_visibility_by_segment(self):
         cantus_segment = make_fake_segment(id=4063)
@@ -705,6 +712,87 @@ class SourceBrowseChantsViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
         self.assertTemplateUsed(response, "400.html")
+
+    def test_post_request_forbidden(self) -> None:
+        """
+        Ensure that a POST request is forbidden for
+        unauthenticated users and users that are not
+        allowed to edit chants in a source.
+        """
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
+        user = get_user_model().objects.create(email="test@test.com")
+        user.groups.add(self.contrib_group)
+        response = self.client.post(reverse("browse-chants", args=[source.id]))
+        self.assertEqual(response.status_code, 302)
+        self.client.force_login(user)
+        response = self.client.post(reverse("browse-chants", args=[source.id]))
+        self.assertEqual(response.status_code, 403)
+
+    def test_bulk_chant_edit_integration(self) -> None:
+        """
+        Tests integration of BrowseChantsBulkEditFormset and
+        the browse chants view. In particular, checks that:
+        - bad/incomplete request data leads to errors in the formset
+        - good request data leads to changes in the relevant chants (checked
+            by the presence of changes in the response context)
+        """
+        cantus_segment = make_fake_segment(id=4063)
+        source = make_fake_source(segment=cantus_segment)
+        user = get_user_model().objects.create(email="test@test.com")
+        user.groups.add(self.contrib_group)
+        source.current_editors.add(user)
+        self.client.force_login(user)
+        chant_1 = make_fake_chant(source=source)
+        make_fake_chant(source=source)
+        formset = BrowseChantsBulkEditFormset(
+            instance=source,
+            queryset=Chant.objects.filter(source=source),
+        )
+        # Collect the initial formset data
+        management_form_data = {
+            f"chant_set-{key}": str(value)
+            for key, value in formset.management_form.initial.items()
+        }
+        chant_1_form_data = {
+            f"chant_set-0-{key}": value
+            for key, value in formset.forms[0].initial.items()
+        }
+        chant_2_form_data = {
+            f"chant_set-1-{key}": value
+            for key, value in formset.forms[1].initial.items()
+        }
+        complete_form_data = management_form_data.copy()
+        complete_form_data.update(chant_1_form_data)
+        complete_form_data.update(chant_2_form_data)
+        with self.subTest("Incomplete request data"):
+            bad_form_data = management_form_data.copy()
+            bad_form_data.update(chant_1_form_data)
+            response = self.client.post(
+                reverse("browse-chants", args=[source.id]), bad_form_data
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertIsNotNone(response.context["bulk_edit_formset"].errors)
+        with self.subTest("Bad request data: empty field"):
+            bad_form_data = complete_form_data.copy()
+            bad_form_data["chant_set-0-folio"] = ""
+            response = self.client.post(
+                reverse("browse-chants", args=[source.id]), bad_form_data
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertIsNotNone(response.context["bulk_edit_formset"].errors)
+            old_folio = chant_1.folio
+            chant_1.refresh_from_db()
+            self.assertEqual(old_folio, chant_1.folio)
+        with self.subTest("Good request data"):
+            good_form_data = complete_form_data.copy()
+            good_form_data["chant_set-0-mode"] = "0"
+            response = self.client.post(
+                reverse("browse-chants", args=[source.id]), good_form_data
+            )
+            self.assertEqual(response.status_code, 200)
+            chant_1.refresh_from_db()
+            self.assertEqual(chant_1.mode, "0")
 
 
 class SourceListViewTest(TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -27,6 +27,7 @@ from main_app.tests.make_fakes import (
 )
 from main_app.tests.mixins import HTMLContentsTestMixin
 from main_app.forms import BrowseChantsBulkEditFormset
+from users.models import User
 
 # Create a Faker instance with locale set to Latin
 faker = Faker("la")

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -25,6 +25,7 @@ from main_app.forms import (
     SourceEditForm,
     SourceBrowseChantsProofreadForm,
     ImageLinkForm,
+    BrowseChantsBulkEditFormset,
 )
 from main_app.models import (
     Century,
@@ -52,7 +53,7 @@ CANTUS_SEGMENT_ID = 4063
 BOWER_SEGMENT_ID = 4064
 
 
-class SourceBrowseChantsView(ListView):
+class SourceBrowseChantsView(UserPassesTestMixin, ListView):  # type: ignore[type-arg]
     """The view for the `Browse Chants` page.
 
     Displays a list of Chant objects, accessed with ``chants`` followed by a series of GET params
@@ -74,24 +75,30 @@ class SourceBrowseChantsView(ListView):
     template_name = "browse_chants.html"
     pk_url_kwarg = "source_id"
     source: Source
+    extra_context = {
+        "bulk_edit_formset": None,
+    }
 
-    def get_queryset(self):
-        """Gather the chants to be displayed.
+    def test_func(self) -> bool:
+        """
+        Gets source attribute. If the source is unpublished, only authenticated users can
+        access this view.
+        """
+        source_id = self.kwargs.get(self.pk_url_kwarg)
+        self.source = get_object_or_404(Source, id=source_id)
+        if self.request.method == "POST":
+            return user_can_edit_chants_in_source(self.request.user, self.source)
+        return self.source.published or self.request.user.is_authenticated
 
-        When in the `browse chants` page, there must be a source specified.
+    def get_queryset(self) -> QuerySet[Chant]:
+        """
+        Gather the chants to be displayed.
+
         The chants in the specified source are filtered by a set of optional search parameters.
 
         Returns:
             queryset: The Chant objects to be displayed.
         """
-        source_id = self.kwargs.get(self.pk_url_kwarg)
-        source = get_object_or_404(Source, id=source_id)
-        self.source = source
-
-        display_unpublished = self.request.user.is_authenticated
-        if (source.published is False) and (not display_unpublished):
-            raise PermissionDenied()
-
         # optional search params
         feast_id = self.request.GET.get("feast")
         genre_id = self.request.GET.get("genre")
@@ -108,7 +115,7 @@ class SourceBrowseChantsView(ListView):
         volpiano_proofread = self.request.GET.get("volpiano_proofread")
 
         # get all chants in the specified source
-        chants: QuerySet[Chant] = source.chant_set.select_related(
+        chants: QuerySet[Chant] = self.source.chant_set.select_related(
             "feast", "service", "genre"
         )
         # filter the chants with optional search params
@@ -151,8 +158,8 @@ class SourceBrowseChantsView(ListView):
 
         return chants.order_by("folio", "c_sequence")
 
-    def get_context_data(self, **kwargs):
-        context: dict = super().get_context_data(**kwargs)
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context: dict[str, Any] = super().get_context_data(**kwargs)
         source: Source = self.source
         if source.segment_id != CANTUS_SEGMENT_ID:
             # the chant list ("Browse Chants") page should only be visitable
@@ -170,7 +177,7 @@ class SourceBrowseChantsView(ListView):
 
         # sources in the Bower Segment contain only Sequences and no Chants,
         # so they should not appear among the list of sources
-        cantus_segment: QuerySet[Segment] = Segment.objects.get(id=CANTUS_SEGMENT_ID)
+        cantus_segment: Segment = Segment.objects.get(id=CANTUS_SEGMENT_ID)
 
         # to be displayed in the "Source" dropdown in the form
         sources: QuerySet[Source] = cantus_segment.source_set.select_related(
@@ -184,7 +191,7 @@ class SourceBrowseChantsView(ListView):
         context["user_can_edit_chant"] = user_can_edit_chants_in_source(user, source)
         context["user_can_proofread_source"] = user_can_proofread_source(user, source)
 
-        chants_in_source: QuerySet[Chant] = source.chant_set
+        chants_in_source = source.chant_set
         if chants_in_source.count() == 0:
             # these are needed in the selectors and hyperlinks on the right side of the page
             # if there's no chant in the source, there should be no options in those selectors
@@ -195,16 +202,15 @@ class SourceBrowseChantsView(ListView):
             return context
 
         # generate options for the folio selector on the right side of the page
-        folios: tuple[str] = (
+        folios = (
             chants_in_source.values_list("folio", flat=True)
             .distinct()
             .order_by("folio")
         )
         context["folios"] = folios
 
-        if self.request.GET.get("folio"):
+        if folio := self.request.GET.get("folio"):
             # if browsing chants on a specific folio
-            folio: str = self.request.GET.get("folio")
             index: int = list(folios).index(folio)
             # get the previous and next folio, if available
             context["previous_folio"] = folios[index - 1] if index != 0 else None
@@ -217,7 +223,22 @@ class SourceBrowseChantsView(ListView):
         context["proofread_filter_form"] = SourceBrowseChantsProofreadForm(
             self.request.GET or None
         )
+        if not self.extra_context.get("bulk_edit_formset"):
+            context["bulk_edit_formset"] = BrowseChantsBulkEditFormset(
+                instance=source, queryset=self.object_list
+            )
         return context
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        formset = BrowseChantsBulkEditFormset(request.POST, instance=self.source)
+        if formset.is_valid():
+            formset.save()
+            messages.success(request, "Chants updated successfully!")
+        else:
+            self.extra_context = {
+                "bulk_edit_formset": formset,
+            }
+        return self.get(request, *args, **kwargs)
 
 
 class SourceDetailView(JSONResponseMixin, DetailView):  # type: ignore[type-arg]

--- a/django/cantusdb_project/static/css/browse_chants_bulk_edit.css
+++ b/django/cantusdb_project/static/css/browse_chants_bulk_edit.css
@@ -1,0 +1,25 @@
+.edit-table {
+    table-layout: fixed;
+}
+
+.sm-edit-col {
+    width: 70px;
+}
+
+.med-edit-col {
+    width: 100px;
+}
+
+.full-text-edit-col {
+    width: 400px;
+}
+
+/* Override default style for 
+django-autocomplete-light select2 widget */
+.select2-container {
+    min-width: 130px !important;
+}
+
+.autocomplete-edit-col {
+    width: 150px;
+}

--- a/django/cantusdb_project/static/js/chant_list.js
+++ b/django/cantusdb_project/static/js/chant_list.js
@@ -130,10 +130,26 @@ window.addEventListener("load", function () {
         const stdProofread = document.querySelector('input[name="manuscript_full_text_std_proofread"]:checked')?.value;
         const proofread = document.querySelector('input[name="manuscript_full_text_proofread"]:checked')?.value;
         const volpianoProof = document.querySelector('input[name="volpiano_proofread"]:checked')?.value;
-        
+
         updateURLParam('manuscript_full_text_std_proofread', stdProofread);
         updateURLParam('manuscript_full_text_proofread', proofread);
         updateURLParam('volpiano_proofread', volpianoProof);
         window.location.assign(url);
+    }
+
+
+    // Use #bulkChantEditToggle button to toggle the bulk chant edit form.
+    const userCanEditChants = document.getElementById("data-user-can-edit-chants").textContent === "true";
+    if (userCanEditChants) {
+        const bulkChantEditToggle = document.getElementById("bulkChantEditToggle");
+        const bulkChantEditForm = document.getElementById("bulkChantEditForm");
+        const chantDisplayTable = document.getElementById("chantDisplayTable");
+        const bulkChantEditSubmit = document.getElementById("bulkChantEditSubmit");
+        bulkChantEditToggle.addEventListener("click", function () {
+            bulkChantEditForm.classList.toggle("d-none");
+            chantDisplayTable.classList.toggle("d-none");
+            bulkChantEditSubmit.classList.toggle("d-none");
+            bulkChantEditToggle.textContent = bulkChantEditForm.classList.contains("d-none") ? "Bulk Edit Chants" : "Stop Editing";
+        });
     }
 });


### PR DESCRIPTION
This PR modifies the `SourceBrowseChantsView` to allow for bulk edits to certain chant fields.

Closes #1714. 

Authenticated users who are allowed to edit chants in a source see a new button on the browse chants page:

![image](https://github.com/user-attachments/assets/8ee4eacc-be90-4d80-8f4d-42cfbac07917)

When clicked, this button shows a form for editing the displayed aspects of the chants. The chants in the form can be filtered using the browse chants page filters.

![image](https://github.com/user-attachments/assets/e4674c9b-cfb9-40cb-b6ee-7140c13ab647)

Changes made through this form are captured by django reversion.

Required fields are maintained, but for the moment, the folio-c_sequence uniqueness requirement is not. This is because we will use this form to fix folio-c_sequence uniqueness issues in the data and then institute a model-level constraint (per #1713).

Also closes #1769, replacing the use of a `CharField` for the `c_sequence` field on both the chant create and chant edit forms with an `IntegerField` to match the type of `c_sequence` on the `Chant` model.

Adds tests to support this feature.