### PR TITLE
feat: add "Source data contributed by" field to Source model

### DIFF
--- a/django/cantusdb_project/main_app/admin/source.py
+++ b/django/cantusdb_project/main_app/admin/source.py
@@ -71,6 +71,7 @@ class SourceAdmin(BaseModelAdmin):
         "description_entered_by",
         "proofreaders",
         "other_editors",
+        "source_data_contributed_by",
     )
 
     list_display = (

--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -321,6 +321,7 @@ class SourceCreateForm(forms.ModelForm):
             "description_entered_by",
             "proofreaders",
             "other_editors",
+            "source_data_contributed_by",
             "complete_inventory",
             "summary",
             "description",
@@ -371,6 +372,9 @@ class SourceCreateForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
             "other_editors": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "source_data_contributed_by": autocomplete.ModelSelect2Multiple(
                 url="all-users-autocomplete"
             ),
             "production_method": SelectWidget(),
@@ -566,6 +570,7 @@ class SourceEditForm(forms.ModelForm):
             "description_entered_by",
             "proofreaders",
             "other_editors",
+            "source_data_contributed_by",
             "production_method",
             "source_completeness",
         ]
@@ -605,6 +610,9 @@ class SourceEditForm(forms.ModelForm):
                 url="all-users-autocomplete"
             ),
             "other_editors": autocomplete.ModelSelect2Multiple(
+                url="all-users-autocomplete"
+            ),
+            "source_data_contributed_by": autocomplete.ModelSelect2Multiple(
                 url="all-users-autocomplete"
             ),
             "production_method": SelectWidget(),

--- a/django/cantusdb_project/main_app/management/commands/import_cantorales.py
+++ b/django/cantusdb_project/main_app/management/commands/import_cantorales.py
@@ -340,7 +340,7 @@ class Command(BaseCommand):
                     for name in re.split(r",\s*", contributor_raw):
                         name = name.strip()
                         if name in contributor_users:
-                            source.inventoried_by.add(contributor_users[name])
+                            source.source_data_contributed_by.add(contributor_users[name])
 
                 verb = "Created" if was_created else "Updated"
                 self.stdout.write(f"  {verb} source: {source} (row {row_num})")

--- a/django/cantusdb_project/main_app/migrations/0042_source_source_data_contributed_by.py
+++ b/django/cantusdb_project/main_app/migrations/0042_source_source_data_contributed_by.py
@@ -1,8 +1,12 @@
 from django.conf import settings
 from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
 
 
-def move_cantorales_contributors(apps, schema_editor):
+def move_cantorales_contributors(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
     """
     Move users from inventoried_by to source_data_contributed_by for all
     sources in the "Cantorales in the Americas" segment.

--- a/django/cantusdb_project/main_app/migrations/0042_source_source_data_contributed_by.py
+++ b/django/cantusdb_project/main_app/migrations/0042_source_source_data_contributed_by.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 related_name="contributed_data_for_sources",
                 to=settings.AUTH_USER_MODEL,
-                verbose_name="source data contributed by",
+                verbose_name="source metadata contributed by",
             ),
         ),
         migrations.RunPython(

--- a/django/cantusdb_project/main_app/migrations/0042_source_source_data_contributed_by.py
+++ b/django/cantusdb_project/main_app/migrations/0042_source_source_data_contributed_by.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+def move_cantorales_contributors(apps, schema_editor):
+    """
+    Move users from inventoried_by to source_data_contributed_by for all
+    sources in the "Cantorales in the Americas" segment.
+
+    These sources were populated by the import_cantorales management command,
+    which put contributor names into inventoried_by by mistake.  Since
+    Cantorales sources have no chant inventory, every user in inventoried_by
+    on one of these sources is a data contributor, not an inventorier.
+    """
+    Segment = apps.get_model("main_app", "Segment")
+    try:
+        cantorales = Segment.objects.get(name="Cantorales in the Americas")
+    except Segment.DoesNotExist:
+        return  # segment not yet created (e.g. fresh database)
+
+    for source in cantorales.sources.prefetch_related("inventoried_by").all():
+        contributors = list(source.inventoried_by.all())
+        if contributors:
+            source.source_data_contributed_by.add(*contributors)
+            source.inventoried_by.remove(*contributors)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("main_app", "0041_alter_source_source_completeness"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="source",
+            name="source_data_contributed_by",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="contributed_data_for_sources",
+                to=settings.AUTH_USER_MODEL,
+                verbose_name="source data contributed by",
+            ),
+        ),
+        migrations.RunPython(
+            move_cantorales_contributors,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -137,7 +137,7 @@ class Source(BaseModel):
     )
     source_data_contributed_by = models.ManyToManyField(
         get_user_model(),
-        verbose_name="source data contributed by",
+        verbose_name="source metadata contributed by",
         related_name="contributed_data_for_sources",
         blank=True,
     )

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -110,7 +110,7 @@ class Source(BaseModel):
     )
 
     ######
-    # The following six fields have nothing to do with user permissions,
+    # The following seven fields have nothing to do with user permissions,
     # instead they give credit to users who are indexers and are displayed
     # on the user detail page as sources the user has contributed to.
     inventoried_by = models.ManyToManyField(
@@ -133,6 +133,12 @@ class Source(BaseModel):
     )
     other_editors = models.ManyToManyField(
         get_user_model(), related_name="edited_sources", blank=True
+    )
+    source_data_contributed_by = models.ManyToManyField(
+        get_user_model(),
+        verbose_name="source data contributed by",
+        related_name="contributed_data_for_sources",
+        blank=True,
     )
     ######
 

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -110,9 +110,10 @@ class Source(BaseModel):
     )
 
     ######
-    # The following seven fields have nothing to do with user permissions,
-    # instead they give credit to users who are indexers and are displayed
-    # on the user detail page as sources the user has contributed to.
+    # The following seven fields have nothing to do with user permissions;
+    # instead they give credit to users who are contributors/editors (e.g.,
+    # indexers, data contributors, proofreaders) and are displayed on the
+    # user detail page as sources the user has contributed to.
     inventoried_by = models.ManyToManyField(
         get_user_model(), related_name="inventoried_sources", blank=True
     )

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -584,6 +584,23 @@
                                 {% endfor %}
                             </ul>
                         {% endif %}
+                        {% if source.source_data_contributed_by.exists %}
+                            Source data contributed by:
+                            <ul class="mb-0">
+                                {% for editor in source.source_data_contributed_by.all %}
+                                    <li>
+                                        {% if editor.full_name %}
+                                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a>
+                                            <br />
+                                        {% else %}
+                                            <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a>
+                                            <br />
+                                        {% endif %}
+                                        {{ editor.institution|default_if_none:"" }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
                         {{ source.indexing_notes|default_if_none:""|safe }}
                         <br />
                         {% with creator=source.created_by %}

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -585,7 +585,7 @@
                             </ul>
                         {% endif %}
                         {% if source.source_data_contributed_by.exists %}
-                            Source data contributed by:
+                            Source metadata contributed by:
                             <ul class="mb-0">
                                 {% for contributor in source.source_data_contributed_by.all %}
                                     <li>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -587,16 +587,16 @@
                         {% if source.source_data_contributed_by.exists %}
                             Source data contributed by:
                             <ul class="mb-0">
-                                {% for editor in source.source_data_contributed_by.all %}
+                                {% for contributor in source.source_data_contributed_by.all %}
                                     <li>
-                                        {% if editor.full_name %}
-                                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a>
+                                        {% if contributor.full_name %}
+                                            <a href="{% url 'user-detail' contributor.id %}">{{ contributor.full_name }}</a>
                                             <br />
                                         {% else %}
-                                            <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a>
+                                            <a href="{% url 'user-detail' contributor.id %}">User {{ contributor.id }}</a>
                                             <br />
                                         {% endif %}
-                                        {{ editor.institution|default_if_none:"" }}
+                                        {{ contributor.institution|default_if_none:"" }}
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/django/cantusdb_project/main_app/templates/source_create.html
+++ b/django/cantusdb_project/main_app/templates/source_create.html
@@ -137,6 +137,12 @@
                         </div>
                     </div>
                     <div class="row mb-2 small">
+                        <div class="col-lg-3">
+                            {{ form.source_data_contributed_by.label_tag }}
+                            {{ form.source_data_contributed_by }}
+                        </div>
+                    </div>
+                    <div class="row mb-2 small">
                         <div class="col-lg-2">
                             <label for="{{ form.complete_inventory.id_for_label }}">
                                 Full / partial inventory:

--- a/django/cantusdb_project/main_app/templates/source_create.html
+++ b/django/cantusdb_project/main_app/templates/source_create.html
@@ -108,6 +108,12 @@
                     </div>
                     <div class="row mb-2 small">
                         <div class="col-lg-3">
+                            {{ form.source_data_contributed_by.label_tag }}
+                            {{ form.source_data_contributed_by }}
+                        </div>
+                    </div>
+                    <div class="row mb-2 small">
+                        <div class="col-lg-3">
                             {{ form.inventoried_by.label_tag }}
                             {{ form.inventoried_by }}
                         </div>
@@ -134,12 +140,6 @@
                         <div class="col-lg-3">
                             {{ form.other_editors.label_tag }}
                             {{ form.other_editors }}
-                        </div>
-                    </div>
-                    <div class="row mb-2 small">
-                        <div class="col-lg-3">
-                            {{ form.source_data_contributed_by.label_tag }}
-                            {{ form.source_data_contributed_by }}
                         </div>
                     </div>
                     <div class="row mb-2 small">

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -328,16 +328,16 @@
         {% if source.source_data_contributed_by.exists %}
             Source data contributed by:
             <ul class="mb-0">
-                {% for editor in source.source_data_contributed_by.all %}
+                {% for contributor in source.source_data_contributed_by.all %}
                     <li>
-                        {% if editor.full_name %}
-                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a>
+                        {% if contributor.full_name %}
+                            <a href="{% url 'user-detail' contributor.id %}">{{ contributor.full_name }}</a>
                             <br />
                         {% else %}
-                            <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a>
+                            <a href="{% url 'user-detail' contributor.id %}">User {{ contributor.id }}</a>
                             <br />
                         {% endif %}
-                        {{ editor.institution|default_if_none:"" }}
+                        {{ contributor.institution|default_if_none:"" }}
                     </li>
                 {% endfor %}
             </ul>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -326,7 +326,7 @@
             </ul>
         {% endif %}
         {% if source.source_data_contributed_by.exists %}
-            Source data contributed by:
+            Source metadata contributed by:
             <ul class="mb-0">
                 {% for contributor in source.source_data_contributed_by.all %}
                     <li>

--- a/django/cantusdb_project/main_app/templates/source_detail.html
+++ b/django/cantusdb_project/main_app/templates/source_detail.html
@@ -325,6 +325,23 @@
                 {% endfor %}
             </ul>
         {% endif %}
+        {% if source.source_data_contributed_by.exists %}
+            Source data contributed by:
+            <ul class="mb-0">
+                {% for editor in source.source_data_contributed_by.all %}
+                    <li>
+                        {% if editor.full_name %}
+                            <a href="{% url 'user-detail' editor.id %}">{{ editor.full_name }}</a>
+                            <br />
+                        {% else %}
+                            <a href="{% url 'user-detail' editor.id %}">User {{ editor.id }}</a>
+                            <br />
+                        {% endif %}
+                        {{ editor.institution|default_if_none:"" }}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
         {% if source.description_entered_by.exists %}
             Source description author{{ source.description_entered_by.all|pluralize }}:
             <ul class="mb-0">

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -105,6 +105,12 @@
         </div>
         <div class="row mb-2 small">
             <div class="col-lg-3">
+                {{ form.source_data_contributed_by.label_tag }}
+                {{ form.source_data_contributed_by }}
+            </div>
+        </div>
+        <div class="row mb-2 small">
+            <div class="col-lg-3">
                 {{ form.inventoried_by.label_tag }}
                 {{ form.inventoried_by }}
             </div>
@@ -131,12 +137,6 @@
             <div class="col-lg-3">
                 {{ form.other_editors.label_tag }}
                 {{ form.other_editors }}
-            </div>
-        </div>
-        <div class="row mb-2 small">
-            <div class="col-lg-3">
-                {{ form.source_data_contributed_by.label_tag }}
-                {{ form.source_data_contributed_by }}
             </div>
         </div>
         <div class="row mb-2 small">

--- a/django/cantusdb_project/main_app/templates/source_edit.html
+++ b/django/cantusdb_project/main_app/templates/source_edit.html
@@ -134,6 +134,12 @@
             </div>
         </div>
         <div class="row mb-2 small">
+            <div class="col-lg-3">
+                {{ form.source_data_contributed_by.label_tag }}
+                {{ form.source_data_contributed_by }}
+            </div>
+        </div>
+        <div class="row mb-2 small">
             <div class="col-lg-5">
                 <label for="{{ form.complete_inventory.id_for_label }}">
                     Full / partial inventory:

--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -302,6 +302,11 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                        {% if is_paginated %}
+                            <div class="row mb-2">
+                                <div class="col">{% include "pagination.html" %}</div>
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
@@ -213,7 +213,7 @@
                             </div>
                             <div class="col-lg-1">
                                 <button type="submit" class="btn btn-dark btn-sm m-1" id="btn-submit">Apply</button>
-                                <a href="/CanadianChantDB/#search-container"
+                                <a href="/Cantorales/#search-container"
                                    class="btn btn-dark btn-sm m-1"
                                    id="btn-reset">Reset</a>
                             </div>
@@ -297,6 +297,11 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                        {% if is_paginated %}
+                            <div class="row mb-2">
+                                <div class="col">{% include "pagination.html" %}</div>
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/django/cantusdb_project/main_app/templates/user_detail.html
+++ b/django/cantusdb_project/main_app/templates/user_detail.html
@@ -38,7 +38,7 @@
             </dd>
         {% endif %}
     </dl>
-    {% if inventoried_sources or full_text_sources or melody_sources or description_sources or proofread_sources or edited_sources %}
+    {% if inventoried_sources or full_text_sources or melody_sources or description_sources or proofread_sources or edited_sources or contributed_data_sources %}
         <h4 id="sources">Sources</h4>
         {% if inventoried_sources %}
             <h5>Inventoried</h5>
@@ -99,6 +99,17 @@
             <h5>Edited</h5>
             <ul>
                 {% for source in edited_sources %}
+                    <li>
+                        <a href="{% url 'source-detail' source.id %}"
+                           title="{{ source.heading }}">{{ source.short_heading }}</a> ({{ source.heading }})
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        {% if contributed_data_sources %}
+            <h5>Contributed Source Data</h5>
+            <ul>
+                {% for source in contributed_data_sources %}
                     <li>
                         <a href="{% url 'source-detail' source.id %}"
                            title="{{ source.heading }}">{{ source.short_heading }}</a> ({{ source.heading }})

--- a/django/cantusdb_project/main_app/tests/make_fakes.py
+++ b/django/cantusdb_project/main_app/tests/make_fakes.py
@@ -549,6 +549,7 @@ def make_fake_source(**kwargs: Any) -> Source:
     source.melodies_entered_by.set([make_fake_user()])
     source.proofreaders.set([make_fake_user()])
     source.other_editors.set([make_fake_user()])
+    source.source_data_contributed_by.set([make_fake_user()])
     source.segment_m2m.set(segments)
 
     return source

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -279,7 +279,7 @@ class SourceDetailView(CustomAccessMixin, JSONResponseMixin, DetailView):  # typ
             self.model.objects.select_related(
                 "holding_institution", "provenance", "created_by"
             )
-            .prefetch_related("segment_m2m", "proofreaders", "inventoried_by")
+            .prefetch_related("segment_m2m", "proofreaders", "inventoried_by", "source_data_contributed_by")
             .all()
         )
 
@@ -463,6 +463,7 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
             description_entered_by_q = Q()
             proofreaders_q = Q()
             other_editors_q = Q()
+            source_data_contributed_by_q = Q()
             indexing_notes_q = Q()
             # For each term, add it to the Q object of each field with an OR operation.
             # We split the terms so that the words can be separated in the actual
@@ -481,6 +482,9 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 )
                 proofreaders_q |= Q(proofreaders__full_name__icontains=term)
                 other_editors_q |= Q(other_editors__full_name__icontains=term)
+                source_data_contributed_by_q |= Q(
+                    source_data_contributed_by__full_name__icontains=term
+                )
                 indexing_notes_q |= Q(indexing_notes__icontains=term)
             # All the Q objects are put together with OR.
             # The end result is that at least one term has to match in at least one
@@ -492,6 +496,7 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 | description_entered_by_q
                 | proofreaders_q
                 | other_editors_q
+                | source_data_contributed_by_q
                 | indexing_notes_q
             )
             q_obj_filter &= indexing_search_q

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -279,7 +279,16 @@ class SourceDetailView(CustomAccessMixin, JSONResponseMixin, DetailView):  # typ
             self.model.objects.select_related(
                 "holding_institution", "provenance", "created_by"
             )
-            .prefetch_related("segment_m2m", "proofreaders", "inventoried_by", "source_data_contributed_by")
+            .prefetch_related(
+                "segment_m2m",
+                "proofreaders",
+                "inventoried_by",
+                "source_data_contributed_by",
+                "full_text_entered_by",
+                "melodies_entered_by",
+                "other_editors",
+                "description_entered_by",
+            )
             .all()
         )
 

--- a/django/cantusdb_project/main_app/views/user.py
+++ b/django/cantusdb_project/main_app/views/user.py
@@ -83,6 +83,13 @@ class UserDetailView(CustomAccessMixin, DetailView):  # type: ignore
             .order_by("holding_institution__siglum")
         )
 
+        context["contributed_data_sources"] = (
+            base_source_set.filter(source_data_contributed_by=user)
+            .select_related("holding_institution")
+            .all()
+            .order_by("holding_institution__siglum")
+        )
+
         return context
 
 


### PR DESCRIPTION
Adds a new `source_data_contributed_by` ManyToManyField to Source to credit users who contributed source data. Was previously under `inventoried_by`, which is intended for chant indexers.

- Adds the `source_data_contributed_by` field to the Source model
- Adds a data migration that moves all `inventoried_by` users on Cantorales-segment sources into the new field
- Updates `import_cantorales.py` to populate `source_data_contributed_by` directly on future imports
- Displays the field in source detail, source edit, source create, chant detail, and user detail pages
- Adds the field to both source forms (with autocomplete widget) and Django admin
- Updates `UserDetailView` to show sources a user has contributed data for
- Updates the source list search to include the new field
- Updates `make_fakes.py` for tests