### PR TITLE
Fix sorting behaviour on Chant Search Views

### DIFF
--- a/django/cantusdb_project/main_app/admin/institution.py
+++ b/django/cantusdb_project/main_app/admin/institution.py
@@ -41,7 +41,13 @@ class InstitutionAdmin(BaseModelAdmin):
         "alternate_names",
         "migrated_identifier",
     )
-    readonly_fields = ("migrated_identifier", "created_by", "date_created", "date_updated", "last_updated_by")
+    readonly_fields = (
+        "migrated_identifier",
+        "created_by",
+        "date_created",
+        "date_updated",
+        "last_updated_by",
+    )
     list_filter = ("is_private_collector", "is_private_collection", "city")
     inlines = (InstitutionIdentifierInline, InstitutionSourceInline)
     fieldsets = [
@@ -61,7 +67,7 @@ class InstitutionAdmin(BaseModelAdmin):
                     "created_by",
                     "date_created",
                     "last_updated_by",
-                    "date_updated"
+                    "date_updated",
                 )
             },
         ),

--- a/django/cantusdb_project/main_app/models/__init__.py
+++ b/django/cantusdb_project/main_app/models/__init__.py
@@ -36,4 +36,3 @@ __all__ = [
     "Project",
     "SourceURL",
 ]
-

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -1,5 +1,6 @@
 {% extends "filterable_table_with_search_bar.html" %}
 {% load humanize %}
+{% load helper_tags %}
 {% block title %}<title>Search Chants | Cantus Database</title>{% endblock %}
 {% block scripts %}<script src="/static/js/chant_search.js"></script>{% endblock %}
 {% block heading %}<h3>Search Chants</h3>{% endblock %}
@@ -137,146 +138,23 @@
             <thead>
                 <tr>
                     {% if not source %}
-                        <th scope="col"
-                            class="text-wrap"
-                            style="text-align:center"
-                            title="Siglum">
-                            {% if order == "siglum" %}
-                                {% if sort == "desc" %}
-                                    <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a> ▼
-                                {% else %}
-                                    <a href="{{ url_with_search_params }}&order=siglum&sort=desc">Siglum</a> ▲
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=siglum&sort=asc">Siglum</a>
-                            {% endif %}
-                        </th>
+                        {% sortable_header request "siglum" %}
                     {% endif %}
                     <th scope="col" class="text-wrap" style="text-align:center" title="Folio">Folio</th>
+                    {% sortable_header request "incipit" "Incipit/Full Text"%}
+                    {% sortable_header request "feast" "Feast" %}
+                    {% sortable_header request "service" "Service" %}
+                    {% sortable_header request "genre" "Genre" %}
                     <th scope="col"
                         class="text-wrap"
                         style="text-align:center"
-                        title="Incipit/Full Text">
-                        {% if order == "incipit" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=incipit&sort=desc">Incipit/Full Text</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
-                        {% endif %}
+                        title="Position">Position
                     </th>
-                    <th scope="col" 
-                        class="text-wrap" 
-                        style="text-align:center" 
-                        title="Feast">
-                            {% if order == "feast" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=feast&sort=asc">Feast</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=feast&sort=desc">Feast</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=feast&sort=asc">Feast</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col"
-                        class="text-wrap"
-                        style="text-align:center"
-                        title="Service">
-                        {% if order == "service" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=service&sort=asc">Service</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=service&sort=desc">Service</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=service&sort=asc">Service</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col" class="text-wrap" style="text-align:center" title="Genre">
-                        {% if order == "genre" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=genre&sort=desc">Genre</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=genre&sort=asc">Genre</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col"
-                        class="text-wrap"
-                        style="text-align:center"
-                        title="Position">Position</th>
-                    <th scope="col"
-                        class="text-wrap"
-                        style="text-align:center"
-                        title="Cantus ID">
-                        {% if order == "cantus_id" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=cantus_id&sort=desc">Cantus ID</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=cantus_id&sort=asc">Cantus ID</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col" class="text-wrap" style="text-align:center" title="Mode">
-                        {% if order == "mode" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=mode&sort=desc">Mode</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=mode&sort=asc">Mode</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col"
-                        class="text-wrap"
-                        style="text-align:center"
-                        title="Full Text">
-                        {% if order == "has_fulltext" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">FT</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_fulltext&sort=desc">FT</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=has_fulltext&sort=asc">FT</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col"
-                        class="text-wrap"
-                        style="text-align:center"
-                        title="Volpiano Melody">
-                        {% if order == "has_melody" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_melody&sort=desc">Mel</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=has_melody&sort=asc">Mel</a>
-                        {% endif %}
-                    </th>
-                    <th scope="col"
-                        class="text-wrap"
-                        style="text-align:center"
-                        title="Image Link">
-                        {% if order == "has_image" %}
-                            {% if sort == "desc" %}
-                                <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a> ▼
-                            {% else %}
-                                <a href="{{ url_with_search_params }}&order=has_image&sort=desc">Image</a> ▲
-                            {% endif %}
-                        {% else %}
-                            <a href="{{ url_with_search_params }}&order=has_image&sort=asc">Image</a>
-                        {% endif %}
-                    </th>
+                    {% sortable_header request "cantus_id" "Cantus ID" %}
+                    {% sortable_header request "mode" "Mode" %}
+                    {% sortable_header request "has_fulltext" "FT" %}
+                    {% sortable_header request "has_melody" "Mel" %}
+                    {% sortable_header request "has_image" "Image" %}
                 </tr>
             </thead>
             <tbody>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -167,7 +167,20 @@
                             <a href="{{ url_with_search_params }}&order=incipit&sort=asc">Incipit/Full Text</a>
                         {% endif %}
                     </th>
-                    <th scope="col" class="text-wrap" style="text-align:center" title="Feast">Feast</th>
+                    <th scope="col" 
+                        class="text-wrap" 
+                        style="text-align:center" 
+                        title="Feast">
+                            {% if order == "feast" %}
+                            {% if sort == "desc" %}
+                                <a href="{{ url_with_search_params }}&order=feast&sort=asc">Feast</a> ▼
+                            {% else %}
+                                <a href="{{ url_with_search_params }}&order=feast&sort=desc">Feast</a> ▲
+                            {% endif %}
+                        {% else %}
+                            <a href="{{ url_with_search_params }}&order=feast&sort=asc">Feast</a>
+                        {% endif %}
+                    </th>
                     <th scope="col"
                         class="text-wrap"
                         style="text-align:center"

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -296,11 +296,18 @@ def make_fake_notation() -> Notation:
     return notation
 
 
-def make_fake_service() -> Service:
+def make_fake_service(
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Service:
     """Generates a fake Service object."""
+    if name is None:
+        name = faker.lexify("???")
+    if description is None:
+        description = faker.sentence()
     service = Service.objects.create(
-        name=faker.lexify(text="??"),
-        description=faker.sentence(),
+        name=name,
+        description=description,
     )
     return service
 

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from unittest import skip
 import random
 from typing import ClassVar
+import urllib.parse
 
 from django.test import TestCase, Client
 from django.urls import reverse
@@ -923,9 +924,9 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_service(self):
         # currently, service sort works by ID rather than by name
-        service_1 = make_fake_service()
-        service_2 = make_fake_service()
-        assert service_1.id < service_2.id
+        service_1 = make_fake_service(name="A")
+        service_2 = make_fake_service(name="B")
+
         chant_1 = make_fake_chant(
             service=service_1, manuscript_full_text_std_spelling="hocus"
         )
@@ -967,9 +968,8 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_service_global_search(self):
         # currently, service sort works by ID rather than by name
-        service_1 = make_fake_service()
-        service_2 = make_fake_service()
-        assert service_1.id < service_2.id
+        service_1 = make_fake_service(name="A")
+        service_2 = make_fake_service(name="B")
         chant_1 = make_fake_chant(
             service=service_1, manuscript_full_text_std_spelling="fluffy"
         )
@@ -1008,9 +1008,8 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_genre(self):
         # currently, genre sort works by ID rather than by name
-        genre_1 = make_fake_genre()
-        genre_2 = make_fake_genre()
-        assert genre_1.id < genre_2.id
+        genre_1 = make_fake_genre(name="A")
+        genre_2 = make_fake_genre(name="B")
         chant_1 = make_fake_chant(
             genre=genre_1, manuscript_full_text_std_spelling="hocus"
         )
@@ -1052,9 +1051,8 @@ class ChantSearchViewTest(TestCase):
 
     def test_order_by_genre_global_search(self):
         # currently, genre sort works by ID rather than by name
-        genre_1 = make_fake_genre()
-        genre_2 = make_fake_genre()
-        assert genre_1.id < genre_2.id
+        genre_1 = make_fake_genre(name="A")
+        genre_2 = make_fake_genre(name="B")
         chant_1 = make_fake_chant(
             genre=genre_1, manuscript_full_text_std_spelling="chuckle"
         )
@@ -1502,9 +1500,10 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(last_result_incipit, chant_1.incipit)
 
     def test_column_header_links(self):
-        # these are the 9 column headers users can order by:
+        # these are the 10 column headers users can order by:
         shelfmark = "glum-01"
         fulltext = "so it begins"
+        feast = make_fake_feast()
         service = make_fake_service()
         genre = make_fake_genre()
         cantus_id = make_random_string(6, "0123456789")
@@ -1515,7 +1514,6 @@ class ChantSearchViewTest(TestCase):
         source = make_fake_source(shelfmark=shelfmark, published=True)
 
         # additional properties for which there are search fields
-        feast = make_fake_feast()
         position = make_random_string(1)
         make_fake_chant(
             manuscript_full_text_std_spelling=fulltext,
@@ -1538,10 +1536,10 @@ class ChantSearchViewTest(TestCase):
             },
         )
         html_1 = str(response_1.content)
-        # if no ordering specified, all 9 links should include "&sort=asc"
+        # if no ordering specified, all 10 links should include "&sort=asc"
         self.assertEqual(html_1.count("&sort=asc"), 10)
 
-        # test that all query parameters are present in all 9 links
+        # test that all query parameters are present in all 10 links
         query_keys_and_values = {
             "op": "contains",
             "keyword": search_term,
@@ -1553,17 +1551,23 @@ class ChantSearchViewTest(TestCase):
             "position": position,
             "melodies": "true",
         }
+
         response_2 = self.client.get(
             reverse("chant-search"),
             query_keys_and_values,
         )
         html_2 = str(response_2.content)
-        for k, v in query_keys_and_values.items():
-            expected_query_param = f"{k}={v}"
-            self.assertEqual(html_2.count(expected_query_param), 10)
-        self.assertEqual(html_2.count("sort=asc"), 10)
 
-        # test links maintain search_bar
+        for k, v in query_keys_and_values.items():
+            # Generate URL-encoded parameter with + for spaces (how Django's urlencode works)
+            v_str = str(v)
+            encoded_param = urllib.parse.quote_plus(v_str)
+            expected_query_param = f"{k}={encoded_param}"
+
+            # Assert that it appears 10 times
+            self.assertEqual(html_2.count(expected_query_param), 10)
+
+        # Test search_bar in the same way
         response_3 = self.client.get(
             reverse("chant-search"),
             {
@@ -1571,7 +1575,13 @@ class ChantSearchViewTest(TestCase):
             },
         )
         html_3 = str(response_3.content)
-        self.assertEqual(html_3.count(f"search_bar={search_term}"), 10)
+
+        # Use quote_plus to encode with + for spaces
+        encoded_search_term = urllib.parse.quote_plus(search_term)
+        expected_search_param = f"search_bar={encoded_search_term}"
+
+        # Assert that it appears 10 times
+        self.assertEqual(html_3.count(expected_search_param), 10)
 
         # for each orderable column, check that 'asc' flips to 'desc', and vice versa
         orderings = (
@@ -2506,7 +2516,7 @@ class ChantSearchMSViewTest(TestCase):
         )
         html_1 = str(response_1.content)
         # if no ordering specified, all 9 links should include "&sort=asc"
-        self.assertEqual(html_1.count("&sort=asc"), 8)
+        self.assertEqual(html_1.count("&sort=asc"), 9)
 
         # test that all query parameters are present in all 9 links
         query_keys_and_values = {
@@ -2525,10 +2535,16 @@ class ChantSearchMSViewTest(TestCase):
             query_keys_and_values,
         )
         html_2 = str(response_2.content)
+
         for k, v in query_keys_and_values.items():
-            expected_query_param = f"{k}={v}"
-            self.assertEqual(html_2.count(expected_query_param), 8)
-            self.assertEqual(html_2.count("sort=asc"), 8)
+            # Generate URL-encoded parameter with + for spaces (how Django's urlencode works)
+            v_str = str(v)
+            encoded_param = urllib.parse.quote_plus(v_str)
+            expected_query_param = f"{k}={encoded_param}"
+
+            # Assert that it appears 10 times
+            self.assertEqual(html_2.count(expected_query_param), 9)
+            self.assertEqual(html_2.count("sort=asc"), 9)
 
         # for each orderable column, check that 'asc' flips to 'desc', and vice versa
         orderings = (
@@ -2560,7 +2576,7 @@ class ChantSearchMSViewTest(TestCase):
             # when no `sort=` is specified, all 7 columns should contain a `sort=asc` in
             # their column header link. Since an ascending sorting _is_ specified for one
             # of the columns, that column should have switched from `sort=asc` to `sort=desc`
-            self.assertEqual(html_asc.count("sort=asc"), 7)
+            self.assertEqual(html_asc.count("sort=asc"), 8)
             response_desc = self.client.get(
                 reverse("chant-search-ms", args=[source.id]),
                 {

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -850,6 +850,39 @@ class ChantSearchViewTest(TestCase):
         last_result_incipit = descending_results[1].incipit
         self.assertEqual(last_result_incipit, chant_1.incipit)
 
+    def test_order_by_feast(self):
+        source = make_fake_source(published=True)
+        feast1 = make_fake_feast(name="A")
+        feast2 = make_fake_feast(name="B")
+        chant_1 = make_fake_chant(source=source, feast=feast1)
+        chant_2 = make_fake_chant(source=source, feast=feast2)
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_feast = ascending_results[0].feast
+        self.assertEqual(first_result_feast, chant_1.feast)
+        last_result_feast = ascending_results[1].feast
+        self.assertEqual(last_result_feast, chant_2.feast)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_feast = descending_results[0].feast
+        self.assertEqual(first_result_feast, chant_2.feast)
+        last_result_feast = descending_results[1].feast
+        self.assertEqual(last_result_feast, chant_1.feast)
+
     def test_order_by_incipit_global_search(self):
         source = make_fake_source(published=True)
         chant_1 = make_fake_chant(

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -1539,7 +1539,7 @@ class ChantSearchViewTest(TestCase):
         )
         html_1 = str(response_1.content)
         # if no ordering specified, all 9 links should include "&sort=asc"
-        self.assertEqual(html_1.count("&sort=asc"), 9)
+        self.assertEqual(html_1.count("&sort=asc"), 10)
 
         # test that all query parameters are present in all 9 links
         query_keys_and_values = {
@@ -1560,8 +1560,8 @@ class ChantSearchViewTest(TestCase):
         html_2 = str(response_2.content)
         for k, v in query_keys_and_values.items():
             expected_query_param = f"{k}={v}"
-            self.assertEqual(html_2.count(expected_query_param), 9)
-        self.assertEqual(html_2.count("sort=asc"), 9)
+            self.assertEqual(html_2.count(expected_query_param), 10)
+        self.assertEqual(html_2.count("sort=asc"), 10)
 
         # test links maintain search_bar
         response_3 = self.client.get(
@@ -1571,13 +1571,14 @@ class ChantSearchViewTest(TestCase):
             },
         )
         html_3 = str(response_3.content)
-        self.assertEqual(html_3.count(f"search_bar={search_term}"), 9)
+        self.assertEqual(html_3.count(f"search_bar={search_term}"), 10)
 
         # for each orderable column, check that 'asc' flips to 'desc', and vice versa
         orderings = (
             "siglum",
             "incipit",
             "service",
+            "feast",
             "genre",
             "cantus_id",
             "mode",
@@ -1604,7 +1605,7 @@ class ChantSearchViewTest(TestCase):
             # when no `sort=` is specified, all 9 columns should contain a `sort=asc` in
             # their column header link. Since an ascending sorting _is_ specified for one
             # of the columns, that column should have switched from `sort=asc` to `sort=desc`
-            self.assertEqual(html_asc.count("sort=asc"), 8)
+            self.assertEqual(html_asc.count("sort=asc"), 9)
             response_desc = self.client.get(
                 reverse("chant-search"),
                 {

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -1255,7 +1255,7 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="this will become a chant without a MS spelling fulltext",
         )
-        chant_2.manuscript_full_text = None
+        chant_2.manuscript_full_text = ""
         chant_2.save()
 
         search_term = "a chant wit"
@@ -1298,7 +1298,7 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="this will become a chant without a MS spelling fulltext",
         )
-        chant_2.manuscript_full_text = None
+        chant_2.manuscript_full_text = ""
         chant_2.save()
 
         search_term = "this"
@@ -1339,7 +1339,7 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="this is a chant about parsley",
         )
-        chant_2.volpiano = None
+        chant_2.volpiano = ""
         chant_2.save()
 
         search_term = "s is a ch"
@@ -1382,7 +1382,7 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="this is a chant about mushrooms",
         )
-        chant_2.volpiano = None
+        chant_2.volpiano = ""
         chant_2.save()
 
         search_term = "this is a chant"
@@ -1423,7 +1423,7 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="this is a chant without",
         )
-        chant_2.image_link = None
+        chant_2.image_link = ""
         chant_2.save()
 
         search_term = "a chant with"
@@ -1466,7 +1466,7 @@ class ChantSearchViewTest(TestCase):
         chant_2 = make_fake_chant(
             manuscript_full_text_std_spelling="this is a chant without",
         )
-        chant_2.image_link = None
+        chant_2.image_link = ""
         chant_2.save()
 
         search_term = "this is"
@@ -1498,6 +1498,40 @@ class ChantSearchViewTest(TestCase):
         self.assertEqual(first_result_incipit, chant_2.incipit)
         last_result_incipit = descending_results[1].incipit
         self.assertEqual(last_result_incipit, chant_1.incipit)
+
+    def test_order_nulls_last(self):
+        source = make_fake_source(published=True)
+        feast = make_fake_feast(name="A")
+
+        chant_with_feast = make_fake_chant(source=source, feast=feast)
+        chant_without_feast = make_fake_chant(source=source, feast=None)
+
+        # Ascending sort — null should be last
+        response_asc = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_asc.context["chants"]
+        self.assertIn(chant_with_feast, ascending_results)
+        self.assertIn(chant_without_feast, ascending_results)
+
+        self.assertEqual(ascending_results[0].feast, feast)
+        self.assertIsNone(ascending_results[1].feast)
+
+        # Descending sort — null should still be last
+        response_desc = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_desc.context["chants"]
+        self.assertEqual(descending_results[0].feast, feast)
+        self.assertIsNone(descending_results[1].feast)
 
     def test_column_header_links(self):
         # these are the 10 column headers users can order by:
@@ -2165,12 +2199,44 @@ class ChantSearchMSViewTest(TestCase):
         last_result_incipit = descending_results[1].incipit
         self.assertEqual(last_result_incipit, chant_1.incipit)
 
+    def test_order_by_feast(self):
+        source = make_fake_source(published=True)
+        feast1 = make_fake_feast(name="A")
+        feast2 = make_fake_feast(name="B")
+        chant_1 = make_fake_chant(source=source, feast=feast1)
+        chant_2 = make_fake_chant(source=source, feast=feast2)
+
+        response_ascending = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_ascending.context["chants"]
+        first_result_feast = ascending_results[0].feast
+        self.assertEqual(first_result_feast, chant_1.feast)
+        last_result_feast = ascending_results[1].feast
+        self.assertEqual(last_result_feast, chant_2.feast)
+
+        response_descending = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_descending.context["chants"]
+        first_result_feast = descending_results[0].feast
+        self.assertEqual(first_result_feast, chant_2.feast)
+        last_result_feast = descending_results[1].feast
+        self.assertEqual(last_result_feast, chant_1.feast)
+
     def test_order_by_service(self):
         source = make_fake_source()
         # currently, service sort works by ID rather than by name
-        service_1 = make_fake_service()
-        service_2 = make_fake_service()
-        assert service_1.id < service_2.id
+        service_1 = make_fake_service(name="A")
+        service_2 = make_fake_service(name="B")
         chant_1 = make_fake_chant(
             service=service_1, manuscript_full_text_std_spelling="hocus", source=source
         )
@@ -2213,8 +2279,8 @@ class ChantSearchMSViewTest(TestCase):
     def test_order_by_genre(self):
         source = make_fake_source()
         # currently, genre sort works by ID rather than by name
-        genre_1 = make_fake_genre()
-        genre_2 = make_fake_genre()
+        genre_1 = make_fake_genre(name="A")
+        genre_2 = make_fake_genre(name="B")
         assert genre_1.id < genre_2.id
         chant_1 = make_fake_chant(
             genre=genre_1, manuscript_full_text_std_spelling="hocus", source=source
@@ -2352,7 +2418,7 @@ class ChantSearchMSViewTest(TestCase):
             manuscript_full_text_std_spelling="this is a chant without",
             source=source,
         )
-        chant_2.manuscript_full_text = None
+        chant_2.manuscript_full_text = ""
         chant_2.save()
 
         search_term = "s is a ch"
@@ -2398,7 +2464,7 @@ class ChantSearchMSViewTest(TestCase):
             source=source,
             manuscript_full_text_std_spelling="this is a chant about parsley",
         )
-        chant_2.volpiano = None
+        chant_2.volpiano = ""
         chant_2.save()
 
         search_term = "s is a ch"
@@ -2444,7 +2510,7 @@ class ChantSearchMSViewTest(TestCase):
             source=source,
             manuscript_full_text_std_spelling="this is a chant without",
         )
-        chant_2.image_link = None
+        chant_2.image_link = ""
         chant_2.save()
 
         search_term = "a chant with"
@@ -2478,6 +2544,40 @@ class ChantSearchMSViewTest(TestCase):
         self.assertEqual(first_result_incipit, chant_2.incipit)
         last_result_incipit = descending_results[1].incipit
         self.assertEqual(last_result_incipit, chant_1.incipit)
+
+    def test_order_nulls_last(self):
+        source = make_fake_source(published=True)
+        feast = make_fake_feast(name="A")
+
+        chant_with_feast = make_fake_chant(source=source, feast=feast)
+        chant_without_feast = make_fake_chant(source=source, feast=None)
+
+        # Ascending sort — null should be last
+        response_asc = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "asc",
+            },
+        )
+        ascending_results = response_asc.context["chants"]
+        self.assertIn(chant_with_feast, ascending_results)
+        self.assertIn(chant_without_feast, ascending_results)
+
+        self.assertEqual(ascending_results[0].feast, feast)
+        self.assertIsNone(ascending_results[1].feast)
+
+        # Descending sort — null should still be last
+        response_desc = self.client.get(
+            reverse("chant-search"),
+            {
+                "order": "feast",
+                "sort": "desc",
+            },
+        )
+        descending_results = response_desc.context["chants"]
+        self.assertEqual(descending_results[0].feast, feast)
+        self.assertIsNone(descending_results[1].feast)
 
     def test_column_header_links(self):
         # these are the 9 column headers users can order by:

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -8,7 +8,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import PermissionDenied
-from django.db.models import F, Q, QuerySet
+from django.db.models import Q, QuerySet
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -8,7 +8,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import PermissionDenied
-from django.db.models import Q, QuerySet
+from django.db.models import F, Q, QuerySet
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -652,10 +652,24 @@ class ChantSearchView(ListView):
             order_get_param, "source__holding_institution__siglum"
         )
 
-        if sort_get_param and sort_get_param == "desc":
-            order = f"-{order}"
+        # Reverse logic for 'has_' fields: we want entries WITH data first when sorting ASC
+        reverse_sort = order_get_param in ["has_fulltext", "has_melody", "has_image"]
 
-        return queryset.order_by(order, "id")
+        # Determine sort direction, flipping if it's a 'has_' field
+        if sort_get_param == "desc":
+            order_expression = (
+                F(order).asc(nulls_last=True)
+                if reverse_sort
+                else F(order).desc(nulls_last=True)
+            )
+        else:
+            order_expression = (
+                F(order).desc(nulls_last=True)
+                if reverse_sort
+                else F(order).asc(nulls_last=True)
+            )
+
+        return queryset.order_by(order_expression, "id")
 
 
 class MelodySearchView(TemplateView):
@@ -806,29 +820,41 @@ class ChantSearchMSView(ListView):
             # as a substring
             q_obj_filter &= Q(feast__name__icontains=feast)
 
-        order_value = self.request.GET.get("order", "siglum")
+        order_value = self.request.GET.get("order")
+        sort_get_param: Optional[str] = self.request.GET.get("sort")
 
-        if order_value in {
-            "siglum",
-            "incipit",
-            "genre",
-            "cantus_id",
-            "mode",
-            "feast",
-            "service",
-        }:
-            order = order_value
-        elif order_value == "has_fulltext":
-            order = "manuscript_full_text"
-        elif order_value == "has_melody":
-            order = "volpiano"
-        elif order_value == "has_image":
-            order = "image_link"
+        order_field_mapping = {
+            "feast": "feast__name",
+            "service": "service__name",
+            "genre": "genre__name",
+            "has_fulltext": "manuscript_full_text",
+            "has_melody": "volpiano",
+            "has_image": "image_link",
+            "incipit": "incipit",
+            "cantus_id": "cantus_id",
+            "mode": "mode",
+        }
+
+        order = order_field_mapping.get(
+            order_value, "source__holding_institution__siglum"
+        )
+
+        # Reverse logic for 'has_' fields: we want entries WITH data first when sorting ASC
+        reverse_sort = order_value in ["has_fulltext", "has_melody", "has_image"]
+
+        # Determine sort direction, flipping if it's a 'has_' field
+        if sort_get_param == "desc":
+            order_expression = (
+                F(order).asc(nulls_last=True)
+                if reverse_sort
+                else F(order).desc(nulls_last=True)
+            )
         else:
-            order = "siglum"
-
-        if sort := self.request.GET.get("sort"):
-            order = f"-{order}" if sort == "desc" else order
+            order_expression = (
+                F(order).desc(nulls_last=True)
+                if reverse_sort
+                else F(order).asc(nulls_last=True)
+            )
 
         source_id = self.kwargs["source_pk"]
         source = Source.objects.get(id=source_id)
@@ -874,7 +900,7 @@ class ChantSearchMSView(ListView):
         # ordering with the folio string gives wrong order
         # old cantus is also not strictly ordered by folio (there are outliers)
         # so we order by id for now, which is the order that the chants are entered into the DB
-        queryset = queryset.order_by(order, "id")
+        queryset = queryset.order_by(order_expression, "id")
         return queryset
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -645,6 +645,7 @@ class ChantSearchView(ListView):
             "has_fulltext",
             "has_melody",
             "has_image",
+            "feast",
         )
         if order_get_param in order_param_options:
             if order_get_param == "has_fulltext":

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -8,7 +8,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import PermissionDenied
-from django.db.models import Q, QuerySet
+from django.db.models import F, Q, QuerySet
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -636,30 +636,22 @@ class ChantSearchView(ListView):
         order_get_param: Optional[str] = self.request.GET.get("order")
         sort_get_param: Optional[str] = self.request.GET.get("sort")
 
-        order_param_options = (
-            "incipit",
-            "service",
-            "genre",
-            "cantus_id",
-            "mode",
-            "has_fulltext",
-            "has_melody",
-            "has_image",
-            "feast",
-        )
-        if order_get_param in order_param_options:
-            if order_get_param == "has_fulltext":
-                order = "manuscript_full_text"
-            elif order_get_param == "has_melody":
-                order = "volpiano"
-            elif order_get_param == "has_image":
-                order = "image_link"
-            else:
-                order = order_get_param
-        else:
-            order = "source__holding_institution__siglum"
+        order_field_mapping = {
+            "feast": "feast__name",
+            "service": "service__name",
+            "genre": "genre__name",
+            "has_fulltext": "manuscript_full_text",
+            "has_melody": "volpiano",
+            "has_image": "image_link",
+            "incipit": "incipit",
+            "cantus_id": "cantus_id",
+            "mode": "mode",
+        }
 
-        # sort values: "asc" and "desc". Default is "asc"
+        order = order_field_mapping.get(
+            order_get_param, "source__holding_institution__siglum"
+        )
+
         if sort_get_param and sort_get_param == "desc":
             order = f"-{order}"
 


### PR DESCRIPTION
This PR adds a sortable column header to the chant search page for Feast (ascending and descending). 

It changes the logic of the sorting so that certain fields like feast, service, and genre are sorted by name instead of ID. 

Additionally, for fulltext, melody, and image link columns, the reverse sorting is applied so that ascending sort will show the results WITH data first. Note that #1585 makes this a bit strange at the moment until we clean up the data. For example, in "desc" sort the empty strings will show up first, then the non-empty data, then the null data. 

Add `nulls_last = True` so that null values will always show up last. For example, a "desc" search for feast will show feast names sorted from z to a followed by null values. Previously the null values would show up first.

- Add tests for this functionality

Resolves #418
Resolves #1593
Resolves #425 

![Screenshot 2025-05-05 at 1 28 05 PM](https://github.com/user-attachments/assets/f11de22b-64af-46f0-b3aa-58025b593800)
