### PR TITLE
Update proofread status for chants in published sources

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
+++ b/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
@@ -4,17 +4,17 @@ from main_app.models import Source, Chant
 # Cantus segment ID constant (same as used in source.py views)
 CANTUS_SEGMENT_ID = 4063
 
-SOURCE_LIST = [123766, 123740, 123739, 123738, 123737, 662398, 651162]
+EXCLUDE = [123766, 123740, 123739, 123738, 123737, 662398, 651162]
 
 
 class Command(BaseCommand):
     help = "Updates the 'other_fields_proofread' field to True for chants in published sources in the Cantus segment."
 
     def handle(self, *args, **options):
-        # Filter for published sources in the Cantus segment only, excluding sources from SOURCE_LIST
+        # Filter for published sources in the Cantus segment only, excluding sources from EXCLUDE
         published_sources = Source.objects.filter(
             published=True, segment_m2m=CANTUS_SEGMENT_ID
-        ).exclude(id__in=SOURCE_LIST)
+        ).exclude(id__in=EXCLUDE)
 
         if not published_sources.exists():
             self.stdout.write(

--- a/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
+++ b/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
@@ -4,34 +4,23 @@ from main_app.models import Source, Chant
 # Cantus segment ID constant (same as used in source.py views)
 CANTUS_SEGMENT_ID = 4063
 
+SOURCE_LIST = [123766, 123740, 123739, 123738, 123737, 662398, 651162]
+
 
 class Command(BaseCommand):
     help = "Updates the 'other_fields_proofread' field to True for chants in published sources in the Cantus segment."
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--source_ids",
-            nargs="+",
-            type=int,
-            help="Optional list of source IDs to update.",
-        )
-
     def handle(self, *args, **options):
-        source_ids = options["source_ids"]
-        # Filter for published sources in the Cantus segment only
+        # Filter for published sources in the Cantus segment only, excluding sources from SOURCE_LIST
         published_sources = Source.objects.filter(
             published=True, segment_m2m=CANTUS_SEGMENT_ID
-        )
+        ).exclude(id__in=SOURCE_LIST)
 
-        if source_ids:
-            published_sources = published_sources.filter(id__in=source_ids)
-            if not published_sources.exists():
-                self.stdout.write(
-                    self.style.WARNING(
-                        "No published sources found for the provided IDs."
-                    )
-                )
-                return
+        if not published_sources.exists():
+            self.stdout.write(
+                self.style.WARNING("No published sources found to update.")
+            )
+            return
 
         updated_chants_count = 0
         error_count = 0

--- a/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
+++ b/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
@@ -1,9 +1,12 @@
 from django.core.management.base import BaseCommand
 from main_app.models import Source, Chant
 
+# Cantus segment ID constant (same as used in source.py views)
+CANTUS_SEGMENT_ID = 4063
+
 
 class Command(BaseCommand):
-    help = "Updates the 'other_fields_proofread' field to True for chants in published sources."
+    help = "Updates the 'other_fields_proofread' field to True for chants in published sources in the Cantus segment."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -15,7 +18,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         source_ids = options["source_ids"]
-        published_sources = Source.objects.filter(published=True)
+        # Filter for published sources in the Cantus segment only
+        published_sources = Source.objects.filter(
+            published=True, segment_m2m=CANTUS_SEGMENT_ID
+        )
 
         if source_ids:
             published_sources = published_sources.filter(id__in=source_ids)
@@ -28,20 +34,40 @@ class Command(BaseCommand):
                 return
 
         updated_chants_count = 0
+        error_count = 0
         chunk_size = 500  # Process in smaller chunks to avoid memory issues
 
+        total_sources = published_sources.count()
+        processed_sources = 0
+
         for source in published_sources.iterator():
-            self.stdout.write(f"Processing source: {source} (ID: {source.id})")
+            processed_sources += 1
+            remaining_sources = total_sources - processed_sources
+
+            self.stdout.write(
+                f"Processing source {processed_sources}/{total_sources}: {source} (ID: {source.id}) "
+                f"[{remaining_sources} remaining]"
+            )
 
             chant_count = 0
+            source_error_count = 0
             # Use iterator to avoid loading all chants into memory at once
-            for chant in Chant.objects.filter(source=source).iterator(
-                chunk_size=chunk_size
+            for chant in (
+                Chant.objects.filter(source=source)
+                .filter(other_fields_proofread=False)
+                .iterator(chunk_size=chunk_size)
             ):
-                chant.other_fields_proofread = True
-                chant.save()  # This ensures signals are fired
-                chant_count += 1
-                updated_chants_count += 1
+                try:
+                    chant.other_fields_proofread = True
+                    chant.save()  # This ensures signals are fired
+                    chant_count += 1
+                    updated_chants_count += 1
+                except Exception as e:
+                    error_count += 1
+                    source_error_count += 1
+                    self.stdout.write(
+                        self.style.WARNING(f"  Error saving chant {chant.id}: {str(e)}")
+                    )
 
                 # Progress reporting every 100 chants
                 if chant_count % 100 == 0:
@@ -49,14 +75,24 @@ class Command(BaseCommand):
                         f"  Processed {chant_count} chants for this source..."
                     )
 
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f"Successfully updated {chant_count} chants for source: {source}"
-                )
+            success_msg = (
+                f"Successfully updated {chant_count} chants for source: {source}"
             )
+            if source_error_count > 0:
+                success_msg += f" ({source_error_count} errors)"
+
+            self.stdout.write(self.style.SUCCESS(success_msg))
 
         self.stdout.write(
             self.style.SUCCESS(
                 f"Finished updating. Total chants updated: {updated_chants_count}."
             )
         )
+
+        if error_count > 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Total errors encountered: {error_count}. "
+                    f"Check the log above for details."
+                )
+            )

--- a/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
+++ b/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
@@ -3,7 +3,7 @@ from main_app.models import Source, Chant
 
 
 class Command(BaseCommand):
-    help = "Updates proofread-related fields to True for chants in published sources."
+    help = "Updates the 'other_fields_proofread' field to True for chants in published sources."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -28,19 +28,31 @@ class Command(BaseCommand):
                 return
 
         updated_chants_count = 0
+        chunk_size = 500  # Process in smaller chunks to avoid memory issues
 
-        for source in published_sources:
-            chants_to_update = Chant.objects.filter(source=source)
-            for chant in chants_to_update:
+        for source in published_sources.iterator():
+            self.stdout.write(f"Processing source: {source} (ID: {source.id})")
+
+            chant_count = 0
+            # Use iterator to avoid loading all chants into memory at once
+            for chant in Chant.objects.filter(source=source).iterator(
+                chunk_size=chunk_size
+            ):
                 chant.other_fields_proofread = True
-                chant.manuscript_full_text_std_proofread = True
-                chant.manuscript_full_text_proofread = True
-                chant.volpiano_proofread = True
-                chant.save()
+                chant.save()  # This ensures signals are fired
+                chant_count += 1
                 updated_chants_count += 1
 
+                # Progress reporting every 100 chants
+                if chant_count % 100 == 0:
+                    self.stdout.write(
+                        f"  Processed {chant_count} chants for this source..."
+                    )
+
             self.stdout.write(
-                self.style.SUCCESS(f"Successfully updated chants for source: {source}")
+                self.style.SUCCESS(
+                    f"Successfully updated {chant_count} chants for source: {source}"
+                )
             )
 
         self.stdout.write(

--- a/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
+++ b/django/cantusdb_project/main_app/management/commands/update_proofread_status.py
@@ -1,0 +1,50 @@
+from django.core.management.base import BaseCommand
+from main_app.models import Source, Chant
+
+
+class Command(BaseCommand):
+    help = "Updates proofread-related fields to True for chants in published sources."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source_ids",
+            nargs="+",
+            type=int,
+            help="Optional list of source IDs to update.",
+        )
+
+    def handle(self, *args, **options):
+        source_ids = options["source_ids"]
+        published_sources = Source.objects.filter(published=True)
+
+        if source_ids:
+            published_sources = published_sources.filter(id__in=source_ids)
+            if not published_sources.exists():
+                self.stdout.write(
+                    self.style.WARNING(
+                        "No published sources found for the provided IDs."
+                    )
+                )
+                return
+
+        updated_chants_count = 0
+
+        for source in published_sources:
+            chants_to_update = Chant.objects.filter(source=source)
+            for chant in chants_to_update:
+                chant.other_fields_proofread = True
+                chant.manuscript_full_text_std_proofread = True
+                chant.manuscript_full_text_proofread = True
+                chant.volpiano_proofread = True
+                chant.save()
+                updated_chants_count += 1
+
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully updated chants for source: {source}")
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Finished updating. Total chants updated: {updated_chants_count}."
+            )
+        )


### PR DESCRIPTION
Add management command to update proofread status for chants in published sources.

This PR introduces a new management command `update_proofread_status`.

This command updates the `other_fields_proofread` field to True for chants within published sources

excludes sources in the `EXCLUDE` list

Related to #1833 and #1835. We should close #1833 once the command has been run.