### PR TITLE
Additional fields visible on institutions

### DIFF
--- a/django/cantusdb_project/main_app/admin/institution.py
+++ b/django/cantusdb_project/main_app/admin/institution.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-
 from main_app.admin.base_admin import BaseModelAdmin
 from main_app.models import Institution, InstitutionIdentifier, Source
 
@@ -42,7 +41,7 @@ class InstitutionAdmin(BaseModelAdmin):
         "alternate_names",
         "migrated_identifier",
     )
-    readonly_fields = ("migrated_identifier",)
+    readonly_fields = ("migrated_identifier", "created_by", "date_created", "date_updated", "last_updated_by")
     list_filter = ("is_private_collector", "is_private_collection", "city")
     inlines = (InstitutionIdentifierInline, InstitutionSourceInline)
     fieldsets = [
@@ -59,6 +58,10 @@ class InstitutionAdmin(BaseModelAdmin):
                     "private_notes",
                     "is_private_collection",
                     "migrated_identifier",
+                    "created_by",
+                    "date_created",
+                    "last_updated_by",
+                    "date_updated"
                 )
             },
         ),


### PR DESCRIPTION
This PR adds the created / updated fields to the institution records in the admin. I was looking to see when an institution record was updated and couldn't see it, so I think having this information visible will be handy.