### PR TITLE
Merge `develop` into `staging`, 26 Sept 2025 - 2

### DIFF
--- a/django/cantusdb_project/templates/header/navbar_links.html
+++ b/django/cantusdb_project/templates/header/navbar_links.html
@@ -58,6 +58,7 @@
             <a class="dropdown-item" href="{% url 'source-list' %}?segment=4063">Cantus DB: Sources with Inventories</a>
             <a class="dropdown-item"
                href="{% url 'canadian-chant-db-source-list' %}">Canadian Chant Database</a>
+            <a class="dropdown-item" href="{% url 'cantorales-source-list' %}">Cantorales in the Americas and Beyond</a>
             <a class="dropdown-item" href="{% url 'source-list' %}?segment=4064">Sequence Database (Clavis Sequentiarum by Calvin Bower)</a>
             <a class="dropdown-item" href="{% url 'source-list' %}">All Sources</a>
         </div>


### PR DESCRIPTION
Adds link to Cantorales landing page in header