### PR TITLE
Remove segment restrictions for chant browsing and show links conditionally

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -202,33 +202,31 @@
             <h4>{{ source.short_heading }}</h4>
         </div>
         <div class="card-body small">
-            {% if not bower_segment %}
-                {# all of the following are different ways to link to the Chant List page #}
-                {# Since sources in the Bower segment contain no chants, the Chant List page #}
-                {# is currently set up to raise a 404 if you try to access it for a source in #}
-                {# the Bower segment. So, we need to display this section only for sources in #}
-                {# the CANTUS segment #}
-                <select id="folioSelect"
-                        class="card-folio-select"
-                        onchange="jumpToFolio({{ source.id }})">
-                    <option value="">Select a folio:</option>
-                    {% for folio in folios %}<option value="{{ folio }}">{{ folio }}</option>{% endfor %}
-                </select>
-                <select id="feastSelect"
-                        class="card-feast-select"
-                        onchange="jumpToFeast({{ source.id }})">
-                    <option value="">Select a feast:</option>
-                    {% for feast_id, feast_name, folio_range in feasts_with_folios %}
-                        <option value="{{ feast_id }}">{{ feast_name }} ({{ folio_range }})</option>
-                    {% endfor %}
-                </select>
-                <a href="{% url "browse-chants" source.id %}"
+            {% if has_chants %}
+                {% if not bower_segment %}
+                    {# all of the following are different ways to link to the Chant List page #}
+                    <select id="folioSelect"
+                            class="card-folio-select"
+                            onchange="jumpToFolio({{ source.id }})">
+                        <option value="">Select a folio:</option>
+                        {% for folio in folios %}<option value="{{ folio }}">{{ folio }}</option>{% endfor %}
+                    </select>
+                    <select id="feastSelect"
+                            class="card-feast-select"
+                            onchange="jumpToFeast({{ source.id }})">
+                        <option value="">Select a feast:</option>
+                        {% for feast_id, feast_name, folio_range in feasts_with_folios %}
+                            <option value="{{ feast_id }}">{{ feast_name }} ({{ folio_range }})</option>
+                        {% endfor %}
+                    </select>
+                    <a href="{% url "browse-chants" source.id %}"
+                       class="guillemet"
+                       target="_blank">View all chants</a>
+                {% endif %}
+                <a href="{% url "source-inventory" source.id %}"
                    class="guillemet"
-                   target="_blank">View all chants</a>
+                   target="_blank">View full inventory</a>
             {% endif %}
-            <a href="{% url "source-inventory" source.id %}"
-               class="guillemet"
-               target="_blank">View full inventory</a>
             {% if source.exists_on_cantus_ultimus %}
                 <a href="https://cantus.simssa.ca/manuscript/{{ source.id }}"
                    class="guillemet"

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -289,6 +289,8 @@ class SourceDetailViewTest(SourcePermissionsTestCase):
     def test_chant_list_link(self) -> None:
         cantus_segment = make_fake_segment(id=4063)
         cantus_source = make_fake_source(segment=[cantus_segment])
+        # Add a chant so the source has content and link should appear
+        make_fake_chant(source=cantus_source)
         chant_list_link = reverse("browse-chants", args=[cantus_source.id])
 
         cantus_source_response = self.client.get(
@@ -297,14 +299,14 @@ class SourceDetailViewTest(SourcePermissionsTestCase):
         cantus_source_html = str(cantus_source_response.content)
         self.assertIn(chant_list_link, cantus_source_html)
 
-        bower_segment = make_fake_segment(id=4064)
-        bower_source = make_fake_source(segment=[bower_segment])
-        bower_chant_list_link = reverse("browse-chants", args=[bower_source.id])
-        bower_source_response = self.client.get(
-            reverse("source-detail", args=[bower_source.id])
+        # Sources without chants should not show the link
+        source_no_chants = make_fake_source(segment=[cantus_segment])
+        no_chants_response = self.client.get(
+            reverse("source-detail", args=[source_no_chants.id])
         )
-        bower_source_html = str(bower_source_response.content)
-        self.assertNotIn(bower_chant_list_link, bower_source_html)
+        no_chants_html = str(no_chants_response.content)
+        no_chants_link = reverse("browse-chants", args=[source_no_chants.id])
+        self.assertNotIn(no_chants_link, no_chants_html)
 
     def test_json_response(self) -> None:
         source = make_fake_source()
@@ -328,9 +330,18 @@ class SourceInventoryViewTest(HTMLContentsTestMixin, SourcePermissionsTestCase):
 
     def test_url_and_templates(self):
         source = make_fake_source()
+        make_fake_chant(source=source)
         response = self.client.get(reverse("source-inventory", args=[source.id]))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "full_inventory.html")
+
+    def test_no_chants_returns_404(self):
+        # Test that sources without chants return 404
+        source_no_chants = make_fake_source(published=True)
+        response = self.client.get(
+            reverse("source-inventory", args=[source_no_chants.id])
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_chant_source_queryset(self):
         chant_source = make_fake_source()
@@ -538,6 +549,7 @@ class SourceInventoryViewTest(HTMLContentsTestMixin, SourcePermissionsTestCase):
         cantus_segment = make_fake_segment(id=4063)
         source = make_fake_source(segment=[cantus_segment])
         source_id = source.id
+        make_fake_chant(source=source)
 
         url = reverse("redirect-source-inventory")
         response = self.client.get(f"{url}?source={source_id}")
@@ -581,6 +593,7 @@ class SourceBrowseChantsViewTest(SourcePermissionsTestCase):
     def test_url_and_templates(self):
         cantus_segment = make_fake_segment(id=4063)
         source = make_fake_source(segment=[cantus_segment])
+        make_fake_chant(source=source)
         response = self.client.get(reverse("browse-chants", args=[source.id]))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "base.html")
@@ -589,16 +602,23 @@ class SourceBrowseChantsViewTest(SourcePermissionsTestCase):
     def test_visibility_by_segment(self):
         cantus_segment = make_fake_segment(id=4063)
         cantus_source = make_fake_source(segment=[cantus_segment], published=True)
+        # Add a chant so the source has content
+        make_fake_chant(source=cantus_source)
         response_1 = self.client.get(reverse("browse-chants", args=[cantus_source.id]))
         self.assertEqual(response_1.status_code, 200)
 
-        # The chant list ("Browse Chants") page should only be visitable
-        # for sources in the CANTUS Database segment, as sources in the Bower
-        # segment contain no chants
+        # Sources without chants should return 404
         bower_segment = make_fake_segment(id=4064)
         bower_source = make_fake_source(segment=[bower_segment], published=True)
         response_1 = self.client.get(reverse("browse-chants", args=[bower_source.id]))
         self.assertEqual(response_1.status_code, 404)
+
+    def test_no_chants_returns_404(self):
+        # Test that sources without chants return 404
+        cantus_segment = make_fake_segment(id=4063)
+        source_no_chants = make_fake_source(segment=[cantus_segment], published=True)
+        response = self.client.get(reverse("browse-chants", args=[source_no_chants.id]))
+        self.assertEqual(response.status_code, 404)
 
     def test_filter_by_source(self):
         cantus_segment = make_fake_segment(id=4063)
@@ -786,6 +806,7 @@ class SourceBrowseChantsViewTest(SourcePermissionsTestCase):
     def test_redirect_with_source_parameter(self):
         cantus_segment = make_fake_segment(id=4063)
         source = make_fake_source(segment=[cantus_segment])
+        make_fake_chant(source=source)
         source_id = source.id
 
         url = reverse("redirect-chants")

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -786,6 +786,7 @@ class SourceBrowseChantsViewTest(SourcePermissionsTestCase):
     def test_context_source(self):
         cantus_segment = make_fake_segment(id=4063)
         source = make_fake_source(segment=[cantus_segment])
+        make_fake_chant(source=source)
         response = self.client.get(reverse("browse-chants", args=[source.id]))
         self.assertEqual(source, response.context["source"])
 

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -165,8 +165,7 @@ class SourceBrowseChantsView(CustomAccessMixin, ListView):  # type: ignore[type-
         source: Source = self.source
 
         # Check if source has any chants - if not, return 404
-        chants_in_source = source.chant_set
-        if chants_in_source.count() == 0:
+        if not source.chant_set.exists():
             raise Http404()
 
         context["source"] = source

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -163,10 +163,10 @@ class SourceBrowseChantsView(CustomAccessMixin, ListView):  # type: ignore[type-
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context_data(**kwargs)
         source: Source = self.source
-        if not CANTUS_SEGMENT_ID in source.segment_m2m.values_list("id", flat=True):
-            # the chant list ("Browse Chants") page should only be visitable
-            # for sources in the CANTUS Database segment, as sources in the Bower
-            # segment contain no chants
+
+        # Check if source has any chants - if not, return 404
+        chants_in_source = source.chant_set
+        if chants_in_source.count() == 0:
             raise Http404()
 
         context["source"] = source
@@ -283,17 +283,16 @@ class SourceDetailView(CustomAccessMixin, JSONResponseMixin, DetailView):  # typ
                 sequences.values_list("folio", flat=True).distinct().order_by("folio")
             )
             context["bower_segment"] = True
+            context["has_chants"] = sequences.exists()
         else:
             # if this is a chant source
-            folios = (
-                source.chant_set.values_list("folio", flat=True)
-                .distinct()
-                .order_by("folio")
-            )
+            chants = source.chant_set
+            folios = chants.values_list("folio", flat=True).distinct().order_by("folio")
             context["folios"] = folios
             # the options for the feast selector on the right, only chant sources have this
             context["feasts_with_folios"] = get_feast_selector_options(source)
             context["bower_segment"] = False
+            context["has_chants"] = chants.exists()
 
         context["user_can_edit_chants"] = self.user_assigned_to_source(source)
         context["user_can_edit_source"] = (
@@ -643,6 +642,11 @@ class SourceInventoryView(CustomAccessMixin, ListView):  # type: ignore[type-arg
                 .order_by("folio", "c_sequence")
                 .select_related("feast", "service", "genre", "diff_db")
             )
+
+        # Return 404 if no chants/sequences exist
+        if not queryset.exists():
+            raise Http404()
+
         return queryset
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
- Remove CANTUS segment check in SourceBrowseChantsView
- Return 404 for sources with no chants in browse/inventory views  
- Only show "View all chants" and "View full inventory" links when source has chants
- Add has_chants context to SourceDetailView

Fixes #1845 