### PR TITLE
Fix logout functionality

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -224,8 +224,12 @@
                                 <a href="{% url 'user-detail' request.user.id %}">{{ request.user }}</a>
                                 |
                                 <a href="{% url 'change-password' %}">Change Password</a>
-                                |
-                                <a href="{% url 'logout' %}">Log out</a>
+                                <div class="mt-3">
+                                    <form method="post" action="{% url 'logout' %}">
+                                        {% csrf_token %}
+                                        <button type="submit" class="btn btn-dark">Log out</button>
+                                    </form>
+                                </div>
                             {% else %}
                                 <h5>Login for Contributors</h5>
                                 <a href="{% url 'login' %}?next={{ request.path }}">


### PR DESCRIPTION
Django's LogoutView by default only accepts POST requests for security reasons.

Fixes #1866 