### PR TITLE
Add robots.txt to block bot traffic on expensive endpoints (#1981) (#…

### DIFF
--- a/config/nginx/conf.d/cantusdb.conf.development
+++ b/config/nginx/conf.d/cantusdb.conf.development
@@ -5,6 +5,10 @@
 server {
     listen 80;
 
+    location = /robots.txt {
+        alias /robots.txt;
+    }
+
     location / {
         proxy_pass http://django:8000;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -179,7 +179,7 @@ urlpatterns = [
         ),
         name="reset_password_complete",
     ),
-    path("task-status", get_task_status, name="get-task-status"),
+    path("task-status/", get_task_status, name="get-task-status"),
     # century
     path("century/<int:pk>", CenturyDetailView.as_view(), name="century-detail"),
     # chant
@@ -565,7 +565,7 @@ urlpatterns = [
         name="proofread-by-autocomplete",
     ),
     path(
-        "holding-autocomplete",
+        "holding-autocomplete/",
         HoldingAutocomplete.as_view(),
         name="holding-autocomplete",
     ),

--- a/django/cantusdb_project/static/js/chant_list.js
+++ b/django/cantusdb_project/static/js/chant_list.js
@@ -183,7 +183,7 @@ window.addEventListener("load", function () {
                 const taskID = data["taskID"];
                 bulkEditLoading.classList.remove("d-none");
                 const interval = setInterval(() => {
-                    fetch(`/task-status?taskID=${taskID}`)
+                    fetch(`/task-status/?taskID=${taskID}`)
                         .then(response => {
                             if (response.status === 200) {
                                 return response.json();

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,3 +7,4 @@ RUN curl -LJO https://github.com/go-acme/lego/releases/download/v4.14.2/lego_v4.
     rm lego_v4.14.2_linux_amd64.tar.gz
 RUN mkdir -p /var/www/lego
 COPY error_pages /error_pages
+COPY robots.txt /robots.txt

--- a/nginx/robots.txt
+++ b/nginx/robots.txt
@@ -1,0 +1,38 @@
+# https://github.com/DDMAL/CantusDB/issues/1981
+User-agent: *
+
+Disallow: /chant-search/
+Disallow: /searchms/
+Disallow: /ci-search/
+Disallow: /melody/
+
+Disallow: /ajax/
+Disallow: /json-sources/
+Disallow: /json-nextchants/
+Disallow: /json-melody/
+Disallow: /json-cid/
+Disallow: /json-node/
+Disallow: /source/*/csv/
+Disallow: /sites/default/files/csv/
+Disallow: /articles-list/
+Disallow: /flatpages-list/
+Disallow: /cid-concordances/
+Disallow: /*-autocomplete/
+Disallow: /task-status/
+
+Disallow: /admin/
+Disallow: /login/
+Disallow: /logout/
+Disallow: /change-password/
+Disallow: /reset-password/
+Disallow: /reset/
+
+Disallow: /chant-create/
+Disallow: /edit-chants/
+Disallow: /edit-syllabification/
+Disallow: /edit-sequence/
+Disallow: /edit-source/
+Disallow: /source-create/
+Disallow: /content-overview/
+Disallow: /proofread-overview/
+Disallow: /my-sources/


### PR DESCRIPTION
- Cherry-pick of #1982 (staging) to production as a hotfix
- Adds `robots.txt` served by nginx to block bot crawlers from hitting expensive paginated search endpoints that were causing OOM crashes
- Fixes trailing slashes on `task-status/` and `holding-autocomplete/` URL patterns
- Corrects CSV export disallow paths in robots.txt