### PR TITLE
Minor fixes: template styles, code cleanliness/typing, sequence detail header, sequence list page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ django/media/
 
 # MyPy
 .mypy_cache
+mypy.ini
 
 # Virtual environments
 .env
@@ -123,3 +124,6 @@ django/cantusdb_project/Drupal_scripts
 
 # cached files for APIs
 api_cache/
+
+
+.python-version

--- a/django/cantusdb_project/cantusdb/settings.py
+++ b/django/cantusdb_project/cantusdb/settings.py
@@ -179,6 +179,9 @@ EMAIL_USE_TLS = True
 
 DEFAULT_FROM_EMAIL = "noreply@cantusdatabase.simssa.ca"
 
+# Session app settings
+SESSION_COOKIE_SECURE = True
+
 # automatically disable all panels which user can then manually enable
 DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": {

--- a/django/cantusdb_project/main_app/models/__init__.py
+++ b/django/cantusdb_project/main_app/models/__init__.py
@@ -14,3 +14,22 @@ from main_app.models.source_identifier import SourceIdentifier
 from main_app.models.institution import Institution
 from main_app.models.institution_identifier import InstitutionIdentifier
 from main_app.models.project import Project
+
+__all__ = [
+    "BaseModel",
+    "Century",
+    "Chant",
+    "Differentia",
+    "Feast",
+    "Genre",
+    "Notation",
+    "Service",
+    "Provenance",
+    "Segment",
+    "Sequence",
+    "Source",
+    "SourceIdentifier",
+    "Institution",
+    "InstitutionIdentifier",
+    "Project",
+]

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from django.db import models
-from main_app.models import BaseModel, Segment
 from django.contrib.auth import get_user_model
+
+from main_app.models import BaseModel, Segment
 
 
 class Source(BaseModel):
@@ -177,10 +180,10 @@ class Source(BaseModel):
     number_of_chants = models.IntegerField(blank=True, null=True)
     number_of_melodies = models.IntegerField(blank=True, null=True)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.heading
 
-    def save(self, *args, **kwargs):
+    def save(self, *args: Any, **kwargs: Any) -> None:
         # when creating a source, assign it to "CANTUS Database" segment by default
         if not self.segment:
             cantus_db_segment = Segment.objects.get(name="CANTUS Database")

--- a/django/cantusdb_project/main_app/templates/content_overview.html
+++ b/django/cantusdb_project/main_app/templates/content_overview.html
@@ -3,7 +3,7 @@
 {# for classname, admin_url_name #}
 {% block title %}<title>Content Overview | Cantus Database</title>{% endblock %}
 {% block content %}
-    <div class="container bg-white rounded py-3">
+    <div class="container bg-white rounded py-3 my-3">
         <h3>Content Overview</h3>
         <div class="row justify-content-center">
             {% for model_name in models %}

--- a/django/cantusdb_project/main_app/templates/registration/change_password.html
+++ b/django/cantusdb_project/main_app/templates/registration/change_password.html
@@ -2,7 +2,7 @@
 {% block content %}
     <div class="container">
         <div class="row justify-content-center">
-            <div class="p-3 col-lg-6 bg-white rounded">
+            <div class="p-3 col-lg-6 bg-white rounded my-3">
                 <!--Display messages -->
                 {% for message in messages %}
                     <div class="alert {{ message.tags }} alert-dismissible" role="alert">

--- a/django/cantusdb_project/main_app/templates/registration/login.html
+++ b/django/cantusdb_project/main_app/templates/registration/login.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="container">
         <div class="row justify-content-center">
-            <div class="p-3 col-lg-6 bg-white rounded">
+            <div class="p-3 col-lg-6 bg-white rounded my-3">
                 <!--Display "submit success" message -->
                 {% if messages %}
                     <div class="alert alert-success text-center">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="container">
         <div class="row justify-content-center">
-            <div class="p-3 col-lg-6 bg-white rounded">
+            <div class="p-3 col-lg-6 bg-white rounded my-3">
                 <!--Display messages -->
                 {% for message in messages %}
                     <div class="alert {{ message.tags }} alert-dismissible" role="alert">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_complete.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_complete.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="container">
         <div class="row justify-content-center">
-            <div class="p-3 col-lg-6 bg-white rounded">
+            <div class="p-3 col-lg-6 bg-white rounded my-3">
                 <p>Your password has been set.  You may go ahead and log in now.</p>
                 <p>
                     <a href="{{ login_url }}">Log in</a>

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_confirm.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_confirm.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="container">
         <div class="row justify-content-center">
-            <div class="p-3 col-lg-6 bg-white rounded">
+            <div class="p-3 col-lg-6 bg-white rounded my-3">
                 {% if validlink %}
                     <p>Please enter your new password twice so we can verify you typed it in correctly.</p>
                     <form method="post">

--- a/django/cantusdb_project/main_app/templates/registration/reset_password_sent.html
+++ b/django/cantusdb_project/main_app/templates/registration/reset_password_sent.html
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="container">
         <div class="row justify-content-center">
-            <div class="p-3 col-lg-6 bg-white rounded">
+            <div class="p-3 col-lg-6 bg-white rounded my-3">
                 <h5>Password Reset Email Sent</h5>
                 <p>
                     We’ve emailed you instructions for resetting your password, if an account exists with the email you entered. You should receive them shortly.

--- a/django/cantusdb_project/main_app/templates/sequence_detail.html
+++ b/django/cantusdb_project/main_app/templates/sequence_detail.html
@@ -131,7 +131,9 @@
     </dl>
     {% if sequence.cantus_id %}
         <h4>Concordances</h4>
-        <small>Concordances for Cantus ID <a href="{{ sequence.get_ci_url }}" target=_blank>{{ sequence.cantus_id }}</a>: Displaying 1 - {{ concordances.count }} of {{ concordances.count }}</small>
+        <p class="small">
+            Displaying {{ concordances.count }} concordances for Cantus ID <a href="{{ sequence.get_ci_url }}" target=_blank>{{ sequence.cantus_id }}</a>.
+        </p>
         <div class="table-responsive">
             <table class="table table-sm small table-bordered">
                 <thead>

--- a/django/cantusdb_project/main_app/templates/sequence_edit.html
+++ b/django/cantusdb_project/main_app/templates/sequence_edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}<title>{{ sequence.title }} | Cantus Database</title>{% endblock %}
 {% block content %}
-    <div class="container">
+    <div class="container my-3">
         <div class="row">
             <div class="p-3 col bg-white rounded">
                 <!--Display form error message -->

--- a/django/cantusdb_project/main_app/templates/source_add_image_links.html
+++ b/django/cantusdb_project/main_app/templates/source_add_image_links.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{% static 'css/source_add_image_links.css' %}" />
 {% endblock %}
 {% block content %}
-    <div class="container bg-white rounded">
+    <div class="container bg-white rounded my-3">
         <div class="row mt-4">
             <div class="col">
                 <h4>

--- a/django/cantusdb_project/main_app/templates/source_create.html
+++ b/django/cantusdb_project/main_app/templates/source_create.html
@@ -9,7 +9,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="p-3 col-lg-12 bg-white rounded">
+            <div class="p-3 col-lg-12 bg-white rounded my-3">
                 <h3>Create Source</h3>
                 <!--Display "submit success" message -->
                 {% if messages %}

--- a/django/cantusdb_project/main_app/tests/test_views/test_sequence.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_sequence.py
@@ -41,7 +41,12 @@ class SequenceListViewTest(TestCase):
         sequences = response.context["sequences"]
         self.assertEqual(
             sequences.query.order_by,
-            ("source__holding_institution__siglum", "s_sequence"),
+            (
+                "source__holding_institution__siglum",
+                "source__shelfmark",
+                "folio",
+                "s_sequence",
+            ),
         )
 
     def test_search_incipit(self):

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -457,7 +457,7 @@ urlpatterns = [
         name="items-count",
     ),
     path(
-        "source/<str:source_id>/csv/",
+        "source/<int:source_id>/csv/",
         csv_export,
         name="csv-export",
     ),

--- a/django/cantusdb_project/main_app/views/genre.py
+++ b/django/cantusdb_project/main_app/views/genre.py
@@ -1,6 +1,6 @@
 from django.views.generic import DetailView, ListView
 from django.db.models import QuerySet
-from main_app.models import Genre  # type: ignore[attr-defined]
+from main_app.models import Genre
 from main_app.mixins import JSONResponseMixin
 
 

--- a/django/cantusdb_project/main_app/views/sequence.py
+++ b/django/cantusdb_project/main_app/views/sequence.py
@@ -70,7 +70,10 @@ class SequenceListView(ListView):
             q_obj_filter &= Q(cantus_id__icontains=cantus_id)
 
         return queryset.filter(q_obj_filter).order_by(
-            "source__holding_institution__siglum", "s_sequence"
+            "source__holding_institution__siglum",
+            "source__shelfmark",
+            "folio",
+            "s_sequence",
         )
 
 

--- a/django/cantusdb_project/main_app/views/service.py
+++ b/django/cantusdb_project/main_app/views/service.py
@@ -4,14 +4,14 @@ from main_app.models import Service
 from main_app.mixins import JSONResponseMixin
 
 
-class ServiceDetailView(JSONResponseMixin, DetailView):
+class ServiceDetailView(JSONResponseMixin, DetailView):  # type: ignore [type-arg]
     model = Service
     context_object_name = "service"
     template_name = "service_detail.html"
     json_fields = ["id", "name", "description"]
 
 
-class ServiceListView(JSONResponseMixin, ListView):
+class ServiceListView(JSONResponseMixin, ListView):  # type: ignore [type-arg]
     model = Service
     queryset = Service.objects.order_by("name")
     paginate_by = 100

--- a/django/cantusdb_project/static/css/style.css
+++ b/django/cantusdb_project/static/css/style.css
@@ -26,6 +26,7 @@ html {
 
 .error-page-container {
 	margin-bottom: 10em;
+	margin-top: 3em;
 }
 
 .copyright-footer {


### PR DESCRIPTION
This PR implements relatively minor fixes to templates and does some code cleanup.

- explicitly exports models so linters stop complaining about imports directly from main_app.models (also removes a place where we had previously silenced this complaining)
- adds some vertical margins to the main content containers of a number of pages that was introduced in #1779 refactoring. These margins are now handled by templates inheriting from the base template, so we add a number of those in here.

On the template clean-up front, we:

- adjust the ordering of the sequence list page to be a little more rational. Add in ordering by source shelfmark and folio.
- removes some verbiage from the header of the concordances table on the sequence detail page that made it seem like we were paginating results. Maybe we should paginate results, but we aren't currently, so now the header conforms more closely to what's actually happening.