### PR TITLE
Optimized chant search page queries

### DIFF
--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -92,6 +92,7 @@ ONLY_FIELDS = (
     "source__shelfmark",
     "source__holding_institution__city",
     "source__holding_institution__name",
+    "source__name",
     "title",
     "incipit",
     "folio",


### PR DESCRIPTION
The use of the ONLY_FIELDS list can optimize loading of records, but if a record needs access to a field that isn't in the ONLY_FIELDS list, it will trigger another SQL query. The source__name was being accessed (to show the heading of the source) but it was not in the list, triggering another SQL query for each entry.

The addition of this value reduces the number of SQL queries from ~108 to ~8.