### PR TITLE
Restrict to Python Version 3.9

### DIFF
--- a/django/cantusdb_project/main_app/admin/institution.py
+++ b/django/cantusdb_project/main_app/admin/institution.py
@@ -41,7 +41,13 @@ class InstitutionAdmin(BaseModelAdmin):
         "alternate_names",
         "migrated_identifier",
     )
-    readonly_fields = ("migrated_identifier", "created_by", "date_created", "date_updated", "last_updated_by")
+    readonly_fields = (
+        "migrated_identifier",
+        "created_by",
+        "date_created",
+        "date_updated",
+        "last_updated_by",
+    )
     list_filter = ("is_private_collector", "is_private_collection", "city")
     inlines = (InstitutionIdentifierInline, InstitutionSourceInline)
     fieldsets = [
@@ -61,7 +67,7 @@ class InstitutionAdmin(BaseModelAdmin):
                     "created_by",
                     "date_created",
                     "last_updated_by",
-                    "date_updated"
+                    "date_updated",
                 )
             },
         ),

--- a/django/cantusdb_project/main_app/models/__init__.py
+++ b/django/cantusdb_project/main_app/models/__init__.py
@@ -36,4 +36,3 @@ __all__ = [
     "Project",
     "SourceURL",
 ]
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -1260,11 +1260,7 @@ files = [
 [package.dependencies]
 astroid = ">=3.3.8,<=3.4.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
-]
+dill = {version = ">=0.2", markers = "python_version < \"3.11\""}
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<7"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
@@ -1801,5 +1797,5 @@ watchdog = ["watchdog (>=2.3)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "529b5678f20482f65cdbc5bf8ccc045a7d9c4cdccbffcf05008b090909fb57fc"
+python-versions = ">=3.9,<3.10"
+content-hash = "2768043b541cb1e5509f7e22c6da34e3b426f6bbc2745df4c36141f72f6834fb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cantusdb"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = ">=3.9,<3.10"
 Django = "4.2.16"
 django-autocomplete-light = "3.9.4"
 django-extra-views = "0.13.0"


### PR DESCRIPTION
- Restrict to Python Version 3.9 because of psycopg-binary 3.1.18 being incompatible with Python 3.13.3
- Fix two formatting mistakes with Black.

Resolves #1831 
