### PR TITLE
New: Simplify source admin

### DIFF
--- a/django/cantusdb_project/main_app/admin/source.py
+++ b/django/cantusdb_project/main_app/admin/source.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
-
-from main_app.admin.base_admin import BaseModelAdmin, EXCLUDE, READ_ONLY
+from django.contrib.auth import get_user_model
+from django.db.models import Q
+from main_app.admin.base_admin import EXCLUDE, READ_ONLY, BaseModelAdmin
 from main_app.admin.filters import InputFilter
-from main_app.forms import AdminSourceForm
 from main_app.models import Source, SourceIdentifier
 
 
@@ -28,7 +28,7 @@ class IdentifiersInline(admin.TabularInline):
 @admin.register(Source)
 class SourceAdmin(BaseModelAdmin):
     exclude = EXCLUDE + ("source_status",)
-    raw_id_fields = ("holding_institution",)
+    autocomplete_fields = ("holding_institution", "provenance")
     inlines = (IdentifiersInline,)
 
     # These search fields are also available on the user-source inline relationship in the user admin page
@@ -73,6 +73,7 @@ class SourceAdmin(BaseModelAdmin):
         "id",
     )
 
+
     list_filter = (
         SourceKeyFilter,
         "full_source",
@@ -85,8 +86,14 @@ class SourceAdmin(BaseModelAdmin):
 
     ordering = ("holding_institution__siglum", "shelfmark")
 
-    form = AdminSourceForm
-
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         return queryset.select_related("holding_institution")
+
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        if db_field.name == "current_editors":
+            kwargs["queryset"] = get_user_model().objects.filter(
+                Q(groups__name="project manager")
+                | Q(groups__name="editor")
+                | Q(groups__name="contributor")).distinct().order_by("full_name")
+        return super().formfield_for_manytomany(db_field, request, **kwargs)

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -867,105 +867,105 @@ class AdminSequenceForm(forms.ModelForm):
     )
 
 
-class AdminSourceForm(forms.ModelForm):
-    class Meta:
-        model = Source
-        fields = "__all__"
-
-    # title = forms.CharField(
-    #     required=True,
-    #     widget=TextInputWidget,
-    #     help_text="Full Source Identification (City, Archive, Shelf-mark)",
-    # )
-    # title.widget.attrs.update({"style": "width: 610px;"})
-    #
-    # siglum = forms.CharField(
-    #     required=True,
-    #     widget=TextInputWidget,
-    #     help_text="RISM-style siglum + Shelf-mark (e.g. GB-Ob 202).",
-    # )
-
-    shelfmark = forms.CharField(
-        required=True,
-        widget=TextInputWidget,
-    )
-
-    name = forms.CharField(required=False, widget=TextInputWidget)
-
-    holding_institution = forms.ModelChoiceField(
-        queryset=Institution.objects.all().order_by("city", "name"),
-        required=False,
-    )
-
-    provenance = forms.ModelChoiceField(
-        queryset=Provenance.objects.all().order_by("name"),
-        required=False,
-    )
-
-    century = forms.ModelMultipleChoiceField(
-        queryset=Century.objects.all().order_by("name"),
-        required=False,
-        widget=FilteredSelectMultiple(verbose_name="Century", is_stacked=False),
-    )
-
-    current_editors = forms.ModelMultipleChoiceField(
-        queryset=get_user_model()
-        .objects.filter(
-            Q(groups__name="project manager")
-            | Q(groups__name="editor")
-            | Q(groups__name="contributor")
-        )
-        .distinct()
-        .order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(verbose_name="current editors", is_stacked=False),
-    )
-
-    inventoried_by = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(verbose_name="inventoried by", is_stacked=False),
-    )
-
-    full_text_entered_by = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(
-            verbose_name="full text entered by", is_stacked=False
-        ),
-    )
-
-    description_entered_by = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(
-            verbose_name="description entered by", is_stacked=False
-        ),
-    )
-
-    melodies_entered_by = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(
-            verbose_name="melodies entered by", is_stacked=False
-        ),
-    )
-
-    proofreaders = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(verbose_name="proofreaders", is_stacked=False),
-    )
-
-    other_editors = forms.ModelMultipleChoiceField(
-        queryset=get_user_model().objects.all().order_by("full_name"),
-        required=False,
-        widget=FilteredSelectMultiple(verbose_name="other editors", is_stacked=False),
-    )
-
-    complete_inventory = forms.ChoiceField(
-        choices=COMPLETE_INVENTORY_FORM_CHOICES, required=False
-    )
+# class AdminSourceForm(forms.ModelForm):
+#     class Meta:
+#         model = Source
+#         fields = "__all__"
+#
+#     # title = forms.CharField(
+#     #     required=True,
+#     #     widget=TextInputWidget,
+#     #     help_text="Full Source Identification (City, Archive, Shelf-mark)",
+#     # )
+#     # title.widget.attrs.update({"style": "width: 610px;"})
+#     #
+#     # siglum = forms.CharField(
+#     #     required=True,
+#     #     widget=TextInputWidget,
+#     #     help_text="RISM-style siglum + Shelf-mark (e.g. GB-Ob 202).",
+#     # )
+#
+#     shelfmark = forms.CharField(
+#         required=True,
+#         widget=TextInputWidget,
+#     )
+#
+#     name = forms.CharField(required=False, widget=TextInputWidget)
+#
+#     holding_institution = forms.ModelChoiceField(
+#         queryset=Institution.objects.all().order_by("city", "name"),
+#         required=False,
+#     )
+#
+#     provenance = forms.ModelChoiceField(
+#         queryset=Provenance.objects.all().order_by("name"),
+#         required=False,
+#     )
+#
+#     century = forms.ModelMultipleChoiceField(
+#         queryset=Century.objects.all().order_by("name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(verbose_name="Century", is_stacked=False),
+#     )
+#
+#     current_editors = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model()
+#         .objects.filter(
+#             Q(groups__name="project manager")
+#             | Q(groups__name="editor")
+#             | Q(groups__name="contributor")
+#         )
+#         .distinct()
+#         .order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(verbose_name="current editors", is_stacked=False),
+#     )
+#
+#     inventoried_by = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model().objects.all().order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(verbose_name="inventoried by", is_stacked=False),
+#     )
+#
+#     full_text_entered_by = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model().objects.all().order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(
+#             verbose_name="full text entered by", is_stacked=False
+#         ),
+#     )
+#
+#     description_entered_by = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model().objects.all().order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(
+#             verbose_name="description entered by", is_stacked=False
+#         ),
+#     )
+#
+#     melodies_entered_by = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model().objects.all().order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(
+#             verbose_name="melodies entered by", is_stacked=False
+#         ),
+#     )
+#
+#     proofreaders = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model().objects.all().order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(verbose_name="proofreaders", is_stacked=False),
+#     )
+#
+#     other_editors = forms.ModelMultipleChoiceField(
+#         queryset=get_user_model().objects.all().order_by("full_name"),
+#         required=False,
+#         widget=FilteredSelectMultiple(verbose_name="other editors", is_stacked=False),
+#     )
+#
+#     complete_inventory = forms.ChoiceField(
+#         choices=COMPLETE_INVENTORY_FORM_CHOICES, required=False
+#     )
 
 
 class AdminUserChangeForm(forms.ModelForm):


### PR DESCRIPTION
Previously the source admin page used a completely separate admin form that was handcrafted for each field. As best I can tell, this was only really used because the "Current editors" m2m select needed to be filtered to only project managers, editors, and contributors.

This PR removes the custom admin form and replaces it with the `ModelAdmin.formfield_for_manytomany` method, which allows you to pass in a custom QuerySet for specific m2m fields.

In addition, by reverting to the default admin behaviour this also makes the "autocomplete" widget available, so this has been added for the holding institutions and the provenance field.

For now I have left the custom admin form in place but have commented it out.