### PR TITLE
fix: display provenance notes on source detail page (fixes #1923)

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -218,6 +218,10 @@
                 Provenance: <b><a href="{% url 'provenance-detail' source.provenance.id %}">{{ source.provenance.name }}</a></b>
                 <br />
             {% endif %}
+            {% if source.provenance_notes %}
+                Provenance notes: <b>{{ source.provenance_notes }}</b>
+                <br />
+            {% endif %}
             {% if source.date or source.century %}
                 Date:
                 {% join_absolute_url_links source.century.all 'name' '/' %}

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -321,6 +321,20 @@ class SourceDetailViewTest(SourcePermissionsTestCase):
         self.assertEqual(response["Content-Type"], "application/json")
         self.assertEqual(response.json()["source"]["id"], source.id)
 
+    def test_provenance_notes_displayed(self) -> None:
+        notes = "test_provenance_notes_value"
+        source = make_fake_source(provenance_notes=notes)
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        html = response.content.decode("utf-8")
+        self.assertIn("Provenance notes:", html)
+        self.assertIn(notes, html)
+
+    def test_provenance_notes_not_displayed_when_empty(self) -> None:
+        source = make_fake_source(provenance_notes="")
+        response = self.client.get(reverse("source-detail", args=[source.id]))
+        html = response.content.decode("utf-8")
+        self.assertNotIn("Provenance notes:", html)
+
 
 class SourceInventoryViewTest(HTMLContentsTestMixin, SourcePermissionsTestCase):
     view_name = "source-inventory"


### PR DESCRIPTION
The `provenance_notes` field was being saved correctly via the edit/create forms but never rendered on the source detail page.

## Changes
- `source_detail.html`: display `provenance_notes` in the sidebar, after the provenance name
- `test_source.py`: add two tests verifying the field is shown when set and hidden when empty

Fixes #1923