### PR TITLE
feat: add IIIF manifest-based image link mapping and fix CSV validation bugs

### DIFF
--- a/django/cantusdb_project/main_app/iiif_utils.py
+++ b/django/cantusdb_project/main_app/iiif_utils.py
@@ -1,0 +1,316 @@
+"""
+Utilities for parsing IIIF manifests and generating folio-to-image mappings.
+
+Supports both IIIF Presentation API 2.x and 3.0 manifests.
+"""
+
+import csv
+import io
+import re
+from dataclasses import dataclass
+
+import requests
+
+
+@dataclass
+class CanvasInfo:
+    """Represents a single canvas/page extracted from a IIIF manifest."""
+
+    label: str
+    image_url: str
+    canvas_index: int
+
+
+def fetch_manifest(manifest_url: str, timeout: int = 30) -> dict:
+    """
+    Fetch and parse a IIIF manifest JSON from the given URL.
+
+    Args:
+        manifest_url: URL to the IIIF manifest JSON.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed manifest as a dictionary.
+
+    Raises:
+        requests.RequestException: If the fetch fails.
+        ValueError: If the response is not valid JSON.
+    """
+    response = requests.get(manifest_url, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_label_text(label: object) -> str:
+    """
+    Extract plain text from a IIIF label, handling both API 2.x and 3.0 formats.
+
+    API 2.x: label is a string or a list of strings.
+    API 3.0: label is a dict like {"en": ["Folio 1r"]}.
+    """
+    if isinstance(label, str):
+        return label
+    if isinstance(label, list):
+        # List of strings (API 2.x) or list of dicts
+        for item in label:
+            if isinstance(item, str):
+                return item
+            if isinstance(item, dict):
+                return item.get("@value", str(item))
+        return str(label[0]) if label else ""
+    if isinstance(label, dict):
+        # API 3.0: {"en": ["Folio 1r"], "none": ["f. 1r"]}
+        for values in label.values():
+            if isinstance(values, list) and values:
+                return str(values[0])
+        return ""
+    return str(label)
+
+
+def _extract_image_url_v2(canvas: dict) -> str:
+    """Extract the best image URL from a IIIF 2.x canvas."""
+    images = canvas.get("images", [])
+    if not images:
+        return ""
+    resource = images[0].get("resource", {})
+    # Try to get the IIIF Image API service URL
+    service = resource.get("service", {})
+    if isinstance(service, list):
+        service = service[0] if service else {}
+    service_id = service.get("@id", "")
+    if service_id:
+        # Construct a full image URL from the service
+        return f"{service_id.rstrip('/')}/full/max/0/default.jpg"
+    # Fall back to the resource @id (direct image URL)
+    return resource.get("@id", "")
+
+
+def _extract_image_url_v3(canvas: dict) -> str:
+    """Extract the best image URL from a IIIF 3.0 canvas."""
+    items = canvas.get("items", [])
+    if not items:
+        return ""
+    # Navigate: canvas -> AnnotationPage -> Annotation -> body
+    annotation_page = items[0]
+    annotations = annotation_page.get("items", [])
+    if not annotations:
+        return ""
+    body = annotations[0].get("body", {})
+    # Try service first
+    services = body.get("service", [])
+    if isinstance(services, dict):
+        services = [services]
+    for service in services:
+        service_id = service.get("id", service.get("@id", ""))
+        if service_id:
+            return f"{service_id.rstrip('/')}/full/max/0/default.jpg"
+    # Fall back to body id
+    return body.get("id", "")
+
+
+def extract_canvases(manifest: dict) -> list[CanvasInfo]:
+    """
+    Extract canvas information from a IIIF manifest.
+
+    Supports both Presentation API 2.x and 3.0.
+
+    Args:
+        manifest: Parsed IIIF manifest dictionary.
+
+    Returns:
+        List of CanvasInfo objects, one per canvas/page.
+    """
+    canvases = []
+
+    # Detect API version
+    context = manifest.get("@context", "")
+    is_v3 = "iiif.io/api/presentation/3" in str(context)
+
+    if is_v3:
+        canvas_list = manifest.get("items", [])
+        for i, canvas in enumerate(canvas_list):
+            label = _get_label_text(canvas.get("label", ""))
+            image_url = _extract_image_url_v3(canvas)
+            canvases.append(CanvasInfo(label=label, image_url=image_url, canvas_index=i))
+    else:
+        # API 2.x
+        sequences = manifest.get("sequences", [])
+        if not sequences:
+            return canvases
+        canvas_list = sequences[0].get("canvases", [])
+        for i, canvas in enumerate(canvas_list):
+            label = _get_label_text(canvas.get("label", ""))
+            image_url = _extract_image_url_v2(canvas)
+            canvases.append(CanvasInfo(label=label, image_url=image_url, canvas_index=i))
+
+    return canvases
+
+
+# Regex patterns for extracting folio identifiers from canvas labels.
+# Matches patterns like "f. 1r", "fol. 23v", "folio 123r", "1r", "001v",
+# "p. 1", "page 10", etc.
+FOLIO_PATTERN = re.compile(
+    r"""
+    (?:f(?:ol(?:io)?)?\.?\s*)?  # Optional folio prefix
+    (\d{1,4})                    # Page/folio number
+    \s*
+    ([rv](?:ecto|erso)?)?        # Optional recto/verso suffix
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+PAGE_PATTERN = re.compile(
+    r"(?:p(?:age)?\.?\s*)(\d{1,4})",
+    re.IGNORECASE,
+)
+
+
+def _normalize_folio(folio_str: str) -> str:
+    """
+    Normalize a folio string for comparison.
+
+    Strips whitespace, lowercases, and removes common prefixes.
+    """
+    s = folio_str.strip().lower()
+    # Remove common prefixes
+    for prefix in ["fol.", "fol ", "folio ", "f.", "f "]:
+        if s.startswith(prefix):
+            s = s[len(prefix) :].strip()
+    return s
+
+
+def _extract_folio_components(folio_str: str) -> tuple[str, str] | None:
+    """
+    Extract number and recto/verso suffix from a folio string.
+
+    Returns (number, suffix) where suffix is 'r', 'v', or ''.
+    The number is stripped of leading zeros for consistent comparison.
+    Returns None if no folio pattern is found.
+    """
+    normalized = _normalize_folio(folio_str)
+    match = FOLIO_PATTERN.search(normalized)
+    if match:
+        number = match.group(1).lstrip("0") or "0"
+        suffix = (match.group(2) or "")[0:1].lower()  # 'r', 'v', or ''
+        return (number, suffix)
+    return None
+
+
+def match_canvas_to_folio(
+    canvas_label: str, source_folios: list[str]
+) -> str | None:
+    """
+    Attempt to match a canvas label to a folio from the source.
+
+    Uses heuristic matching:
+    1. Exact match (case-insensitive, after normalization)
+    2. Component-based match (number + recto/verso)
+
+    Args:
+        canvas_label: The label of the IIIF canvas.
+        source_folios: List of folio strings from the source.
+
+    Returns:
+        The matching folio string, or None if no match is found.
+    """
+    if not canvas_label or not source_folios:
+        return None
+
+    # Build lookup structures for source folios
+    normalized_to_original: dict[str, str] = {}
+    components_to_original: dict[tuple[str, str], str] = {}
+
+    for folio in source_folios:
+        normalized_to_original[_normalize_folio(folio)] = folio
+        components = _extract_folio_components(folio)
+        if components:
+            components_to_original[components] = folio
+
+    # Try exact normalized match
+    canvas_normalized = _normalize_folio(canvas_label)
+    if canvas_normalized in normalized_to_original:
+        return normalized_to_original[canvas_normalized]
+
+    # Try component-based match
+    canvas_components = _extract_folio_components(canvas_label)
+    if canvas_components and canvas_components in components_to_original:
+        return components_to_original[canvas_components]
+
+    return None
+
+
+def generate_folio_image_mapping(
+    canvases: list[CanvasInfo],
+    source_folios: list[str],
+) -> list[dict[str, str]]:
+    """
+    Generate a folio-to-image URL mapping from IIIF canvases and source folios.
+
+    Each row in the output represents either:
+    - A matched canvas-to-folio pair
+    - An unmatched canvas (folio column empty, with a note)
+    - An unmatched folio (image_url column empty, with a note)
+
+    Args:
+        canvases: List of CanvasInfo from the IIIF manifest.
+        source_folios: List of folio strings from the source's chants.
+
+    Returns:
+        List of dicts with keys: 'folio', 'image_link', 'notes', 'canvas_label'
+    """
+    rows: list[dict[str, str]] = []
+    matched_folios: set[str] = set()
+
+    for canvas in canvases:
+        matched_folio = match_canvas_to_folio(canvas.label, source_folios)
+        note = ""
+        folio = ""
+
+        if matched_folio:
+            folio = matched_folio
+            matched_folios.add(matched_folio)
+        else:
+            note = "No matching folio in source"
+
+        rows.append(
+            {
+                "folio": folio,
+                "image_link": canvas.image_url,
+                "notes": note,
+                "canvas_label": canvas.label,
+            }
+        )
+
+    # Add rows for folios that weren't matched to any canvas
+    for folio in source_folios:
+        if folio not in matched_folios:
+            rows.append(
+                {
+                    "folio": folio,
+                    "image_link": "",
+                    "notes": "No matching canvas in manifest",
+                    "canvas_label": "",
+                }
+            )
+
+    return rows
+
+
+def mapping_to_csv(mapping: list[dict[str, str]]) -> str:
+    """
+    Convert a folio-image mapping to a CSV string.
+
+    Args:
+        mapping: List of dicts from generate_folio_image_mapping.
+
+    Returns:
+        CSV string with headers: folio, image_link, notes, canvas_label
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["folio", "image_link", "notes", "canvas_label"])
+    for row in mapping:
+        writer.writerow(
+            [row["folio"], row["image_link"], row["notes"], row["canvas_label"]]
+        )
+    return output.getvalue().rstrip("\r\n")

--- a/django/cantusdb_project/main_app/iiif_utils.py
+++ b/django/cantusdb_project/main_app/iiif_utils.py
@@ -148,10 +148,12 @@ def extract_canvases(manifest: dict) -> list[CanvasInfo]:
 
 # Regex patterns for extracting folio identifiers from canvas labels.
 # Matches patterns like "f. 1r", "fol. 23v", "folio 123r", "1r", "001v",
-# "p. 1", "page 10", etc.
+# "p. 1", "page 10", etc. Anchored to start of the normalized string
+# to avoid false positives (e.g. "Detail 2r" should NOT match "002r").
 FOLIO_PATTERN = re.compile(
     r"""
-    (?:f(?:ol(?:io)?)?\.?\s*)?  # Optional folio prefix
+    ^                            # Anchor to start of normalized string
+    (?:f(?:ol(?:io)?)?\.?\s*)?   # Optional folio prefix
     (\d{1,4})                    # Page/folio number
     \s*
     ([rv](?:ecto|erso)?)?        # Optional recto/verso suffix
@@ -160,7 +162,7 @@ FOLIO_PATTERN = re.compile(
 )
 
 PAGE_PATTERN = re.compile(
-    r"(?:p(?:age)?\.?\s*)(\d{1,4})",
+    r"^(?:p(?:age)?\.?\s*)(\d{1,4})",
     re.IGNORECASE,
 )
 
@@ -169,13 +171,16 @@ def _normalize_folio(folio_str: str) -> str:
     """
     Normalize a folio string for comparison.
 
-    Strips whitespace, lowercases, and removes common prefixes.
+    Strips whitespace, lowercases, removes common prefixes and brackets.
     """
     s = folio_str.strip().lower()
+    # Strip leading/trailing brackets
+    s = s.strip("[](){}")
     # Remove common prefixes
     for prefix in ["fol.", "fol ", "folio ", "f.", "f "]:
         if s.startswith(prefix):
             s = s[len(prefix) :].strip()
+            break
     return s
 
 

--- a/django/cantusdb_project/main_app/templates/source_add_image_links.html
+++ b/django/cantusdb_project/main_app/templates/source_add_image_links.html
@@ -46,6 +46,26 @@
                 </p>
             </div>
         </div>
+        {% if has_iiif_manifest %}
+            <div class="row mb-4">
+                <div class="col">
+                    <h5>Generate from IIIF Manifest</h5>
+                    <p class="small">
+                        This source has an associated IIIF manifest. Click below to
+                        automatically generate a folio-to-image mapping CSV. The generated
+                        CSV will contain four columns: folio, image_link, notes, and
+                        canvas_label. Review and edit the CSV, then upload it above to
+                        apply the mapping.
+                    </p>
+                    <a href="{% url 'source-iiif-mapping' source.id %}"
+                       class="btn btn-sm btn-outline-primary"
+                       id="generateIIIFBtn">
+                        <i class="bi bi-download"></i> Generate IIIF Mapping CSV
+                    </a>
+                </div>
+            </div>
+            <hr />
+        {% endif %}
         <label for="imgLinksCSV" class="form-label">
             Select CSV file containing image links
         </label>
@@ -69,6 +89,7 @@
         </div>
         <div id="csvTestingDiv" class="row" hidden>
             <div class="col-auto">
+                <h6>Validation</h6>
                 <table class="table table-sm table-borderless csv-testing-table small">
                     <tbody>
                         <tr>

--- a/django/cantusdb_project/main_app/tests/test_iiif_utils.py
+++ b/django/cantusdb_project/main_app/tests/test_iiif_utils.py
@@ -1,0 +1,450 @@
+"""
+Tests for main_app.iiif_utils (IIIF manifest parsing and folio matching).
+"""
+
+from unittest.mock import patch, MagicMock
+from django.test import TestCase
+from django.urls import reverse
+
+from main_app.iiif_utils import (
+    CanvasInfo,
+    extract_canvases,
+    generate_folio_image_mapping,
+    mapping_to_csv,
+    match_canvas_to_folio,
+    _get_label_text,
+    _normalize_folio,
+    _extract_folio_components,
+)
+from main_app.models import Source
+from main_app.models.source_url import SourceURL
+from main_app.tests.make_fakes import make_fake_source, make_fake_chant
+from main_app.tests.mixins import CustomAccessTestMixin
+
+
+# ---- Sample IIIF manifests for testing ----
+
+SAMPLE_MANIFEST_V2 = {
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    "@type": "sc:Manifest",
+    "sequences": [
+        {
+            "canvases": [
+                {
+                    "@id": "https://example.com/canvas/1",
+                    "label": "f. 1r",
+                    "images": [
+                        {
+                            "resource": {
+                                "@id": "https://example.com/image/1/full/full/0/default.jpg",
+                                "service": {
+                                    "@id": "https://example.com/image/1",
+                                },
+                            }
+                        }
+                    ],
+                },
+                {
+                    "@id": "https://example.com/canvas/2",
+                    "label": "f. 1v",
+                    "images": [
+                        {
+                            "resource": {
+                                "@id": "https://example.com/image/2/full/full/0/default.jpg",
+                                "service": {
+                                    "@id": "https://example.com/image/2",
+                                },
+                            }
+                        }
+                    ],
+                },
+                {
+                    "@id": "https://example.com/canvas/3",
+                    "label": "f. 2r",
+                    "images": [
+                        {
+                            "resource": {
+                                "@id": "https://example.com/image/3/full/full/0/default.jpg",
+                                "service": {
+                                    "@id": "https://example.com/image/3",
+                                },
+                            }
+                        }
+                    ],
+                },
+            ]
+        }
+    ],
+}
+
+SAMPLE_MANIFEST_V3 = {
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    "type": "Manifest",
+    "items": [
+        {
+            "type": "Canvas",
+            "label": {"en": ["Folio 1 recto"]},
+            "items": [
+                {
+                    "type": "AnnotationPage",
+                    "items": [
+                        {
+                            "type": "Annotation",
+                            "body": {
+                                "id": "https://example.com/v3/image/1/full/max/0/default.jpg",
+                                "service": [
+                                    {
+                                        "id": "https://example.com/v3/image/1",
+                                        "type": "ImageService3",
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+        {
+            "type": "Canvas",
+            "label": {"en": ["Folio 1 verso"]},
+            "items": [
+                {
+                    "type": "AnnotationPage",
+                    "items": [
+                        {
+                            "type": "Annotation",
+                            "body": {
+                                "id": "https://example.com/v3/image/2/full/max/0/default.jpg",
+                                "service": [
+                                    {
+                                        "id": "https://example.com/v3/image/2",
+                                        "type": "ImageService3",
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+    ],
+}
+
+
+class GetLabelTextTest(TestCase):
+    def test_string_label(self) -> None:
+        self.assertEqual(_get_label_text("f. 1r"), "f. 1r")
+
+    def test_list_label(self) -> None:
+        self.assertEqual(_get_label_text(["f. 1r", "Folio 1"]), "f. 1r")
+
+    def test_dict_label_v3(self) -> None:
+        self.assertEqual(
+            _get_label_text({"en": ["Folio 1 recto"]}), "Folio 1 recto"
+        )
+
+    def test_dict_label_multiple_languages(self) -> None:
+        label = {"en": ["Folio 1 recto"], "none": ["f. 1r"]}
+        result = _get_label_text(label)
+        self.assertIn(result, ["Folio 1 recto", "f. 1r"])
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(_get_label_text(""), "")
+
+    def test_empty_dict(self) -> None:
+        self.assertEqual(_get_label_text({}), "")
+
+
+class NormalizeFolioTest(TestCase):
+    def test_simple_folio(self) -> None:
+        self.assertEqual(_normalize_folio("001r"), "001r")
+
+    def test_strip_prefix_fol(self) -> None:
+        self.assertEqual(_normalize_folio("fol. 1r"), "1r")
+
+    def test_strip_prefix_folio(self) -> None:
+        self.assertEqual(_normalize_folio("folio 1r"), "1r")
+
+    def test_strip_prefix_f(self) -> None:
+        self.assertEqual(_normalize_folio("f. 1r"), "1r")
+
+    def test_whitespace(self) -> None:
+        self.assertEqual(_normalize_folio("  001v  "), "001v")
+
+    def test_case_insensitive(self) -> None:
+        self.assertEqual(_normalize_folio("FOL. 1R"), "1r")
+
+
+class ExtractFolioComponentsTest(TestCase):
+    def test_simple_recto(self) -> None:
+        self.assertEqual(_extract_folio_components("1r"), ("1", "r"))
+
+    def test_simple_verso(self) -> None:
+        self.assertEqual(_extract_folio_components("2v"), ("2", "v"))
+
+    def test_zero_padded(self) -> None:
+        self.assertEqual(_extract_folio_components("001r"), ("1", "r"))
+
+    def test_with_prefix(self) -> None:
+        self.assertEqual(_extract_folio_components("f. 1r"), ("1", "r"))
+
+    def test_no_suffix(self) -> None:
+        self.assertEqual(_extract_folio_components("23"), ("23", ""))
+
+    def test_full_word_recto(self) -> None:
+        self.assertEqual(_extract_folio_components("1 recto"), ("1", "r"))
+
+    def test_no_match(self) -> None:
+        self.assertIsNone(_extract_folio_components("front cover"))
+
+
+class ExtractCanvasesTest(TestCase):
+    def test_v2_manifest(self) -> None:
+        canvases = extract_canvases(SAMPLE_MANIFEST_V2)
+        self.assertEqual(len(canvases), 3)
+        self.assertEqual(canvases[0].label, "f. 1r")
+        self.assertEqual(
+            canvases[0].image_url,
+            "https://example.com/image/1/full/max/0/default.jpg",
+        )
+        self.assertEqual(canvases[0].canvas_index, 0)
+        self.assertEqual(canvases[1].label, "f. 1v")
+        self.assertEqual(canvases[2].label, "f. 2r")
+
+    def test_v3_manifest(self) -> None:
+        canvases = extract_canvases(SAMPLE_MANIFEST_V3)
+        self.assertEqual(len(canvases), 2)
+        self.assertEqual(canvases[0].label, "Folio 1 recto")
+        self.assertEqual(
+            canvases[0].image_url,
+            "https://example.com/v3/image/1/full/max/0/default.jpg",
+        )
+        self.assertEqual(canvases[1].label, "Folio 1 verso")
+
+    def test_empty_manifest(self) -> None:
+        canvases = extract_canvases({})
+        self.assertEqual(canvases, [])
+
+    def test_v2_no_sequences(self) -> None:
+        manifest = {
+            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "sequences": [],
+        }
+        canvases = extract_canvases(manifest)
+        self.assertEqual(canvases, [])
+
+    def test_v2_canvas_no_images(self) -> None:
+        manifest = {
+            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "sequences": [{"canvases": [{"label": "blank", "images": []}]}],
+        }
+        canvases = extract_canvases(manifest)
+        self.assertEqual(len(canvases), 1)
+        self.assertEqual(canvases[0].image_url, "")
+
+    def test_v2_fallback_to_resource_id(self) -> None:
+        manifest = {
+            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "sequences": [
+                {
+                    "canvases": [
+                        {
+                            "label": "page 1",
+                            "images": [
+                                {
+                                    "resource": {
+                                        "@id": "https://example.com/direct.jpg"
+                                    }
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ],
+        }
+        canvases = extract_canvases(manifest)
+        self.assertEqual(canvases[0].image_url, "https://example.com/direct.jpg")
+
+
+class MatchCanvasToFolioTest(TestCase):
+    def test_exact_match(self) -> None:
+        folios = ["001r", "001v", "002r"]
+        self.assertEqual(match_canvas_to_folio("001r", folios), "001r")
+
+    def test_match_with_prefix(self) -> None:
+        folios = ["001r", "001v", "002r"]
+        self.assertEqual(match_canvas_to_folio("f. 001r", folios), "001r")
+
+    def test_component_match(self) -> None:
+        folios = ["001r", "001v", "002r"]
+        self.assertEqual(match_canvas_to_folio("f. 1r", folios), "001r")
+
+    def test_verbose_label_match(self) -> None:
+        folios = ["001r", "001v"]
+        self.assertEqual(match_canvas_to_folio("Folio 1 recto", folios), "001r")
+
+    def test_no_match(self) -> None:
+        folios = ["001r", "001v"]
+        self.assertIsNone(match_canvas_to_folio("front cover", folios))
+
+    def test_empty_label(self) -> None:
+        self.assertIsNone(match_canvas_to_folio("", ["001r"]))
+
+    def test_empty_folios(self) -> None:
+        self.assertIsNone(match_canvas_to_folio("001r", []))
+
+
+class GenerateFolioImageMappingTest(TestCase):
+    def test_full_match(self) -> None:
+        canvases = [
+            CanvasInfo(label="f. 1r", image_url="https://img/1", canvas_index=0),
+            CanvasInfo(label="f. 1v", image_url="https://img/2", canvas_index=1),
+        ]
+        folios = ["1r", "1v"]
+        mapping = generate_folio_image_mapping(canvases, folios)
+        self.assertEqual(len(mapping), 2)
+        self.assertEqual(mapping[0]["folio"], "1r")
+        self.assertEqual(mapping[0]["image_link"], "https://img/1")
+        self.assertEqual(mapping[0]["notes"], "")
+        self.assertEqual(mapping[1]["folio"], "1v")
+
+    def test_unmatched_canvas(self) -> None:
+        canvases = [
+            CanvasInfo(
+                label="front cover", image_url="https://img/cover", canvas_index=0
+            ),
+            CanvasInfo(label="f. 1r", image_url="https://img/1", canvas_index=1),
+        ]
+        folios = ["1r"]
+        mapping = generate_folio_image_mapping(canvases, folios)
+        self.assertEqual(len(mapping), 2)
+        # First row is the unmatched canvas
+        self.assertEqual(mapping[0]["folio"], "")
+        self.assertEqual(mapping[0]["notes"], "No matching folio in source")
+        # Second row is the matched canvas
+        self.assertEqual(mapping[1]["folio"], "1r")
+
+    def test_unmatched_folio(self) -> None:
+        canvases = [
+            CanvasInfo(label="f. 1r", image_url="https://img/1", canvas_index=0),
+        ]
+        folios = ["1r", "2r"]
+        mapping = generate_folio_image_mapping(canvases, folios)
+        self.assertEqual(len(mapping), 2)
+        self.assertEqual(mapping[0]["folio"], "1r")
+        # Unmatched folio appended at the end
+        self.assertEqual(mapping[1]["folio"], "2r")
+        self.assertEqual(mapping[1]["image_link"], "")
+        self.assertEqual(mapping[1]["notes"], "No matching canvas in manifest")
+
+    def test_empty_canvases(self) -> None:
+        mapping = generate_folio_image_mapping([], ["1r"])
+        self.assertEqual(len(mapping), 1)
+        self.assertEqual(mapping[0]["notes"], "No matching canvas in manifest")
+
+    def test_empty_folios(self) -> None:
+        canvases = [
+            CanvasInfo(label="f. 1r", image_url="https://img/1", canvas_index=0),
+        ]
+        mapping = generate_folio_image_mapping(canvases, [])
+        self.assertEqual(len(mapping), 1)
+        self.assertEqual(mapping[0]["notes"], "No matching folio in source")
+
+
+class MappingToCSVTest(TestCase):
+    def test_basic_csv(self) -> None:
+        mapping = [
+            {
+                "folio": "1r",
+                "image_link": "https://img/1",
+                "notes": "",
+                "canvas_label": "f. 1r",
+            },
+            {
+                "folio": "",
+                "image_link": "https://img/cover",
+                "notes": "No matching folio in source",
+                "canvas_label": "front cover",
+            },
+        ]
+        csv_str = mapping_to_csv(mapping)
+        lines = csv_str.strip().split("\n")
+        self.assertEqual(len(lines), 3)  # header + 2 data rows
+        self.assertIn("folio", lines[0])
+        self.assertIn("image_link", lines[0])
+        self.assertIn("notes", lines[0])
+        self.assertIn("canvas_label", lines[0])
+        self.assertIn("1r", lines[1])
+        self.assertIn("https://img/1", lines[1])
+
+
+class SourceIIIFMappingViewTest(CustomAccessTestMixin, TestCase):
+    source: Source
+    default_user = "superuser"
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.source = make_fake_source(published=True)
+        for folio in ["001r", "001v", "002r"]:
+            make_fake_chant(source=cls.source, folio=folio)
+        cls.manifest_url = SourceURL.objects.create(
+            source=cls.source,
+            url="https://example.com/manifest.json",
+            url_type=SourceURL.URLTypes.IIIF_MANIFEST,
+        )
+
+    def test_permissions(self) -> None:
+        self.run_request_permissions_test(
+            reverse("source-iiif-mapping", args=[self.source.id]),
+            get_allowed_users=["superuser"],
+            post_allowed_users=[],
+            test_name="IIIF mapping",
+        )
+
+    @patch("main_app.views.source.fetch_manifest")
+    def test_generates_csv(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.return_value = SAMPLE_MANIFEST_V2
+        response = self.client.get(
+            reverse("source-iiif-mapping", args=[self.source.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertIn(
+            f"source_{self.source.id}_iiif_mapping.csv",
+            response["Content-Disposition"],
+        )
+        content = response.content.decode("utf-8")
+        self.assertIn("folio", content)
+        self.assertIn("image_link", content)
+        self.assertIn("notes", content)
+
+    def test_no_manifest_returns_404(self) -> None:
+        source_no_manifest = make_fake_source(published=True)
+        make_fake_chant(source=source_no_manifest, folio="001r")
+        response = self.client.get(
+            reverse("source-iiif-mapping", args=[source_no_manifest.id])
+        )
+        self.assertEqual(response.status_code, 404)
+
+    @patch("main_app.views.source.fetch_manifest")
+    def test_manifest_fetch_failure(self, mock_fetch: MagicMock) -> None:
+        import requests
+
+        mock_fetch.side_effect = requests.RequestException("Connection failed")
+        response = self.client.get(
+            reverse("source-iiif-mapping", args=[self.source.id])
+        )
+        self.assertEqual(response.status_code, 502)
+
+    @patch("main_app.views.source.fetch_manifest")
+    def test_manifest_empty_canvases(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.return_value = {
+            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "sequences": [{"canvases": []}],
+        }
+        response = self.client.get(
+            reverse("source-iiif-mapping", args=[self.source.id])
+        )
+        self.assertEqual(response.status_code, 404)

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -87,6 +87,7 @@ from main_app.views.source import (
     SourceDeleteView,
     SourceInventoryView,
     SourceAddImageLinksView,
+    SourceIIIFMappingView,
 )
 from main_app.views.user import (
     CustomLogoutView,
@@ -378,6 +379,11 @@ urlpatterns = [
         "source/<int:source_id>/add-image-links",
         SourceAddImageLinksView.as_view(),
         name="source-add-image-links",
+    ),
+    path(
+        "source/<int:source_id>/iiif-mapping",
+        SourceIIIFMappingView.as_view(),
+        name="source-iiif-mapping",
     ),
     path(
         "proofread-overview/",

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -1,6 +1,8 @@
+import logging
 import re
 from typing import Any, Optional, Union
 
+import requests
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
@@ -22,6 +24,7 @@ from django.views.generic import (
     UpdateView,
     DeleteView,
     FormView,
+    View,
 )
 from django.views.generic.detail import SingleObjectMixin
 from main_app.forms import (
@@ -42,11 +45,20 @@ from main_app.models import (
     Institution,
     Sequence,
 )
+from main_app.models.source_url import SourceURL
 from main_app.permissions import CustomAccessMixin
 from main_app.mixins import JSONResponseMixin
+from main_app.iiif_utils import (
+    fetch_manifest,
+    extract_canvases,
+    generate_folio_image_mapping,
+    mapping_to_csv,
+)
 
 from main_app.views.chant import get_feast_selector_options
 from main_app.tasks import save_browse_chants_formset
+
+logger = logging.getLogger(__name__)
 
 CANTUS_SEGMENT_ID = 4063
 BOWER_SEGMENT_ID = 4064
@@ -689,9 +701,96 @@ class SourceAddImageLinksView(CustomAccessMixin, SingleObjectMixin, FormView):  
         )
         return {folio: "" for folio in folios if folio}
 
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        # Check if this source has a IIIF manifest
+        has_iiif = self.object.source_links.filter(
+            url_type=SourceURL.URLTypes.IIIF_MANIFEST
+        ).exists()
+        context["has_iiif_manifest"] = has_iiif
+        return context
+
     def form_valid(self, form: ImageLinkForm) -> HttpResponseRedirect:
         """
         Save the image links to the database.
         """
         form.save(self.object)
+        messages.success(self.request, "Image links saved successfully!")
         return HttpResponseRedirect(self.get_success_url())
+
+
+class SourceIIIFMappingView(CustomAccessMixin, SingleObjectMixin, View):  # type: ignore
+    """
+    View to generate a folio-to-image CSV mapping from a source's IIIF manifest.
+
+    Fetches the IIIF manifest, parses canvases, matches them to folios
+    in the source, and returns a downloadable CSV file.
+    """
+
+    pk_url_kwarg = "source_id"
+    queryset = Source.objects.select_related("holding_institution")
+    object: Source
+    http_method_names = ["get"]
+
+    def test_func(self) -> bool:
+        return self.user.is_superuser
+
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.object = self.get_object()
+
+        # Get the IIIF manifest URL for this source
+        manifest_link = self.object.source_links.filter(
+            url_type=SourceURL.URLTypes.IIIF_MANIFEST
+        ).first()
+
+        if not manifest_link:
+            return JsonResponse(
+                {"error": "No IIIF manifest found for this source."},
+                status=404,
+            )
+
+        # Fetch and parse the manifest
+        try:
+            manifest = fetch_manifest(manifest_link.url)
+        except requests.RequestException as e:
+            logger.exception("Failed to fetch IIIF manifest: %s", manifest_link.url)
+            return JsonResponse(
+                {"error": f"Failed to fetch IIIF manifest: {e}"},
+                status=502,
+            )
+        except ValueError:
+            logger.exception(
+                "Invalid JSON in IIIF manifest: %s", manifest_link.url
+            )
+            return JsonResponse(
+                {"error": "IIIF manifest is not valid JSON."},
+                status=502,
+            )
+
+        # Extract canvases from the manifest
+        canvases = extract_canvases(manifest)
+        if not canvases:
+            return JsonResponse(
+                {"error": "No canvases found in the IIIF manifest."},
+                status=404,
+            )
+
+        # Get source folios
+        source_folios = list(
+            self.object.chant_set.values_list("folio", flat=True)
+            .distinct()
+            .order_by("folio")
+        )
+        source_folios = [f for f in source_folios if f]
+
+        # Generate the mapping and CSV
+        mapping = generate_folio_image_mapping(canvases, source_folios)
+        csv_content = mapping_to_csv(mapping)
+
+        # Return as a downloadable CSV
+        response = HttpResponse(csv_content, content_type="text/csv")
+        source_id = self.object.id
+        response["Content-Disposition"] = (
+            f'attachment; filename="source_{source_id}_iiif_mapping.csv"'
+        )
+        return response

--- a/django/cantusdb_project/static/js/source_add_image_links.js
+++ b/django/cantusdb_project/static/js/source_add_image_links.js
@@ -35,24 +35,28 @@ function parseAndPreviewImageLinkCSV(csv, imgLinkInputs) {
     // Return two arrays: one with the folios and one with the image links
     // for use in testing functions.
     const rows = csv.split('\n');
-    const columns = rows[0].split(',');
+    // Auto-detect delimiter: some locales (e.g. French) use semicolons
+    const delimiter = rows[0].includes(';') ? ';' : ',';
+    const columns = rows[0].split(delimiter);
     // Check if a header row is present, by checking whether
     // the second column is a URL
-    const start = columns[1].startsWith('http') ? 0 : 1;
+    const start = (columns[1] || '').startsWith('http') ? 0 : 1;
     const tableBody = document.getElementById('csvPreviewBody');
     // Clear the table and fill in the new data
     // using this rough CSV parser. Note that since this
     // function is meant to be used by just a few administrators,
     // we aren't going to worry too much about parsing edge cases. 
-    // For example, note that we just parse at the first comma to split
+    // For example, note that we just parse at the first delimiter to split
     // columns.
     tableBody.innerHTML = '';
     const parsedCSV = [];
     for (let i = start; i < rows.length; i++) {
-        const row = rows[i];
-        let [folio, imageLink] = row.split(',', 2);
+        const row = rows[i].trim();
+        if (!row) continue;
+        let [folio, imageLink] = row.split(delimiter, 2);
         folio = folio.trim();
-        imageLink = imageLink.trim();
+        if (!folio) continue;
+        imageLink = (imageLink || '').trim();
         addPreviewTableRow(tableBody, folio, imageLink);
         const folioInput = imgLinkInputs[folio];
         if (folioInput) {
@@ -77,7 +81,7 @@ function getFoliosAtDuplicatedValues(array) {
         imageLinkCounts[imageLink] = (imageLinkCounts[imageLink] || 0) + 1;
     }
     const folioDuplicates = Object.keys(folioCounts).filter(folio => folioCounts[folio] > 1);
-    const imageLinkDuplicates = Object.keys(imageLinkCounts).filter(imageLink => imageLinkCounts[imageLink] > 1);
+    const imageLinkDuplicates = Object.keys(imageLinkCounts).filter(imageLink => imageLink !== '' && imageLinkCounts[imageLink] > 1);
     const folioWImageDuplicates = [];
     for (let i = 0; i < array.length; i++) {
         if (imageLinkDuplicates.includes(array[i].imageLink)) {
@@ -127,7 +131,7 @@ function csvLoadCallback(csv) {
     if (foliosWDupImageLinks.length === csvFolios.length) {
         displayCheckResults('imageLinkDuplication', [], "", "All image links identical");
     } else {
-        displayCheckResults('imageLinkDuplication', foliosWDupImageLinks, "Image links duplicated on the following subset of folios", "No image links duplicated");
+        displayCheckResults('imageLinkDuplication', foliosWDupImageLinks, "Image links duplicated on the following subset of folios");
     }
     document.getElementById('csvTestingDiv').hidden = false;
 }


### PR DESCRIPTION
## Summary

Add IIIF manifest integration to the source image links page and fix several bugs in the CSV validation UI.

Closes #1964

## Changes

### IIIF Manifest Integration
- New `iiif_utils.py` module with functions to fetch IIIF manifests, extract canvases, match them to source folios, and generate a CSV mapping
- New `SourceIIIFMappingView` that generates a downloadable folio-to-image CSV from a source's IIIF manifest
- "Generate IIIF Mapping CSV" button shown on sources that have an associated IIIF manifest
- Folio matching handles zero-padded numbers, various prefixes (`f.`, `fol.`, `Folio`), and recto/verso suffixes
- Regex anchored to prevent false positives (e.g. canvas labels like "Detail 2r" won't match folio `002r`)

### CSV Validation Bug Fixes
- Skip rows with empty folio fields from IIIF CSVs that include unmatched canvases, fixing phantom warnings (e.g. "the following folios do not exist in the source: ,,,,,,")
- Exclude empty strings from image link duplication checks
- Auto-detect semicolon delimiters for locale compatibility (e.g. French)
- Handle missing second column gracefully to prevent JS errors

### UX Improvements
- Add "Validation" header above the check results table
- Remove redundant "No image links duplicated" success text for visual consistency
- Show "Image links saved successfully!" message after saving

## Testing
- 43 unit tests for all IIIF utility functions and the mapping view in `test_iiif_utils.py`
- Tested against all 5 real IIIF manifests currently in CantusDB (all DIAMM, API v2)
- Tested label parsing and image URL extraction against Bodleian and e-codices manifests
- Verified false positive prevention with labels like "Detail 2r", "Image 5v", "Decoration", etc.