### PR TITLE
fix: add pagination controls to Cantorales and Canadian Chant DB pages

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -302,6 +302,11 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                        {% if is_paginated %}
+                            <div class="row mb-2">
+                                <div class="col">{% include "pagination.html" %}</div>
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
@@ -213,7 +213,7 @@
                             </div>
                             <div class="col-lg-1">
                                 <button type="submit" class="btn btn-dark btn-sm m-1" id="btn-submit">Apply</button>
-                                <a href="/CanadianChantDB/#search-container"
+                                <a href="/Cantorales/#search-container"
                                    class="btn btn-dark btn-sm m-1"
                                    id="btn-reset">Reset</a>
                             </div>
@@ -297,6 +297,11 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                        {% if is_paginated %}
+                            <div class="row mb-2">
+                                <div class="col">{% include "pagination.html" %}</div>
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
Closes #1976

- The Cantorales (`/Cantorales/`) and Canadian Chant DB (`/CanadianChantDB/`) pages use the same `SourceListView` with `paginate_by = 100`, but their templates were missing the pagination navigation controls. Users could see "Displaying 1-100 of N sources" but had no way to reach pages beyond the first.
- Adds the `{% include "pagination.html" %}` block (matching the main source list template) to both segment templates.
- Also fixes a copy-paste bug where the Cantorales "Reset" button linked to `/CanadianChantDB/` instead of `/Cantorales/`.