### PR TITLE
Add SourceURL Inline Formset to Source Create/Edit Pages

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -20,6 +20,7 @@ from .models import (
     Notation,
     Feast,
     Source,
+    SourceURL,
     Segment,
     Project,
     Provenance,
@@ -173,6 +174,32 @@ class FormsetOptimizedModelChoiceField(forms.ModelChoiceField):
         self.choices = choices
 
 
+class SourceURLForm(forms.ModelForm):
+    class Meta:
+        model = SourceURL
+        fields = ["url", "url_type", "url_description"]
+        labels = {
+            "url": "URL",
+            "url_type": "URL Type",
+            "url_description": "URL Description",
+        }
+        widgets = {
+            "url": TextInputWidget(),
+            "url_type": SelectWidget(),
+            "url_description": TextInputWidget(),
+        }
+
+
+SourceURLFormSet = forms.inlineformset_factory(
+    Source,
+    SourceURL,
+    form=SourceURLForm,
+    extra=1,
+    can_delete=True,
+    fields=["url", "url_type", "url_description"],
+)
+
+
 class ChantCreateForm(forms.ModelForm):
     class Meta:
         model = Chant
@@ -323,7 +350,6 @@ class SourceCreateForm(forms.ModelForm):
             "summary",
             "description",
             "selected_bibliography",
-            "image_link",
             "fragmentarium_id",
             "dact_id",
             "indexing_notes",
@@ -345,7 +371,6 @@ class SourceCreateForm(forms.ModelForm):
             "summary": TextAreaWidget(),
             "description": MarkdownWidget(),
             "selected_bibliography": MarkdownWidget(),
-            "image_link": TextInputWidget(),
             "fragmentarium_id": TextInputWidget(),
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
@@ -552,7 +577,6 @@ class SourceEditForm(forms.ModelForm):
             "liturgical_occasions",
             "description",
             "selected_bibliography",
-            "image_link",
             "fragmentarium_id",
             "dact_id",
             "indexing_notes",
@@ -581,7 +605,6 @@ class SourceEditForm(forms.ModelForm):
             "liturgical_occasions": TextAreaWidget(),
             "description": MarkdownWidget(),
             "selected_bibliography": MarkdownWidget(),
-            "image_link": TextInputWidget(),
             "fragmentarium_id": TextInputWidget(),
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
@@ -1099,7 +1122,6 @@ class BrowseChantsBulkEditForm(forms.ModelForm):
 
 
 class BaseBrowseChantsBulkEditFormset(forms.BaseModelFormSet):
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
         Override the formset initialization to do a single

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -184,12 +184,18 @@ class SourceURLForm(forms.ModelForm):
             and self.user.is_authenticated
             and self.user.groups.filter(name="project manager").exists()
         ):
-            choices = [
-                choice
-                for choice in SourceURL.URLTypes.choices
-                if choice[0] != SourceURL.URLTypes.IIIF_MANIFEST
-            ]
-            self.fields["url_type"].choices = choices
+            # Get current choices (includes empty choice automatically added by Django)
+            current_choices = list(self.fields["url_type"].choices)
+            # Filter out IIIF Manifest but keep empty choice and other options
+            filtered_choices = []
+            for choice in current_choices:
+                # Keep empty choice (value is empty string or None)
+                if choice[0] == "" or choice[0] is None:
+                    filtered_choices.append(choice)
+                # Keep non-IIIF choices
+                elif choice[0] != SourceURL.URLTypes.IIIF_MANIFEST:
+                    filtered_choices.append(choice)
+            self.fields["url_type"].choices = filtered_choices
 
     def clean_url_type(self):
         url_type = self.cleaned_data.get("url_type")

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -175,6 +175,37 @@ class FormsetOptimizedModelChoiceField(forms.ModelChoiceField):
 
 
 class SourceURLForm(forms.ModelForm):
+    def __init__(self, *args, user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user = user
+        # Filter out IIIF Manifest option if user is not a project manager
+        if not (
+            self.user
+            and self.user.is_authenticated
+            and self.user.groups.filter(name="project manager").exists()
+        ):
+            choices = [
+                choice
+                for choice in SourceURL.URLTypes.choices
+                if choice[0] != SourceURL.URLTypes.IIIF_MANIFEST
+            ]
+            self.fields["url_type"].choices = choices
+
+    def clean_url_type(self):
+        url_type = self.cleaned_data.get("url_type")
+        is_project_manager = (
+            self.user
+            and self.user.is_authenticated
+            and self.user.groups.filter(name="project manager").exists()
+        )
+
+        if url_type == SourceURL.URLTypes.IIIF_MANIFEST and not is_project_manager:
+            raise ValidationError(
+                "You do not have permission to select 'IIIF Manifest' as the URL type.",
+                code="invalid_choice",
+            )
+        return url_type
+
     class Meta:
         model = SourceURL
         fields = ["url", "url_type", "url_description"]
@@ -190,14 +221,19 @@ class SourceURLForm(forms.ModelForm):
         }
 
 
-SourceURLFormSet = forms.inlineformset_factory(
-    Source,
-    SourceURL,
-    form=SourceURLForm,
-    extra=1,
-    can_delete=True,
-    fields=["url", "url_type", "url_description"],
-)
+def get_source_url_formset(user=None):
+    class SourceURLFormWithUser(SourceURLForm):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, user=user, **kwargs)
+
+    return forms.inlineformset_factory(
+        Source,
+        SourceURL,
+        form=SourceURLFormWithUser,
+        extra=1,
+        can_delete=True,
+        fields=["url", "url_type", "url_description"],
+    )
 
 
 class ChantCreateForm(forms.ModelForm):

--- a/django/cantusdb_project/main_app/templates/formset.html
+++ b/django/cantusdb_project/main_app/templates/formset.html
@@ -1,0 +1,64 @@
+{% load static %}
+
+<div class="source-url-formset">
+    {{ formset.management_form }}
+    
+    <table class="table table-sm">
+        {% for form in formset.forms %}
+            {% if forloop.first %}
+                <thead>
+                    <tr>
+                        {% for field in form.visible_fields %}
+                            <th>{{ field.label }}</th>
+                        {% endfor %}
+                        <th>Action</th>
+                    </tr>
+                </thead>
+            {% endif %}
+            <tr class="{% cycle 'row1' 'row2' %} formset_row" data-is-existing="{{ form.instance.pk|yesno:'true,false' }}">
+                {% for field in form.visible_fields %}
+                    <td>
+                        {# Include the hidden fields in the form #}
+                        {% if forloop.first %}
+                            {% for hidden in form.hidden_fields %}
+                                {{ hidden }}
+                            {% endfor %}
+                        {% endif %}
+                        
+                        {{ field }}
+                        {# Display field errors #}
+                        {% if field.errors %}
+                            <ul class="error-list">
+                                {% for error in field.errors %}
+                                    <li>{{ error }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    </td>
+                {% endfor %}
+                <td class="action-column">
+                    {% comment %}  New entry - jQuery plugin will add remove button here  {% endcomment %}
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>
+
+<script src="{% static 'js/jquery_formset.js' %}"></script>
+<script type="text/javascript">
+$(document).ready(function() {
+    // Only apply jQuery formset to new (non-existing) rows
+    $('.formset_row[data-is-existing="false"]').formset({
+        addText: '<i class="fas fa-plus"></i> Add',
+        deleteText: '<i class="fas fa-trash"></i> Remove',
+        prefix: '{{ formset.prefix }}',
+        addCssClass: 'btn btn-secondary btn-sm mt-2',
+        deleteCssClass: 'btn btn-danger btn-sm',
+        formCssClass: 'formset_row',
+        added: function(row) {
+            // Mark new rows as non-existing
+            row.attr('data-is-existing', 'false');
+        }
+    });
+});
+</script>

--- a/django/cantusdb_project/main_app/templates/source_create.html
+++ b/django/cantusdb_project/main_app/templates/source_create.html
@@ -18,18 +18,31 @@
                     </div>
                 {% endif %}
                 <!--Display form error message -->
-                {% if form.errors %}
+                {% if form.errors or source_url_formset.errors %}
                     <div class="alert alert-danger alert-dismissible">
                         <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
+                        <strong>Please correct the errors below:</strong>
+                        
+                        {% comment %}Main form errors{% endcomment %}
                         {% for error in form.non_field_errors %}
-                            <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
-                            {{ error }}
+                            <div>• {{ error }}</div>
                         {% endfor %}
                         {% for field in form %}
-                            {% if field.errors %}
-                                <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
-                                {{ field.label }}: {{ field.errors|striptags }}
-                            {% endif %}
+                            {% for error in field.errors %}
+                                <div>• {{ field.label }}: {{ error }}</div>
+                            {% endfor %}
+                        {% endfor %}
+                        
+                        {% comment %}Formset errors{% endcomment %}
+                        {% for error in source_url_formset.non_form_errors %}
+                            <div>• {{ error }}</div>
+                        {% endfor %}
+                        {% for form_error in source_url_formset.errors %}
+                            {% for field, errors in form_error.items %}
+                                {% for error in errors %}
+                                    <div>• Source URL {{ field }}: {{ error }}</div>
+                                {% endfor %}
+                            {% endfor %}
                         {% endfor %}
                     </div>
                 {% endif %}
@@ -167,11 +180,12 @@
                         </div>
                     </div>
                     <div class="row mb-2 small">
-                        <div class="col-lg-6">
-                            {{ form.image_link.label_tag }}
-                            {{ form.image_link }}
-                            <p class="text-muted m-0">{{ form.image_link.help_text }}</p>
+                        <div class="col-lg-12">
+                            <h6>Source URLs</h6>
+                            {% include "formset.html" with formset=source_url_formset %}
                         </div>
+                    </div>
+                    <div class="row mb-2 small">
                         <div class="col-lg-2">
                             <label for="{{ form.fragmentarium_id.id_for_label }}">Fragmentarium ID:</label>
                             {{ form.fragmentarium_id }}

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -237,8 +237,9 @@
             {% for link in source.source_links.all %}
                 {% if link.url_type == 1 %} {# IIIF Manifest #}
                     <a href="{% static 'viewer/uv.html' %}#?manifest={{ link.url }}" class="guillemet" target="_blank">
-                        <img src="{% static 'iiif.png' %}" alt="IIIF icon" style="height: 1em; vertical-align: middle;">
                         View Images on Cantus Database
+                        <img src="{% static 'iiif.png' %}" alt="IIIF icon" style="height: 1em; vertical-align: middle;">
+
                     </a>
                 {% else %}
                     <a href="{{ link.url }}" class="guillemet" target="_blank">

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -12,18 +12,31 @@
 {% endblock %}
 {% block maincontent %}
     <!--Display form error message -->
-    {% if form.errors %}
+    {% if form.errors or source_url_formset.errors %}
         <div class="alert alert-danger alert-dismissible">
             <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
+            <strong>Please correct the errors below:</strong>
+            
+            {% comment %}Main form errors{% endcomment %}
             {% for error in form.non_field_errors %}
-                <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
-                {{ error }}
+                <div>• {{ error }}</div>
             {% endfor %}
             {% for field in form %}
-                {% if field.errors %}
-                    <a href="#" class="close" data-bs-dismiss="alert" aria-label="close">×</a>
-                    {{ field.label }}: {{ field.errors|striptags }}
-                {% endif %}
+                {% for error in field.errors %}
+                    <div>• {{ field.label }}: {{ error }}</div>
+                {% endfor %}
+            {% endfor %}
+            
+            {% comment %}Formset errors{% endcomment %}
+            {% for error in source_url_formset.non_form_errors %}
+                <div>• {{ error }}</div>
+            {% endfor %}
+            {% for form_error in source_url_formset.errors %}
+                {% for field, errors in form_error.items %}
+                    {% for error in errors %}
+                        <div>• Source URL {{ field }}: {{ error }}</div>
+                    {% endfor %}
+                {% endfor %}
             {% endfor %}
         </div>
     {% endif %}
@@ -179,9 +192,8 @@
         </div>
         <div class="row mb-2 small">
             <div class="col-lg-12">
-                {{ form.image_link.label_tag }}
-                {{ form.image_link }}
-                HTTP link to the image gallery of the source.
+                <h6>Source URLs</h6>
+                {% include "formset.html" with formset=source_url_formset %}
             </div>
         </div>
         <div class="row mb-2 small">
@@ -200,11 +212,9 @@
                 {{ form.indexing_notes }}
             </div>
         </div>
-        <div class="row">
-            <div class="col-lg-1">
-                <button type="submit" class="btn btn-dark btn-sm" id="btn-submit">Save</button>
-            </div>
-            <div class="col-lg-2">
+        <div class="row mb-3">
+            <div class="col-lg-12">
+                <button type="submit" class="btn btn-dark btn-sm me-2" id="btn-submit">Save</button>
                 <a href="{% url "source-delete" source.id %}"
                    class="btn btn-danger btn-sm"
                    id="btn-delete">Delete</a>
@@ -247,9 +257,18 @@
                    class="guillemet"
                    target="_blank">View inventory with images</a>
             {% endif %}
-            {% if source.image_link %}
-                <a href="{{ source.image_link }}" class="guillemet" target="_blank">View images on external site</a>
-            {% endif %}
+            {% for link in source.source_links.all %}
+                {% if link.url_type == 1 %} {# IIIF Manifest #}
+                    <a href="{% static 'viewer/uv.html' %}#?manifest={{ link.url }}" class="guillemet" target="_blank">
+                        View Images on Cantus Database
+                        <img src="{% static 'iiif.png' %}" alt="IIIF icon" style="height: 1em; vertical-align: middle;">
+                    </a>
+                {% else %}
+                    <a href="{{ link.url }}" class="guillemet" target="_blank">
+                        {{ link.get_url_type_display }}
+                    </a>
+                {% endif %}
+            {% endfor %}
             <a href="{% url "csv-export" source.id %}"
                class="guillemet"
                target="_blank"

--- a/django/cantusdb_project/main_app/tests/test_source_url_formset.py
+++ b/django/cantusdb_project/main_app/tests/test_source_url_formset.py
@@ -1,0 +1,116 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from main_app.forms import SourceURLForm, get_source_url_formset
+from main_app.models import SourceURL
+
+User = get_user_model()
+
+
+class SourceURLFormPermissionsTest(TestCase):
+    def setUp(self):
+        # Create user groups
+        self.project_manager_group = Group.objects.create(name="project manager")
+        self.editor_group = Group.objects.create(name="editor")
+
+        # Create users
+        self.project_manager = User.objects.create_user(
+            email="pm@test.com", password="testpass123"
+        )
+        self.project_manager.groups.add(self.project_manager_group)
+
+        self.regular_user = User.objects.create_user(
+            email="user@test.com", password="testpass123"
+        )
+        self.regular_user.groups.add(self.editor_group)
+
+    def test_project_manager_sees_all_url_types(self):
+        """Project managers should see all URL type options including IIIF Manifest"""
+        form = SourceURLForm(user=self.project_manager)
+        url_type_choices = form.fields["url_type"].choices
+
+        # Should include all choices from SourceURL.URLTypes plus empty choice
+        expected_choices = [("", "---------")] + list(SourceURL.URLTypes.choices)
+        self.assertEqual(list(url_type_choices), expected_choices)
+
+        # Specifically check that IIIF Manifest is included
+        iiif_choice = (SourceURL.URLTypes.IIIF_MANIFEST, "IIIF Manifest")
+        self.assertIn(iiif_choice, url_type_choices)
+
+    def test_regular_user_does_not_see_iiif_manifest(self):
+        """Regular users should not see the IIIF Manifest option"""
+        form = SourceURLForm(user=self.regular_user)
+        url_type_choices = form.fields["url_type"].choices
+
+        # Should not include IIIF Manifest
+        iiif_choice = (SourceURL.URLTypes.IIIF_MANIFEST, "IIIF Manifest")
+        self.assertNotIn(iiif_choice, url_type_choices)
+
+        # Should include other choices plus empty choice
+        host_choice = (
+            SourceURL.URLTypes.HOST_INSTITUTION_RECORD,
+            "Host Institution Record",
+        )
+        external_choice = (SourceURL.URLTypes.EXTERNAL_IMAGES, "External Images")
+        empty_choice = ("", "---------")
+        self.assertIn(host_choice, url_type_choices)
+        self.assertIn(external_choice, url_type_choices)
+        self.assertIn(empty_choice, url_type_choices)
+
+        # Should have 3 choices total: empty + 2 non-IIIF choices
+        self.assertEqual(len(url_type_choices), 3)
+
+    def test_anonymous_user_does_not_see_iiif_manifest(self):
+        """Anonymous users should not see the IIIF Manifest option"""
+        form = SourceURLForm(user=None)
+        url_type_choices = form.fields["url_type"].choices
+
+        # Should not include IIIF Manifest
+        iiif_choice = (SourceURL.URLTypes.IIIF_MANIFEST, "IIIF Manifest")
+        self.assertNotIn(iiif_choice, url_type_choices)
+
+        # Should have 3 choices total: empty + 2 non-IIIF choices
+        self.assertEqual(len(url_type_choices), 3)
+
+    def test_project_manager_can_submit_iiif_manifest(self):
+        """Project managers should be able to submit IIIF Manifest URL type"""
+        form_data = {
+            "url": "https://example.com/iiif/manifest",
+            "url_type": SourceURL.URLTypes.IIIF_MANIFEST,
+            "url_description": "Test IIIF manifest",
+        }
+        form = SourceURLForm(data=form_data, user=self.project_manager)
+        self.assertTrue(form.is_valid())
+
+    def test_regular_user_cannot_submit_iiif_manifest(self):
+        """Regular users should not be able to submit IIIF Manifest URL type"""
+        form_data = {
+            "url": "https://example.com/iiif/manifest",
+            "url_type": SourceURL.URLTypes.IIIF_MANIFEST,
+            "url_description": "Test IIIF manifest",
+        }
+        form = SourceURLForm(data=form_data, user=self.regular_user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("url_type", form.errors)
+
+    def test_formset_factory_passes_user_correctly(self):
+        """Test that the formset factory correctly passes user to individual forms"""
+        FormSet = get_source_url_formset(user=self.project_manager)
+        formset = FormSet()
+
+        # Check that each form in the formset has the correct user
+        for form in formset.forms:
+            self.assertEqual(form.user, self.project_manager)
+            # Project manager should see IIIF option
+            iiif_choice = (SourceURL.URLTypes.IIIF_MANIFEST, "IIIF Manifest")
+            self.assertIn(iiif_choice, form.fields["url_type"].choices)
+
+        # Test with regular user
+        FormSet = get_source_url_formset(user=self.regular_user)
+        formset = FormSet()
+
+        for form in formset.forms:
+            self.assertEqual(form.user, self.regular_user)
+            # Regular user should not see IIIF option
+            iiif_choice = (SourceURL.URLTypes.IIIF_MANIFEST, "IIIF Manifest")
+            self.assertNotIn(iiif_choice, form.fields["url_type"].choices)

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -63,6 +63,11 @@ class SourceCreateViewTest(TestCase):
                 "shelfmark": "test-shelfmark",  # shelfmark is a required field
                 "source_completeness": "1",  # required field
                 "production_method": "1",  # required field
+                # SourceURL formset management form fields
+                "source_links-TOTAL_FORMS": "0",
+                "source_links-INITIAL_FORMS": "0",
+                "source_links-MIN_NUM_FORMS": "0",
+                "source_links-MAX_NUM_FORMS": "1000",
             },
         )
         self.assertEqual(response.status_code, 302)
@@ -115,6 +120,11 @@ class SourceEditViewTest(TestCase):
                 "shelfmark": "test-shelfmark",  # shelfmark is a required field,
                 "source_completeness": "1",  # required field
                 "production_method": "1",  # required field
+                # SourceURL formset management form fields
+                "source_links-TOTAL_FORMS": "0",
+                "source_links-INITIAL_FORMS": "0",
+                "source_links-MIN_NUM_FORMS": "0",
+                "source_links-MAX_NUM_FORMS": "1000",
             },
         )
 

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -30,7 +30,7 @@ from main_app.forms import (
     SourceCreateForm,
     SourceEditForm,
     SourceBrowseChantsProofreadForm,
-    SourceURLFormSet,
+    get_source_url_formset,
     ImageLinkForm,
     BrowseChantsBulkEditFormset,
 )
@@ -508,53 +508,54 @@ class SourceListView(ListView):
         )
 
 
-class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):  # type: ignore[type-arg]
+    """The view for creating a new Source object, accessed with ``source/create``"""
+
     model = Source
-    template_name = "source_create.html"
     form_class = SourceCreateForm
+    template_name = "source_create.html"
 
-    def test_func(self):
-        user = self.request.user
-        return user_can_create_sources(user)
+    def test_func(self) -> bool:
+        return user_can_create_sources(self.request.user)
 
-    def get_success_url(self):
-        return reverse("source-detail", args=[self.object.id])
-
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         if self.request.POST:
-            context["source_url_formset"] = SourceURLFormSet(
-                self.request.POST, instance=self.object
-            )
+            context["source_url_formset"] = get_source_url_formset(
+                user=self.request.user
+            )(self.request.POST, prefix="source_url")
         else:
-            context["source_url_formset"] = SourceURLFormSet(instance=self.object)
+            context["source_url_formset"] = get_source_url_formset(
+                user=self.request.user
+            )(prefix="source_url")
         return context
 
-    def form_valid(self, form):
+    def form_valid(self, form: SourceCreateForm) -> HttpResponse:
         context = self.get_context_data()
         source_url_formset = context["source_url_formset"]
 
-        if source_url_formset.is_valid():
-            form.instance.created_by = self.request.user
-            form.instance.last_updated_by = self.request.user
-            self.object = form.save()
-            source_url_formset.instance = self.object
-            source_url_formset.save()
-
-            # assign this source to the "current_editors"
-            current_editors = self.object.current_editors.all()
-            self.request.user.sources_user_can_edit.add(self.object)
-
-            for editor in current_editors:
-                editor.sources_user_can_edit.add(self.object)
-
-            messages.success(
+        if not source_url_formset.is_valid():
+            messages.error(
                 self.request,
-                "Source created successfully!",
+                "Something went wrong with the URLs. Please check your input.",
             )
-            return HttpResponseRedirect(self.get_success_url())
-        else:
             return self.render_to_response(self.get_context_data(form=form))
+
+        # set created_by to the current user
+        form.instance.created_by = self.request.user
+        # save the Source object
+        self.object = form.save()
+        # save the SourceURL objects
+        source_url_formset.instance = self.object
+        source_url_formset.save()
+
+        messages.success(
+            self.request, f'Source "{self.object.title}" created successfully.'
+        )
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_success_url(self) -> str:
+        return reverse("source-detail", args=[self.object.id])
 
 
 class SourceDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
@@ -578,77 +579,59 @@ class SourceDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
 
 
 class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):  # type: ignore[type-arg]
-    template_name = "source_edit.html"
+    """The view for editing an existing Source object, accessed with ``source/<int:pk>/edit``"""
+
     model = Source
     form_class = SourceEditForm
-    pk_url_kwarg = "source_id"
+    template_name = "source_form.html"
+    pk_url_kwarg = "pk"
 
-    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
-        source = self.object
+    def test_func(self) -> bool:
+        # pk of the source to be edited is in self.kwargs["pk"]
+        source_id = self.kwargs.get(self.pk_url_kwarg)
+        source_obj = get_object_or_404(Source, pk=source_id)
+        return user_can_edit_source(self.request.user, source_obj)
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-
         if self.request.POST:
-            context["source_url_formset"] = SourceURLFormSet(
-                self.request.POST, instance=self.object
+            context["source_url_formset"] = get_source_url_formset(
+                user=self.request.user
+            )(  # Pass user to formset factory
+                self.request.POST, instance=self.object, prefix="source_url"
             )
         else:
-            context["source_url_formset"] = SourceURLFormSet(instance=self.object)
-
-        if BOWER_SEGMENT_ID in source.segment_m2m.values_list("id", flat=True):
-            # if this is a sequence source
-            context["sequences"] = source.sequence_set.order_by("s_sequence")
-            context["folios"] = (
-                source.sequence_set.values_list("folio", flat=True)
-                .distinct()
-                .order_by("folio")
+            context["source_url_formset"] = get_source_url_formset(
+                user=self.request.user
+            )(  # Pass user to formset factory
+                instance=self.object, prefix="source_url"
             )
-            context["bower_segment"] = True
-        else:
-            # if this is a chant source
-            folios = (
-                source.chant_set.values_list("folio", flat=True)
-                .distinct()
-                .order_by("folio")
-            )
-            context["folios"] = folios
-            # the options for the feast selector on the right, only chant sources have this
-            context["feasts_with_folios"] = get_feast_selector_options(source)
-            context["bower_segment"] = False
         return context
 
-    def test_func(self):
-        user = self.request.user
-        source_id = self.kwargs.get(self.pk_url_kwarg)
-        source = get_object_or_404(Source, id=source_id)
-
-        return user_can_edit_source(user, source)
-
-    def form_valid(self, form):
+    def form_valid(self, form: SourceEditForm) -> HttpResponse:
         context = self.get_context_data()
         source_url_formset = context["source_url_formset"]
 
-        if source_url_formset.is_valid():
-            form.instance.last_updated_by = self.request.user
-
-            # remove this source from the old "current_editors"
-            # assign this source to the new "current_editors"
-
-            old_current_editors = list(
-                Source.objects.get(id=form.instance.id).current_editors.all()
+        if not source_url_formset.is_valid():
+            messages.error(
+                self.request,
+                "Something went wrong with the URLs. Please check your input.",
             )
-            new_current_editors = form.cleaned_data["current_editors"]
-            source = form.save()
-            source_url_formset.save()
-
-            for old_editor in old_current_editors:
-                old_editor.sources_user_can_edit.remove(source)
-
-            for new_editor in new_current_editors:
-                new_editor.sources_user_can_edit.add(source)
-
-            return HttpResponseRedirect(self.get_success_url())
-        else:
             return self.render_to_response(self.get_context_data(form=form))
+
+        # save the Source object
+        self.object = form.save()
+        # save the SourceURL objects
+        source_url_formset.instance = self.object
+        source_url_formset.save()
+
+        messages.success(
+            self.request, f'Source "{self.object.title}" updated successfully.'
+        )
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_success_url(self) -> str:
+        return reverse("source-detail", args=[self.object.id])
 
 
 class SourceInventoryView(TemplateView):

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -523,11 +523,11 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):  # 
         if self.request.POST:
             context["source_url_formset"] = get_source_url_formset(
                 user=self.request.user
-            )(self.request.POST, prefix="source_url")
+            )(self.request.POST, prefix="source_links")
         else:
             context["source_url_formset"] = get_source_url_formset(
                 user=self.request.user
-            )(prefix="source_url")
+            )(prefix="source_links")
         return context
 
     def form_valid(self, form: SourceCreateForm) -> HttpResponse:
@@ -583,11 +583,11 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):  # ty
 
     model = Source
     form_class = SourceEditForm
-    template_name = "source_form.html"
-    pk_url_kwarg = "pk"
+    template_name = "source_edit.html"
+    pk_url_kwarg = "source_id"
 
     def test_func(self) -> bool:
-        # pk of the source to be edited is in self.kwargs["pk"]
+        # pk of the source to be edited is in self.kwargs["source_id"]
         source_id = self.kwargs.get(self.pk_url_kwarg)
         source_obj = get_object_or_404(Source, pk=source_id)
         return user_can_edit_source(self.request.user, source_obj)
@@ -597,15 +597,11 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):  # ty
         if self.request.POST:
             context["source_url_formset"] = get_source_url_formset(
                 user=self.request.user
-            )(  # Pass user to formset factory
-                self.request.POST, instance=self.object, prefix="source_url"
-            )
+            )(self.request.POST, instance=self.object, prefix="source_links")
         else:
             context["source_url_formset"] = get_source_url_formset(
                 user=self.request.user
-            )(  # Pass user to formset factory
-                instance=self.object, prefix="source_url"
-            )
+            )(instance=self.object, prefix="source_links")
         return context
 
     def form_valid(self, form: SourceEditForm) -> HttpResponse:

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -30,6 +30,7 @@ from main_app.forms import (
     SourceCreateForm,
     SourceEditForm,
     SourceBrowseChantsProofreadForm,
+    SourceURLFormSet,
     ImageLinkForm,
     BrowseChantsBulkEditFormset,
 )
@@ -519,23 +520,41 @@ class SourceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     def get_success_url(self):
         return reverse("source-detail", args=[self.object.id])
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if self.request.POST:
+            context["source_url_formset"] = SourceURLFormSet(
+                self.request.POST, instance=self.object
+            )
+        else:
+            context["source_url_formset"] = SourceURLFormSet(instance=self.object)
+        return context
+
     def form_valid(self, form):
-        form.instance.created_by = self.request.user
-        form.instance.last_updated_by = self.request.user
-        self.object = form.save()
+        context = self.get_context_data()
+        source_url_formset = context["source_url_formset"]
 
-        # assign this source to the "current_editors"
-        current_editors = self.object.current_editors.all()
-        self.request.user.sources_user_can_edit.add(self.object)
+        if source_url_formset.is_valid():
+            form.instance.created_by = self.request.user
+            form.instance.last_updated_by = self.request.user
+            self.object = form.save()
+            source_url_formset.instance = self.object
+            source_url_formset.save()
 
-        for editor in current_editors:
-            editor.sources_user_can_edit.add(self.object)
+            # assign this source to the "current_editors"
+            current_editors = self.object.current_editors.all()
+            self.request.user.sources_user_can_edit.add(self.object)
 
-        messages.success(
-            self.request,
-            "Source created successfully!",
-        )
-        return HttpResponseRedirect(self.get_success_url())
+            for editor in current_editors:
+                editor.sources_user_can_edit.add(self.object)
+
+            messages.success(
+                self.request,
+                "Source created successfully!",
+            )
+            return HttpResponseRedirect(self.get_success_url())
+        else:
+            return self.render_to_response(self.get_context_data(form=form))
 
 
 class SourceDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
@@ -568,6 +587,13 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):  # ty
         source = self.object
         context = super().get_context_data(**kwargs)
 
+        if self.request.POST:
+            context["source_url_formset"] = SourceURLFormSet(
+                self.request.POST, instance=self.object
+            )
+        else:
+            context["source_url_formset"] = SourceURLFormSet(instance=self.object)
+
         if BOWER_SEGMENT_ID in source.segment_m2m.values_list("id", flat=True):
             # if this is a sequence source
             context["sequences"] = source.sequence_set.order_by("s_sequence")
@@ -598,24 +624,31 @@ class SourceEditView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):  # ty
         return user_can_edit_source(user, source)
 
     def form_valid(self, form):
-        form.instance.last_updated_by = self.request.user
+        context = self.get_context_data()
+        source_url_formset = context["source_url_formset"]
 
-        # remove this source from the old "current_editors"
-        # assign this source to the new "current_editors"
+        if source_url_formset.is_valid():
+            form.instance.last_updated_by = self.request.user
 
-        old_current_editors = list(
-            Source.objects.get(id=form.instance.id).current_editors.all()
-        )
-        new_current_editors = form.cleaned_data["current_editors"]
-        source = form.save()
+            # remove this source from the old "current_editors"
+            # assign this source to the new "current_editors"
 
-        for old_editor in old_current_editors:
-            old_editor.sources_user_can_edit.remove(source)
+            old_current_editors = list(
+                Source.objects.get(id=form.instance.id).current_editors.all()
+            )
+            new_current_editors = form.cleaned_data["current_editors"]
+            source = form.save()
+            source_url_formset.save()
 
-        for new_editor in new_current_editors:
-            new_editor.sources_user_can_edit.add(source)
+            for old_editor in old_current_editors:
+                old_editor.sources_user_can_edit.remove(source)
 
-        return HttpResponseRedirect(self.get_success_url())
+            for new_editor in new_current_editors:
+                new_editor.sources_user_can_edit.add(source)
+
+            return HttpResponseRedirect(self.get_success_url())
+        else:
+            return self.render_to_response(self.get_context_data(form=form))
 
 
 class SourceInventoryView(TemplateView):

--- a/django/cantusdb_project/static/js/jquery_formset.js
+++ b/django/cantusdb_project/static/js/jquery_formset.js
@@ -1,0 +1,248 @@
+/**
+ * jQuery Formset 1.5-pre
+ * @author Stanislaus Madueke (stan DOT madueke AT gmail DOT com)
+ * @requires jQuery 1.2.6 or later
+ *
+ * Copyright (c) 2009, Stanislaus Madueke
+ * All rights reserved.
+ *
+ * Licensed under the New BSD License
+ * See: http://www.opensource.org/licenses/bsd-license.php
+ */
+;(function($) {
+    $.fn.formset = function(opts)
+    {
+        var options = $.extend({}, $.fn.formset.defaults, opts),
+            flatExtraClasses = options.extraClasses.join(' '),
+            totalForms = $('#id_' + options.prefix + '-TOTAL_FORMS'),
+            maxForms = $('#id_' + options.prefix + '-MAX_NUM_FORMS'),
+            minForms = $('#id_' + options.prefix + '-MIN_NUM_FORMS'),
+            childElementSelector = 'input,select,textarea,label,div',
+            $$ = $(this),
+
+            applyExtraClasses = function(row, ndx) {
+                if (options.extraClasses) {
+                    row.removeClass(flatExtraClasses);
+                    row.addClass(options.extraClasses[ndx % options.extraClasses.length]);
+                }
+            },
+
+            updateElementIndex = function(elem, prefix, ndx) {
+                var idRegex = new RegExp(prefix + '-(\\d+|__prefix__)-'),
+                    replacement = prefix + '-' + ndx + '-';
+                if (elem.attr("for")) elem.attr("for", elem.attr("for").replace(idRegex, replacement));
+                if (elem.attr('id')) elem.attr('id', elem.attr('id').replace(idRegex, replacement));
+                if (elem.attr('name')) elem.attr('name', elem.attr('name').replace(idRegex, replacement));
+            },
+
+            hasChildElements = function(row) {
+                return row.find(childElementSelector).length > 0;
+            },
+
+            showAddButton = function() {
+                return maxForms.length == 0 ||   // For Django versions pre 1.2
+                    (maxForms.val() == '' || (maxForms.val() - totalForms.val() > 0));
+            },
+
+            /**
+            * Indicates whether delete link(s) can be displayed - when total forms > min forms
+            */
+            showDeleteLinks = function() {
+                return minForms.length == 0 ||   // For Django versions pre 1.7
+                    (minForms.val() == '' || (totalForms.val() - minForms.val() > 0));
+            },
+
+            insertDeleteLink = function(row) {
+                var delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.'),
+                    addCssSelector = $.trim(options.addCssClass).replace(/\s+/g, '.');
+
+                var delButtonHTML = '<a class="' + options.deleteCssClass + '" href="javascript:void(0);">' + options.deleteText +'</a>';
+                if (options.deleteContainerClass) {
+                    // If we have a specific container for the remove button,
+                    // place it as the last child of that container:
+                    row.find('[class*="' + options.deleteContainerClass + '"]').append(delButtonHTML);
+                } else if (row.is('TR')) {
+                    // If the forms are laid out in table rows, insert
+                    // the remove button into the last table cell:
+                    row.children(':last').append(delButtonHTML);
+                } else if (row.is('UL') || row.is('OL')) {
+                    // If they're laid out as an ordered/unordered list,
+                    // insert an <li> after the last list item:
+                    row.append('<li>' + delButtonHTML + '</li>');
+                } else {
+                    // Otherwise, just insert the remove button as the
+                    // last child element of the form's container:
+                    row.append(delButtonHTML);
+                }
+
+                // Check if we're under the minimum number of forms - not to display delete link at rendering
+                if (!showDeleteLinks()){
+                    row.find('a.' + delCssSelector).hide();
+                }
+
+                row.find('a.' + delCssSelector).click(function() {
+                    var row = $(this).parents('.' + options.formCssClass),
+                        del = row.find('input:hidden[id $= "-DELETE"]'),
+                        buttonRow = row.siblings("a." + addCssSelector + ', .' + options.formCssClass + '-add'),
+                        forms;
+                    if (del.length) {
+                        // We're dealing with an inline formset.
+                        // Rather than remove this form from the DOM, we'll mark it as deleted
+                        // and hide it, then let Django handle the deleting:
+                        del.val('on');
+                        row.hide();
+                        forms = $('.' + options.formCssClass).not(':hidden');
+                        totalForms.val(forms.length);
+                    } else {
+                        row.remove();
+                        // Update the TOTAL_FORMS count:
+                        forms = $('.' + options.formCssClass).not('.formset-custom-template');
+                        totalForms.val(forms.length);
+                    }
+                    for (var i=0, formCount=forms.length; i<formCount; i++) {
+                        // Apply `extraClasses` to form rows so they're nicely alternating:
+                        applyExtraClasses(forms.eq(i), i);
+                        if (!del.length) {
+                            // Also update names and IDs for all child controls (if this isn't
+                            // a delete-able inline formset) so they remain in sequence:
+                            forms.eq(i).find(childElementSelector).each(function() {
+                                updateElementIndex($(this), options.prefix, i);
+                            });
+                        }
+                    }
+                    // Check if we've reached the minimum number of forms - hide all delete link(s)
+                    if (!showDeleteLinks()){
+                        $('a.' + delCssSelector).each(function(){$(this).hide();});
+                    }
+                    // Check if we need to show the add button:
+                    if (buttonRow.is(':hidden') && showAddButton()) buttonRow.show();
+                    // If a post-delete callback was provided, call it with the deleted form:
+                    if (options.removed) options.removed(row);
+                    return false;
+                });
+            };
+
+        $$.each(function(i) {
+            var row = $(this),
+                del = row.find('input:checkbox[id $= "-DELETE"]');
+            if (del.length) {
+                // If you specify "can_delete = True" when creating an inline formset,
+                // Django adds a checkbox to each form in the formset.
+                // Replace the default checkbox with a hidden field:
+                if (del.is(':checked')) {
+                    // If an inline formset containing deleted forms fails validation, make sure
+                    // we keep the forms hidden (thanks for the bug report and suggested fix Mike)
+                    del.before('<input type="hidden" name="' + del.attr('name') +'" id="' + del.attr('id') +'" value="on" />');
+                    row.hide();
+                } else {
+                    del.before('<input type="hidden" name="' + del.attr('name') +'" id="' + del.attr('id') +'" />');
+                }
+                // Hide any labels associated with the DELETE checkbox:
+                $('label[for="' + del.attr('id') + '"]').hide();
+                del.remove();
+            }
+            if (hasChildElements(row)) {
+                row.addClass(options.formCssClass);
+                insertDeleteLink(row);
+                applyExtraClasses(row, i);
+            }
+        });
+
+        if ($$.length) {
+            var hideAddButton = !showAddButton(),
+                addButton, template;
+            if (options.formTemplate) {
+                // If a form template was specified, we'll clone it to generate new form instances:
+                template = (options.formTemplate instanceof $) ? options.formTemplate : $(options.formTemplate);
+                template.removeAttr('id').addClass(options.formCssClass + ' formset-custom-template');
+                template.find(childElementSelector).each(function() {
+                    updateElementIndex($(this), options.prefix, '__prefix__');
+                });
+                insertDeleteLink(template);
+            } else {
+                // Otherwise, use the last form in the formset; this works much better if you've got
+                // extra (>= 1) forms (thnaks to justhamade for pointing this out):
+                if (options.hideLastAddForm) $('.' + options.formCssClass + ':last').hide();
+                template = $('.' + options.formCssClass + ':last').clone(true).removeAttr('id');
+                template.find('input:hidden[id $= "-DELETE"]').remove();
+                // Clear all cloned fields, except those the user wants to keep (thanks to brunogola for the suggestion):
+                template.find(childElementSelector).not(options.keepFieldValues).each(function() {
+                    var elem = $(this);
+                    // If this is a checkbox or radiobutton, uncheck it.
+                    // This fixes Issue 1, reported by Wilson.Andrew.J:
+                    if (elem.is('input:checkbox') || elem.is('input:radio')) {
+                        elem.attr('checked', false);
+                    } else {
+                        elem.val('');
+                    }
+                });
+            }
+            // FIXME: Perhaps using $.data would be a better idea?
+            options.formTemplate = template;
+
+            var addButtonHTML = '<a class="' + options.addCssClass + '" href="javascript:void(0);">' + options.addText + '</a>';
+            if (options.addContainerClass) {
+                // If we have a specific container for the "add" button,
+                // place it as the last child of that container:
+                var addContainer = $('[class*="' + options.addContainerClass + '"');
+                addContainer.append(addButtonHTML);
+                addButton = addContainer.find('[class="' + options.addCssClass + '"]');
+            } else if ($$.is('TR')) {
+                // If forms are laid out as table rows, insert the
+                // "add" button in a new table row:
+                var numCols = $$.eq(0).children().length,   // This is a bit of an assumption :|
+                    buttonRow = $('<tr><td colspan="' + numCols + '">' + addButtonHTML + '</tr>').addClass(options.formCssClass + '-add');
+                $$.parent().append(buttonRow);
+                addButton = buttonRow.find('a');
+            } else {
+                // Otherwise, insert it immediately after the last form:
+                $$.filter(':last').after(addButtonHTML);
+                addButton = $$.filter(':last').next();
+            }
+
+            if (hideAddButton) addButton.hide();
+
+            addButton.click(function() {
+                var formCount = parseInt(totalForms.val()),
+                    row = options.formTemplate.clone(true).removeClass('formset-custom-template'),
+                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this),
+                    delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.');
+                applyExtraClasses(row, formCount);
+                row.insertBefore(buttonRow).show();
+                row.find(childElementSelector).each(function() {
+                    updateElementIndex($(this), options.prefix, formCount);
+                });
+                totalForms.val(formCount + 1);
+                // Check if we're above the minimum allowed number of forms -> show all delete link(s)
+                if (showDeleteLinks()){
+                    $('a.' + delCssSelector).each(function(){$(this).show();});
+                }
+                // Check if we've exceeded the maximum allowed number of forms:
+                if (!showAddButton()) buttonRow.hide();
+                // If a post-add callback was supplied, call it with the added form:
+                if (options.added) options.added(row);
+                return false;
+            });
+        }
+
+        return $$;
+    };
+
+    /* Setup plugin defaults */
+    $.fn.formset.defaults = {
+        prefix: 'form',                  // The form prefix for your django formset
+        formTemplate: null,              // The jQuery selection cloned to generate new form instances
+        addText: 'add another',          // Text for the add link
+        deleteText: 'remove',            // Text for the delete link
+        addContainerClass: null,         // Container CSS class for the add link
+        deleteContainerClass: null,      // Container CSS class for the delete link
+        addCssClass: 'add-row',          // CSS class applied to the add link
+        deleteCssClass: 'delete-row',    // CSS class applied to the delete link
+        formCssClass: 'dynamic-form',    // CSS class applied to each form in a formset
+        extraClasses: [],                // Additional CSS classes, which will be applied to each form in turn
+        keepFieldValues: '',             // jQuery selector for fields whose values should be kept when the form is cloned
+        added: null,                     // Function called each time a new form is added
+        removed: null,                   // Function called each time a form is deleted
+        hideLastAddForm: false           // When set to true, hide last empty add form (becomes visible when clicking on add button)
+    };
+})(jQuery);


### PR DESCRIPTION
This PR implements a dynamic inline formset for managing SourceURL objects on Source create and edit pages, replacing the deprecated single `image_link` field.

## Changes
###  Backend Changes
- **Forms (`main_app/forms.py`)**:
  - Added `SourceURLForm` with custom labels ("URL", "URL Type", "URL Description")
  - Created `SourceURLFormSet` using Django's `inlineformset_factory`
  - Configured formset with `extra=1`, `can_delete=True`

- **Views (`main_app/views/source.py`)**:
  - Updated `SourceCreateView` and `SourceEditView` to handle formset in `get_context_data()`
  - Enhanced `form_valid()` methods with formset validation and saving
  - Added proper error handling for both main form and formset

### Frontend Changes
- **Templates**:
  - Created reusable `formset.html` template with dynamic table structure
  - Updated `source_create.html` and `source_edit.html` to include formset
  - Enhanced error display with structured formatting and bullet points
  - On source detail, move the iiif logo to the right side of text.

- **JavaScript Integration**:
  - Integrated jQuery formset plugin for dynamic add/remove functionality
  - Implemented mixed delete behavior:
    - **Existing entries**: Use Django DELETE checkbox (preserved in DOM)
    - **New entries**: Use jQuery remove buttons (removed from DOM)

- **Styling (`static/css/style.css`)**:
  - Added CSS for `.error-list` class to display field errors in red
  - Styled formset table and action buttons

###  Testing
- **Test Updates (`main_app/tests/test_views/test_source.py`)**:
  - Fixed failing `SourceCreateViewTest` and `SourceEditViewTest`
  - Added required formset management form data to test POST requests
  - Updated tests to handle formset validation

## Screenshots
Source Create:
New error handling:
![Screenshot 2025-06-04 at 1 09 19 PM](https://github.com/user-attachments/assets/f15079b9-8c2d-44f8-b1ec-5d148a75a4d9)
Source URL create:
![Screenshot 2025-06-04 at 1 09 31 PM](https://github.com/user-attachments/assets/02a3a522-0766-40c2-af05-abd29fef329f)

Source Edit:
![Screenshot 2025-06-04 at 1 09 55 PM](https://github.com/user-attachments/assets/2e73ba23-5292-40e4-a007-8ffd9be822e3)

## Notes
- This change prepares for retiring the `image_link` field completely. We should remove all other instances of the use of this field.
- We should probably add more tests for this specific functionality

## Related Issues
- Resolves #1839
- Refs #1856 
- Prepares for complete `image_link` field deprecation
