### PR TITLE
Fix outstanding permissions errors/issues

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -350,7 +350,7 @@ class SourceCreateForm(forms.ModelForm):
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
             "current_editors": autocomplete.ModelSelect2Multiple(
-                url="current-editors-autocomplete"
+                url="active-users-autocomplete"
             ),
             "melodies_entered_by": autocomplete.ModelSelect2Multiple(
                 url="all-users-autocomplete"
@@ -556,7 +556,6 @@ class SourceEditForm(forms.ModelForm):
             "fragmentarium_id",
             "dact_id",
             "indexing_notes",
-            "current_editors",
             "melodies_entered_by",
             "inventoried_by",
             "full_text_entered_by",
@@ -585,9 +584,6 @@ class SourceEditForm(forms.ModelForm):
             "fragmentarium_id": TextInputWidget(),
             "dact_id": TextInputWidget(),
             "indexing_notes": TextAreaWidget(),
-            "current_editors": autocomplete.ModelSelect2Multiple(
-                url="current-editors-autocomplete"
-            ),
             "melodies_entered_by": autocomplete.ModelSelect2Multiple(
                 url="all-users-autocomplete"
             ),

--- a/django/cantusdb_project/main_app/permissions.py
+++ b/django/cantusdb_project/main_app/permissions.py
@@ -161,6 +161,11 @@ class CustomAccessMixin(AccessMixin):
             return self.src_perm_cache.get(source.id)
         return self.check_user_assignment(source)
 
+    def user_created_source(self, source: Source) -> bool:
+        if source.created_by == self.user:
+            return True
+        return False
+
     def check_user_assignment(self, source: Source) -> bool:
         """
         Runs a database query to check if the user is assigned to a source.

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -105,12 +105,6 @@
         </div>
         <div class="row mb-2 small">
             <div class="col-lg-3">
-                {{ form.current_editors.label_tag }}
-                {{ form.current_editors }}
-            </div>
-        </div>
-        <div class="row mb-2 small">
-            <div class="col-lg-3">
                 {{ form.melodies_entered_by.label_tag }}
                 {{ form.melodies_entered_by }}
             </div>

--- a/django/cantusdb_project/main_app/tests/test_views/test_autocomplete.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_autocomplete.py
@@ -25,22 +25,25 @@ class AutocompleteViewsTest(TestCase):
         u2 = get_user_model().objects.create(full_name="Lucas")
         editor = Group.objects.get(name="editor")
         editor.user_set.add(u1)
+        inactive_user = get_user_model().objects.create(email="inactive@test.com")
+        inactive_user.is_active = False
+        inactive_user.save()
 
         for i in range(10):
             make_fake_century()
 
-    def test_current_editors_autocomplete(self):
-        response = self.client.get(reverse("current-editors-autocomplete"))
+    def test_active_users_autocomplete(self):
+        response = self.client.get(reverse("active-users-autocomplete"))
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
-        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(len(data["results"]), 3)
 
     def test_all_users_autocomplete(self):
         response = self.client.get(reverse("all-users-autocomplete"))
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(len(data["results"]), 3)
+        self.assertEqual(len(data["results"]), 4)
 
         response2 = self.client.get(reverse("all-users-autocomplete"), {"q": "L"})
         self.assertEqual(response2.status_code, 200)
@@ -55,7 +58,7 @@ class AutocompleteViewsTest(TestCase):
 
     def test_non_authenticated_user(self):
         self.client.logout()
-        response = self.client.get(reverse("current-editors-autocomplete"))
+        response = self.client.get(reverse("active-users-autocomplete"))
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["results"]), 0)

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -96,7 +96,7 @@ from main_app.views.user import (
 )
 from main_app.views.proofreading import ProofreadView
 from main_app.views.autocomplete import (
-    CurrentEditorsAutocomplete,
+    ActiveUsersAutocomplete,
     AllUsersAutocomplete,
     CenturyAutocomplete,
     FeastAutocomplete,
@@ -534,8 +534,8 @@ urlpatterns = [
         name="redirect-how-to-manuscript-descriptions",
     ),
     path(
-        "current-editors-autocomplete/",
-        CurrentEditorsAutocomplete.as_view(),
+        "active-users-autocomplete/",
+        ActiveUsersAutocomplete.as_view(),
         name="current-editors-autocomplete",
     ),
     path(

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -536,7 +536,7 @@ urlpatterns = [
     path(
         "active-users-autocomplete/",
         ActiveUsersAutocomplete.as_view(),
-        name="current-editors-autocomplete",
+        name="active-users-autocomplete",
     ),
     path(
         "all-users-autocomplete/",

--- a/django/cantusdb_project/main_app/views/autocomplete.py
+++ b/django/cantusdb_project/main_app/views/autocomplete.py
@@ -13,20 +13,12 @@ from main_app.models import (
 )
 
 
-class CurrentEditorsAutocomplete(autocomplete.Select2QuerySetView):
+class ActiveUsersAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         if not self.request.user.is_authenticated:
             return get_user_model().objects.none()
         # pylint: disable=unsupported-binary-operation
-        qs = (
-            get_user_model()
-            .objects.filter(
-                Q(groups__name="project manager")
-                | Q(groups__name="editor")
-                | Q(groups__name="contributor")
-            )
-            .order_by("full_name")
-        )
+        qs = get_user_model().objects.filter(is_active=True).order_by("full_name")
         if self.q:
             qs = qs.filter(
                 Q(full_name__istartswith=self.q) | Q(email__istartswith=self.q)

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -307,8 +307,8 @@ class SourceDetailView(CustomAccessMixin, JSONResponseMixin, DetailView):  # typ
             context["has_chants"] = chants.exists()
 
         context["user_can_edit_chants"] = self.user_assigned_to_source(source)
-        context["user_can_edit_source"] = (
-            self.user_is_editor and self.user_assigned_to_source(source)
+        context["user_can_edit_source"] = self.user_assigned_to_source(source) and (
+            self.user_is_editor or self.user_created_source(source)
         )
         return context
 

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -607,22 +607,7 @@ class SourceEditView(CustomAccessMixin, UpdateView):  # type: ignore[type-arg]
 
     def form_valid(self, form):
         form.instance.last_updated_by = self.request.user
-
-        # remove this source from the old "current_editors"
-        # assign this source to the new "current_editors"
-
-        old_current_editors = list(
-            Source.objects.get(id=form.instance.id).current_editors.all()
-        )
-        new_current_editors = form.cleaned_data["current_editors"]
-        source = form.save()
-
-        for old_editor in old_current_editors:
-            old_editor.sources_user_can_edit.remove(source)
-
-        for new_editor in new_current_editors:
-            new_editor.sources_user_can_edit.add(source)
-
+        form.save()
         return HttpResponseRedirect(self.get_success_url())
 
 


### PR DESCRIPTION
This PR addresses some issues discovered during testing for #1881.

- Removes ability of non-superusers to modify assigned editors of sources after source creation
- Changes autocomplete for the `current_editors` field on the SourceCreate page to include all active users
- Add the link to the source edit page from the source detail page for standard users who created the source and are still assigned to the source