### PR TITLE
fix(tests): make SourceListViewTest.test_ordering deterministic

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -1374,12 +1374,13 @@ class SourceListViewTest(CustomAccessTestMixin, TestCase):
                         else ""
                     ),
                     (
-                        source.holding_institution.siglum
-                        if source.holding_institution
-                        and not source.holding_institution.is_private_collector
-                        else ""
-                    ),
+                        source.holding_institution.siglum is None,
+                        source.holding_institution.siglum or ""
+                    )
+                    if source.holding_institution
+                    else (True, ""),
                     source.shelfmark,
+                    source.pk,
                 ),
             )
             self.assertEqual(list(expected_source_order), list(response_sources))


### PR DESCRIPTION
Fixes #1970

## Summary

- Fix flaky "Order by country" subtest in `SourceListViewTest.test_ordering` that failed ~4% of the time
- The Python sort key used `""` for private collector sigla, but Django's `order_by` uses the raw DB value (`NULL`). When a private collector shared a country with another source, the tiebreaker orderings diverged
- Align the Python sort key with PostgreSQL's `NULLS LAST` behavior and add a `pk` tiebreaker for full determinism
- Ran the test 100 times against the develop branch and it no longer fails

## Root cause

Private collectors have `siglum=NULL` (enforced by a model constraint). The test's Python sort key had an `is_private_collector` guard that substituted `""`, while Django's `order_by("holding_institution__siglum")` sorts by the actual DB value. With the deliberately-created duplicate country, the siglum became the tiebreaker — and the two orderings disagreed.