### PR TITLE
Fix HTML entity display in source list templates

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -231,12 +231,12 @@
                                         </td>
                                         <td class="text-wrap"
                                             style="text-align:center"
-                                            title="{{ source.summary|default:""|truncatechars_html:500 }}">
+                                            title="{{ source.summary|default:""|safe|truncatechars_html:500 }}">
                                             {% if source.name %}
-                                                <b>"{{ source.name }}"</b>
+                                                <b>"{{ source.name|safe }}"</b>
                                                 <br />
                                             {% endif %}
-                                            {{ source.summary|default:""|truncatechars_html:120 }}
+                                            {{ source.summary|default:""|safe|truncatechars_html:120 }}
                                         </td>
                                         <td class="text-wrap" style="text-align:center">
                                             {% if source.century %}

--- a/django/cantusdb_project/main_app/templates/source_lists/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/source_list.html
@@ -168,12 +168,12 @@
                         </td>
                         <td class="text-wrap"
                             style="text-align:center"
-                            title="{{ source.summary|default:""|truncatechars_html:500 }}">
+                            title="{{ source.summary|default:""|safe|truncatechars_html:500 }}">
                             {% if source.name %}
-                                <b>"{{ source.name }}"</b>
+                                <b>"{{ source.name|safe }}"</b>
                                 <br />
                             {% endif %}
-                            {{ source.summary|default:""|truncatechars_html:120 }}
+                            {{ source.summary|default:""|safe|truncatechars_html:120 }}
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             {% if source.century %}


### PR DESCRIPTION
Add 'safe' filter to source.name and source.summary fields

Fixes #1875 