### PR TITLE
fix: links on Canadian Chant DB page open in new tabs

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -203,7 +203,8 @@
                                     <tr>
                                         <td class="text-wrap" style="text-align:center">
                                             {% if source.holding_institution %}
-                                                <a href="{% url 'institution-detail' source.holding_institution.id %}">
+                                                <a href="{% url 'institution-detail' source.holding_institution.id %}"
+                                                   target="_blank">
                                                     <b>
                                                         {% if source.holding_institution.city %}
                                                             {{ source.holding_institution.city }},
@@ -233,11 +234,12 @@
                                         </td>
                                         <td class="text-wrap" style="text-align:center">
                                             {% if source.century %}
-                                                {% join_absolute_url_links source.century.all 'name' '/' %}
+                                                {% join_absolute_url_links source.century.all 'name' '/' True %}
                                                 <br />
                                             {% endif %}
                                             {% if source.provenance %}
-                                                <a href="{% url 'provenance-detail' source.provenance.id %}">{{ source.provenance.name }}</a>
+                                                <a href="{% url 'provenance-detail' source.provenance.id %}"
+                                                   target="_blank">{{ source.provenance.name }}</a>
                                             {% endif %}
                                         </td>
                                         <td class="text-wrap" style="text-align:center">

--- a/django/cantusdb_project/main_app/templatetags/helper_tags.py
+++ b/django/cantusdb_project/main_app/templatetags/helper_tags.py
@@ -262,7 +262,7 @@ def sortable_header(
 
 @register.simple_tag(takes_context=False)
 def join_absolute_url_links(
-    objects: list[BaseModel], display_attr: str, sep: str
+    objects: list[BaseModel], display_attr: str, sep: str, newtab: bool = False
 ) -> SafeString:
     """
     Takes a series of objects and returns an html string of
@@ -274,8 +274,15 @@ def join_absolute_url_links(
     """
     return format_html_join(
         sep,
-        '<b><a href="{0}">{1}</a></b>',
-        ((obj.get_absolute_url(), getattr(obj, display_attr)) for obj in objects),
+        '<b><a href="{0}"{2}>{1}</a></b>',
+        (
+            (
+                obj.get_absolute_url(),
+                getattr(obj, display_attr),
+                ' target="_blank"' if newtab else "",
+            )
+            for obj in objects
+        ),
     )
 
 


### PR DESCRIPTION
Closes #1808.

Adds a new argument to the `join_absolute_url_links` template tag to designate whether the resulting links should open a new tab.