### PR TITLE
Merge develop into staging, 2026-01-28

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -38,6 +38,17 @@
                                 Folio 2r from the <a href="{% url 'source-detail' 123723 %}">Salzinnes Antiphonal</a>, held at the Patrick Power Library at Saint Mary’s University in Halifax, Canada (M2149.L4 1554)
                             </figcaption>
                         </figure>
+                        <div class="px-5">
+                            <p>
+                                The Canadian Chant Database is an initiative of the <a href="https://dact-chant.ca/" target="_blank">Digital Analysis of Chant Transmission (DACT) Project</a>.
+                            </p>
+                            <a href="https://dact-chant.ca/" target="_blank">
+                                <img class="img-fluid p-2 ccdb-dact-logo"
+                                    src="{% static "footer/dact-logo.png" %}"
+                                    alt="Digital Analysis of Chant Transmission Logo"
+                                    title="Digital Analysis of Chant Transmission" />
+                            </a>
+                        </div>
                     </div>
                     <div class="ccdb-grid-summary px-5 pt-5">
                         <div class="text-white d-block text-center">
@@ -46,17 +57,43 @@
                         <p class="pt-5">
                             The goal of the Canadian Chant Database is to catalogue–and eventually inventory–all manuscripts and manuscript fragments containing plainchant derived from the medieval European tradition in libraries, archives, institutions, and private ownership in Canada. Printed chant books are limited to those sources that were published specifically for use in Canada.
                         </p>
-                    </div>
-                    <div class="px-5">
-                        <p>
-                            The Canadian Chant Database is an initiative of the <a href="https://dact-chant.ca/" target="_blank">Digital Analysis of Chant Transmission (DACT) Project</a>.
-                        </p>
-                        <a href="https://dact-chant.ca/" target="_blank">
-                            <img class="img-fluid p-2 ccdb-dact-logo"
-                                 src="{% static "footer/dact-logo.png" %}"
-                                 alt="Digital Analysis of Chant Transmission Logo"
-                                 title="Digital Analysis of Chant Transmission" />
-                        </a>
+                        
+                        <h5 class="mt-4 mb-3">Personnel</h5>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-2">
+                                    <strong>Jennifer Bain</strong><br>
+                                    <div class="small">DACT Project Director</div>
+                                    <div class="small">Dalhousie University, Halifax</div>
+                                </div>
+                                <div class="mb-2">
+                                    <strong>Debra Lacoste</strong><br>
+                                    <div class="small">DACT Project Manager</div>
+                                    <div class="small">Dalhousie University, Halifax</div>
+                                </div>
+                                <div class="mb-2">
+                                    <strong>Julie Cumming</strong><br>
+                                    <div class="small">Manuscripts Team Lead</div>
+                                    <div class="small">McGill University, Montreal</div>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-2">
+                                    <strong>D. Linda Pearse</strong><br>
+                                    <div class="small">Encounters Team Lead</div>
+                                </div>
+                                <div class="mb-2">
+                                    <strong>Kate Kennedy Steiner</strong><br>
+                                    <div class="small">Central & Eastern Team Lead</div>
+                                    <div class="small">Conrad Grebel University College</div>
+                                </div>
+                                <div class="mb-2">
+                                    <strong>David Watt</strong><br>
+                                    <div class="small">Western Canada</div>
+                                    <div class="small">University of Manitoba</div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="ccdb-grid-map text-center">
                         <iframe src="https://www.google.com/maps/d/embed?mid=1uTSnFP4RHFd7RSBIIZpJ0_i69hIpypo&ehbc=2E312F"

--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -62,33 +62,33 @@
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="mb-2">
-                                    <strong>Jennifer Bain</strong><br>
+                                    <strong>Jennifer Bain</strong>
                                     <div class="small">DACT Project Director</div>
                                     <div class="small">Dalhousie University, Halifax</div>
                                 </div>
                                 <div class="mb-2">
-                                    <strong>Debra Lacoste</strong><br>
+                                    <strong>Debra Lacoste</strong>
                                     <div class="small">DACT Project Manager</div>
                                     <div class="small">Dalhousie University, Halifax</div>
                                 </div>
                                 <div class="mb-2">
-                                    <strong>Julie Cumming</strong><br>
+                                    <strong>Julie Cumming</strong>
                                     <div class="small">Manuscripts Team Lead</div>
                                     <div class="small">McGill University, Montreal</div>
                                 </div>
                             </div>
                             <div class="col-md-6">
                                 <div class="mb-2">
-                                    <strong>D. Linda Pearse</strong><br>
+                                    <strong>D. Linda Pearse</strong>
                                     <div class="small">Encounters Team Lead</div>
                                 </div>
                                 <div class="mb-2">
-                                    <strong>Kate Kennedy Steiner</strong><br>
+                                    <strong>Kate Kennedy Steiner</strong>
                                     <div class="small">Central & Eastern Team Lead</div>
                                     <div class="small">Conrad Grebel University College</div>
                                 </div>
                                 <div class="mb-2">
-                                    <strong>David Watt</strong><br>
+                                    <strong>David Watt</strong>
                                     <div class="small">Western Canada</div>
                                     <div class="small">University of Manitoba</div>
                                 </div>

--- a/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load helper_tags %}
 {% load static %}
-{% block title %}<title>The Cantorales Project</title>{% endblock %}
+{% block title %}<title>Cantorales</title>{% endblock %}
 {% block scripts %}
     <script src="{% static 'js/source_list.js' %}"></script>
     <link href="{% static 'css/cantorales_style.css' %}"

--- a/django/cantusdb_project/static/css/ccdb_style.css
+++ b/django/cantusdb_project/static/css/ccdb_style.css
@@ -14,7 +14,6 @@ body {
 .ccdb-landing-grid {
     grid-template-columns: 1fr 2fr;
     gap: 20px;
-    grid-template-rows: 1fr 1fr;
 }
 
 .ccdb-grid-image {

--- a/django/cantusdb_project/static/css/ccdb_style.css
+++ b/django/cantusdb_project/static/css/ccdb_style.css
@@ -14,7 +14,7 @@ body {
 .ccdb-landing-grid {
     grid-template-columns: 1fr 2fr;
     gap: 20px;
-    grid-template-rows: 1fr 1fr 1.5fr;
+    grid-template-rows: 1fr 1fr;
 }
 
 .ccdb-grid-image {


### PR DESCRIPTION
This pull request primarily updates the layout and content of the Canadian Chant Database landing page, introduces a new "Personnel" section, and makes a minor title change on the Cantorales project page. The changes improve the organization and presentation of information for users.

Content and layout improvements for the Canadian Chant Database landing page:

* Moved the summary section and search button to a new position in the page layout, and added a new "Personnel" section listing key project members and their affiliations in `canadian_chant_db.html`. [[1]](diffhunk://#diff-bea5bfb58c290e5fe9b440a98794e99388ada8ade80a4e84975500a863cc1e2eL41-L49) [[2]](diffhunk://#diff-bea5bfb58c290e5fe9b440a98794e99388ada8ade80a4e84975500a863cc1e2eR52-R97)
* Adjusted the CSS grid layout by removing the explicit `grid-template-rows` property from `.ccdb-landing-grid` in `ccdb_style.css` to better accommodate the new content structure.

Minor content update:

* Changed the HTML page title from "The Cantorales Project" to "Cantorales" in `cantorales.html` for consistency.