### PR TITLE
feat: Add canadian chant database specific search page

### DIFF
--- a/django/cantusdb_project/main_app/templates/ccdb_chant_search.html
+++ b/django/cantusdb_project/main_app/templates/ccdb_chant_search.html
@@ -1,0 +1,367 @@
+{% extends "base.html" %}
+{% load humanize %}
+{% load helper_tags %}
+{% load static %}
+{% block title %}<title>Chant Search – Canadian Chant Database</title>{% endblock %}
+{% block favicon %}<link rel="icon" href="{% static 'ccdb-images/CCDB-favicon.png' %}" />{% endblock %}
+{% block scripts %}
+    <script src="/static/js/chant_search.js"></script>
+    <link href="{% static 'css/ccdb_style.css' %}" rel="stylesheet" media="screen" />
+{% endblock %}
+{% block header %}
+    {% include "header/sticky_header.html" %}
+{% endblock %}
+{% block heading %}{% endblock %}
+{% block content %}
+    <div class="container-fluid ccdb-info">
+        {% include "ccdb_subpage_header.html" %}
+        <div class="row py-5 bg-white bg-opacity-75">
+            <div class="col-lg-9 px-5">
+                <h2 class="mb-4">Chant Search</h2>
+                {% if keyword %}
+                    <p class="small">
+                        » <a href="https://cantusindex.org/search?t={{ keyword }}"
+                             title="Search {{ keyword }} on CantusIndex.org"
+                             target="_blank">Search <b>{{ keyword }}</b> on CantusIndex.org</a>
+                    </p>
+                {% endif %}
+
+                {# ---- Search form ---- #}
+                <form method="get" class="ccdb-filter-form mb-4">
+                    <div class="row align-items-end">
+                        <div class="form-group col-sm-3 col-12">
+                            <label for="keywordSearch" class="small">Keyword search</label>
+                            <select class="form-control form-select form-select-sm ccdb-search-input"
+                                    id="opFilter"
+                                    name="op">
+                                <option {% if request.GET.op == "contains" or not request.GET.op %}selected{% endif %} value="contains">Contains</option>
+                                <option {% if request.GET.op == "starts_with" %}selected{% endif %} value="starts_with">Starts with</option>
+                            </select>
+                        </div>
+                        <div class="form-group col-sm-9 col-12">
+                            <input type="text"
+                                   class="form-control form-control-sm ccdb-search-input"
+                                   name="keyword"
+                                   id="keywordSearch"
+                                   value="{{ request.GET.keyword }}" />
+                        </div>
+                    </div>
+                    <div class="row align-items-end mt-2">
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label class="small">Databases</label>
+                            <div class="dropdown">
+                                <button class="ccdb-db-dropdown-btn"
+                                        type="button"
+                                        data-bs-toggle="dropdown"
+                                        data-bs-auto-close="outside"
+                                        aria-expanded="false">
+                                    {% if selected_dbs|length == 1 %}
+                                        1 database
+                                    {% else %}
+                                        {{ selected_dbs|length }} databases
+                                    {% endif %}
+                                </button>
+                                <ul class="dropdown-menu shadow-sm p-2" style="min-width: 16rem;">
+                                    {% for seg_id, seg_name in available_segments %}
+                                        <li>
+                                            <div class="form-check">
+                                                <input class="form-check-input"
+                                                       type="checkbox"
+                                                       name="db"
+                                                       value="{{ seg_id }}"
+                                                       id="db-seg-{{ seg_id }}"
+                                                       {% if seg_id|stringformat:"s" in selected_dbs %}checked{% endif %}>
+                                                <label class="form-check-label small" for="db-seg-{{ seg_id }}">
+                                                    {{ seg_name }}
+                                                </label>
+                                            </div>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="serviceFilter" class="small">Service</label>
+                            <select id="serviceFilter"
+                                    name="service"
+                                    class="form-control form-select form-select-sm ccdb-search-input">
+                                <option value="">- Any -</option>
+                                {% for service in services %}
+                                    <option value="{{ service.id }}" {% if request.GET.service == service.id|stringformat:"s" %}selected{% endif %}>{{ service.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="genreFilter" class="small">Genre</label>
+                            <select id="genreFilter"
+                                    name="genre"
+                                    class="form-control form-select form-select-sm ccdb-search-input">
+                                <option value="">- Any -</option>
+                                {% for genre in genres %}
+                                    <option value="{{ genre.id }}" {% if request.GET.genre == genre.id|stringformat:"s" %}selected{% endif %}>{{ genre.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="cantus_id" class="small">Cantus ID</label>
+                            <input type="text"
+                                   class="form-control form-control-sm ccdb-search-input"
+                                   name="cantus_id"
+                                   id="cantus_id"
+                                   value="{{ request.GET.cantus_id }}" />
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="mode" class="small">Mode</label>
+                            <input type="text"
+                                   class="form-control form-control-sm ccdb-search-input"
+                                   name="mode"
+                                   id="mode"
+                                   value="{{ request.GET.mode }}" />
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="feast" class="small">Feast</label>
+                            <input type="text"
+                                   class="form-control form-control-sm ccdb-search-input"
+                                   name="feast"
+                                   id="feast"
+                                   value="{{ request.GET.feast }}" />
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="position" class="small">Position</label>
+                            <input type="text"
+                                   class="form-control form-control-sm ccdb-search-input"
+                                   name="position"
+                                   id="position"
+                                   value="{{ request.GET.position }}" />
+                        </div>
+                        <div class="form-group col-lg-3 col-sm-6 col-12">
+                            <label for="melodiesFilter" class="small">Melodies</label>
+                            <select class="form-control form-select form-select-sm ccdb-search-input"
+                                    id="melodiesFilter"
+                                    name="melodies">
+                                <option value="">- Any -</option>
+                                <option value="true" {% if request.GET.melodies == "true" %}selected{% endif %}>Chants with melodies</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row align-items-end pt-2">
+                        <div class="form-group col-lg">
+                            <button type="submit" class="btn btn-sm ccdb-button text-white" id="btn-submit">Apply</button>
+                            <a href="{% url 'ccdb-chant-search' %}" class="btn btn-sm btn-outline-secondary ms-2">Reset</a>
+                        </div>
+                    </div>
+                </form>
+
+                {# ---- Tabs (only shown once a search has been made) ---- #}
+                {% if not query_empty %}
+                    <ul class="nav nav-tabs ccdb-tabs mb-0" id="searchResultTabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active"
+                                    id="chants-tab"
+                                    data-bs-toggle="tab"
+                                    data-bs-target="#chants-pane"
+                                    type="button"
+                                    role="tab"
+                                    aria-controls="chants-pane"
+                                    aria-selected="true">
+                                Chants
+                                <span class="badge rounded-pill ms-1">{{ page_obj.paginator.count }}</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link"
+                                    id="sources-tab"
+                                    data-bs-toggle="tab"
+                                    data-bs-target="#sources-pane"
+                                    type="button"
+                                    role="tab"
+                                    aria-controls="sources-pane"
+                                    aria-selected="false">
+                                Sources
+                                <span class="badge rounded-pill ms-1">{{ ccdb_source_count }}</span>
+                            </button>
+                        </li>
+                    </ul>
+
+                    <div class="tab-content border border-top-0 rounded-bottom p-3 bg-white" id="searchResultTabContent">
+
+                        {# ---- Chants pane ---- #}
+                        <div class="tab-pane fade show active"
+                             id="chants-pane"
+                             role="tabpanel"
+                             aria-labelledby="chants-tab">
+                            {% include "page_count.html" %}
+                            {% if page_obj.paginator.count > 0 %}
+                                <div class="table-responsive mt-2">
+                                    <table class="table table-sm small table-bordered ccdb-table">
+                                        <thead class="ccdb-table-bg">
+                                            <tr>
+                                                {% sortable_header request "siglum" %}
+                                                <th scope="col" class="text-wrap" style="text-align:center" title="Folio">Folio</th>
+                                                {% sortable_header request "incipit" "Incipit/Full Text" %}
+                                                {% sortable_header request "feast" "Feast" %}
+                                                {% sortable_header request "service" "Service" %}
+                                                {% sortable_header request "genre" "Genre" %}
+                                                <th scope="col" class="text-wrap" style="text-align:center" title="Position">Position</th>
+                                                {% sortable_header request "cantus_id" "Cantus ID" %}
+                                                {% sortable_header request "mode" "Mode" %}
+                                                {% sortable_header request "has_fulltext" "FT" %}
+                                                {% sortable_header request "has_melody" "Mel" %}
+                                                {% sortable_header request "has_image" "Image" %}
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for chant in chants %}
+                                                {% if chant.source.id != 680970 or melodies != "true" %}
+                                                    <tr>
+                                                        <td class="text-wrap" style="text-align:left">
+                                                            {% if chant.source %}
+                                                                <a href="{% url 'source-detail' chant.source_id %}"
+                                                                   title="{{ chant.source.heading }}">{{ chant.source.short_heading }}</a>
+                                                            {% endif %}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {{ chant.folio|default:""|truncatechars_html:140 }}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:left">
+                                                            {% if chant.search_vector %}
+                                                                <b><a href="{% url 'chant-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                                            {% else %}
+                                                                <b><a href="{% url 'sequence-detail' chant.id %}">{{ chant.incipit|default:"" }}</a></b>
+                                                            {% endif %}
+                                                            <div>{{ chant.manuscript_full_text_std_spelling|default:""|truncatewords_html:100 }}</div>
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {% if chant.feast %}
+                                                                <a href="{% url 'feast-detail' chant.feast.id %}"
+                                                                   title="{{ chant.feast.description }}">{{ chant.feast.name }}</a>
+                                                            {% endif %}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {% if chant.service %}
+                                                                <a href="{% url 'service-detail' chant.service.id %}"
+                                                                   title="{{ chant.service.description }}">{{ chant.service.name }}</a>
+                                                            {% endif %}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {% if chant.genre %}
+                                                                <a href="{% url 'genre-detail' chant.genre.id %}"
+                                                                   title="{{ chant.genre.description }}">{{ chant.genre.name }}</a>
+                                                            {% endif %}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">{{ chant.position|default:"" }}</td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            <a href="https://cantusindex.org/id/{{ chant.cantus_id }}"
+                                                               target="_blank">{{ chant.cantus_id|default:"" }}</a>
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">{{ chant.mode|default:"" }}</td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {% if chant.manuscript_full_text %}
+                                                                <span title="Chant record includes Manuscript Full Text">✔</span>
+                                                            {% endif %}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {% if chant.volpiano and chant.source.id != 680970 %}
+                                                                <span title="Chant record has Volpiano melody">♫</span>
+                                                            {% endif %}
+                                                        </td>
+                                                        <td class="text-wrap" style="text-align:center">
+                                                            {% if chant.image_link %}
+                                                                <a href="{{ chant.image_link }}" target="_blank">Image</a>
+                                                            {% endif %}
+                                                        </td>
+                                                    </tr>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                                {% if is_paginated %}
+                                    {% include "pagination.html" %}
+                                {% endif %}
+                            {% else %}
+                                <p class="text-center mt-3">No chants found.</p>
+                            {% endif %}
+                        </div>
+
+                        {# ---- Sources pane ---- #}
+                        <div class="tab-pane fade"
+                             id="sources-pane"
+                             role="tabpanel"
+                             aria-labelledby="sources-tab">
+                            {% if ccdb_source_count > 0 %}
+                                <p class="small text-muted mt-2 mb-2">
+                                    {{ ccdb_source_count }} source{{ ccdb_source_count|pluralize }} found
+                                </p>
+                                <div class="table-responsive">
+                                    <table class="table table-sm small table-bordered ccdb-table">
+                                        <thead class="ccdb-table-bg">
+                                            <tr>
+                                                <th scope="col">Institution</th>
+                                                <th scope="col">Source</th>
+                                                <th scope="col">Date</th>
+                                                <th scope="col">Provenance</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for source in ccdb_sources %}
+                                                <tr>
+                                                    <td class="text-wrap">
+                                                        {% if source.holding_institution %}
+                                                            <a href="{% url 'institution-detail' source.holding_institution.id %}"
+                                                               target="_blank">
+                                                                {% if source.holding_institution.city %}{{ source.holding_institution.city }}, {% endif %}
+                                                                {{ source.holding_institution.name }}
+                                                            </a>
+                                                        {% endif %}
+                                                    </td>
+                                                    <td class="text-wrap">
+                                                        <a href="{% url 'source-detail' source.id %}"
+                                                           target="_blank">
+                                                            <b>{{ source.short_heading|truncatechars_html:100 }}</b>
+                                                        </a>
+                                                    </td>
+                                                    <td class="text-wrap">{{ source.date|default:"" }}</td>
+                                                    <td class="text-wrap">
+                                                        {% if source.provenance %}
+                                                            <a href="{% url 'provenance-detail' source.provenance.id %}"
+                                                               target="_blank">{{ source.provenance.name }}</a>
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-center mt-3">No sources found.</p>
+                                <p class="text-center text-muted small">Tip: Sources return from keyword searches.</p>
+                            {% endif %}
+                        </div>
+
+                    </div>{# end tab-content #}
+                {% endif %}{# end not query_empty #}
+
+            </div>
+            <div class="col-lg-3">
+                <nav class="ccdb-segment-menu sticky-top pt-4">
+                    <ul class="list-unstyled">
+                        <li>
+                            <a href="{% url 'canadian-chant-db-source-list' %}">
+                                <img src="{% static 'ccdb-images/CCDB-favicon_transparentbg.png' %}"
+                                     class="ccdb-nav-home-icon"
+                                     alt="" />Home
+                            </a>
+                        </li>
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
+                        <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-chant-search' %}">Chant Search</a></li>
+                        <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
+                        <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/templates/ccdb_map.html
+++ b/django/cantusdb_project/main_app/templates/ccdb_map.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}<title>Map of Sources – Canadian Chant Database</title>{% endblock %}
+{% block favicon %}<link rel="icon" href="{% static "ccdb-images/CCDB-favicon.png" %}" />{% endblock %}
+{% block scripts %}
+    <link href="{% static 'css/ccdb_style.css' %}" rel="stylesheet" media="screen" />
+{% endblock %}
+{% block header %}
+    {% include "header/sticky_header.html" %}
+{% endblock %}
+{% block heading %}{% endblock %}
+{% block content %}
+    <div class="container-fluid ccdb-info">
+        {% include "ccdb_subpage_header.html" %}
+        <div class="row py-5 bg-white bg-opacity-75">
+            <div class="col-lg-9">
+                <h2 class="px-5 mb-4">Map of Sources</h2>
+                <div class="text-center">
+                    <iframe src="https://www.google.com/maps/d/embed?mid=1uTSnFP4RHFd7RSBIIZpJ0_i69hIpypo&ehbc=2E312F"
+                            width="100%"
+                            height="600"
+                            style="border: none;"></iframe>
+                </div>
+            </div>
+            <div class="col-lg-3">
+                <nav class="ccdb-segment-menu sticky-top pt-4">
+                    <ul class="list-unstyled">
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
+                        <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
+                        <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/templates/ccdb_map.html
+++ b/django/cantusdb_project/main_app/templates/ccdb_map.html
@@ -25,8 +25,16 @@
             <div class="col-lg-3">
                 <nav class="ccdb-segment-menu sticky-top pt-4">
                     <ul class="list-unstyled">
+                        <li>
+                            <a href="{% url 'canadian-chant-db-source-list' %}">
+                                <img src="{% static 'ccdb-images/CCDB-favicon_transparentbg.png' %}"
+                                     class="ccdb-nav-home-icon"
+                                     alt="" />Home
+                            </a>
+                        </li>
                         <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
                         <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-chant-search' %}">Chant Search</a></li>
                         <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
                         <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
                         <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>

--- a/django/cantusdb_project/main_app/templates/ccdb_subpage_header.html
+++ b/django/cantusdb_project/main_app/templates/ccdb_subpage_header.html
@@ -1,0 +1,8 @@
+{% load static %}
+<div class="ccdb-subpage-header">
+    <a href="{% url 'canadian-chant-db-source-list' %}">
+        <img src="{% static 'ccdb-images/CCD-logo.svg' %}"
+             class="ccdb-subpage-logo"
+             alt="Canadian Chant Database" />
+    </a>
+</div>

--- a/django/cantusdb_project/main_app/templates/ccdb_team.html
+++ b/django/cantusdb_project/main_app/templates/ccdb_team.html
@@ -54,8 +54,16 @@
             <div class="col-lg-3">
                 <nav class="ccdb-segment-menu sticky-top pt-4">
                     <ul class="list-unstyled">
+                        <li>
+                            <a href="{% url 'canadian-chant-db-source-list' %}">
+                                <img src="{% static 'ccdb-images/CCDB-favicon_transparentbg.png' %}"
+                                     class="ccdb-nav-home-icon"
+                                     alt="" />Home
+                            </a>
+                        </li>
                         <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
                         <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-chant-search' %}">Chant Search</a></li>
                         <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
                         <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
                         <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>

--- a/django/cantusdb_project/main_app/templates/ccdb_team.html
+++ b/django/cantusdb_project/main_app/templates/ccdb_team.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}<title>Project Team – Canadian Chant Database</title>{% endblock %}
+{% block favicon %}<link rel="icon" href="{% static "ccdb-images/CCDB-favicon.png" %}" />{% endblock %}
+{% block scripts %}
+    <link href="{% static 'css/ccdb_style.css' %}" rel="stylesheet" media="screen" />
+{% endblock %}
+{% block header %}
+    {% include "header/sticky_header.html" %}
+{% endblock %}
+{% block heading %}{% endblock %}
+{% block content %}
+    <div class="container-fluid ccdb-info">
+        {% include "ccdb_subpage_header.html" %}
+        <div class="row py-5 bg-white bg-opacity-75">
+            <div class="col-lg-9 px-5">
+                <h2 class="mb-4">Project Team</h2>
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="mb-3">
+                            <strong>Jennifer Bain</strong>
+                            <div class="small">DACT Project Director</div>
+                            <div class="small">Dalhousie University, Halifax</div>
+                        </div>
+                        <div class="mb-3">
+                            <strong>Debra Lacoste</strong>
+                            <div class="small">DACT Project Manager</div>
+                            <div class="small">Dalhousie University, Halifax</div>
+                        </div>
+                        <div class="mb-3">
+                            <strong>Julie Cumming</strong>
+                            <div class="small">DACT Manuscripts and Printed Chantbooks – McGill University, Team Lead</div>
+                            <div class="small">McGill University, Montreal</div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="mb-3">
+                            <strong>D. Linda Pearse</strong>
+                            <div class="small">DACT Encounters in Kahnawà:ke, Team Lead</div>
+                        </div>
+                        <div class="mb-3">
+                            <strong>Kate Kennedy Steiner</strong>
+                            <div class="small">DACT Manuscripts and Fragments – Central & Eastern Canada, Team Lead</div>
+                            <div class="small">Conrad Grebel University College at the University of Waterloo</div>
+                        </div>
+                        <div class="mb-3">
+                            <strong>David Watt</strong>
+                            <div class="small">DACT Manuscripts and Fragments – Western Canada</div>
+                            <div class="small">University of Manitoba</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-3">
+                <nav class="ccdb-segment-menu sticky-top pt-4">
+                    <ul class="list-unstyled">
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
+                        <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
+                        <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -2,7 +2,7 @@
 {% load helper_tags %}
 {% load static %}
 {% block title %}<title>Canadian Chant Database</title>{% endblock %}
-{% block favicon %}<link rel="icon" href="{% static "ccdb-images/CCDB-favicon.png" %}" />{% endblock %}
+{% block favicon %}<link rel="icon" href="{% static 'ccdb-images/CCDB-favicon.png' %}" />{% endblock %}
 {% block scripts %}
     <script src="{% static 'js/source_list.js' %}"></script>
     <link href="{% static 'css/ccdb_style.css' %}"
@@ -16,67 +16,73 @@
 {% block content %}
     <div class="container-fluid ccdb-info">
         <div class="ccdb-hero-banner">
-            <a href="#search-container">
+            <a href="{% url 'ccdb-browse' %}">
                 <img src="{% static 'ccdb-images/CCD-logo.svg' %}"
                      class="img-fluid ccdb-hero-logo"
                      alt="Logo with words 'Canadian Chant Database'" />
             </a>
+            <span class="ccdb-banner-credit">Salzinnes Antiphonal</span>
         </div>
         <div class="row py-5 bg-white bg-opacity-75">
-            <div class="col-lg-9">
-                <div class="d-lg-grid ccdb-landing-grid">
-                    <div class="ps-4 ccdb-grid-image">
-                        <div class="px-5">
-                            <p>
-                                The Canadian Chant Database is an initiative of the <a href="https://dact-chant.ca/" target="_blank">Digital Analysis of Chant Transmission (DACT) Project</a>.
-                            </p>
+            <div class="col-lg-9 px-5">
+                <form method="get" action="{% url 'ccdb-chant-search' %}" class="d-flex mb-4">
+                    <input type="text"
+                           name="keyword"
+                           class="form-control form-control-lg ccdb-search-input"
+                           placeholder="Search the database" />
+                    <button type="submit" class="btn btn-lg ccdb-button ms-2 px-4">Search</button>
+                </form>
+                <p id="about-section">
+                    The goal of the Canadian Chant Database is to catalogue–and eventually inventory–all manuscripts and manuscript fragments containing plainchant derived from the medieval European tradition in libraries, archives, institutions, and private ownership in Canada. Printed chant books are limited to those sources that were published specifically for use in Canada.
+                </p>
+                <div id="acknowledgements-section" class="ccdb-supporters mt-4">
+                    <p class="text-center mb-3">
+                        The Canadian Chant Database is an initiative of the <a href="https://dact-chant.ca/" target="_blank">Digital Analysis of Chant Transmission (DACT) Project</a>.
+                        Support has been provided by the <a href="https://www.sshrc-crsh.gc.ca/home-accueil-eng.aspx" target="_blank">Social Sciences and Humanities Research Council of Canada</a> and the <a href="https://alliancecan.ca/en" target="_blank">Digital Research Alliance of Canada</a>.
+                    </p>
+                    <div class="row align-items-center justify-content-center text-center">
+                        <div class="col-md-auto">
                             <a href="https://dact-chant.ca/" target="_blank">
-                                <img class="img-fluid p-2 ccdb-dact-logo"
-                                    src="{% static "footer/dact-logo.png" %}"
-                                    alt="Digital Analysis of Chant Transmission Logo"
-                                    title="Digital Analysis of Chant Transmission" />
+                                <img class="img-fluid p-2 ccdb-small-logo"
+                                     src="{% static 'footer/dact-logo.png' %}"
+                                     alt="Digital Analysis of Chant Transmission Logo"
+                                     title="Digital Analysis of Chant Transmission" />
+                            </a>
+                        </div>
+                        <div class="col-md-auto">
+                            <a href="https://alliancecan.ca/" target="_blank">
+                                <img class="img-fluid p-2 ccdb-small-logo"
+                                     src="{% static 'footer/drac-logo.png' %}"
+                                     alt="Digital Research Alliance Logo"
+                                     title="Digital Research Alliance" />
                             </a>
                         </div>
                     </div>
-                    <div class="ccdb-grid-summary px-5 pt-5">
-                        <div class="text-white d-block text-center">
-                            <a class="btn btn-primary px-5 ccdb-button" href="{% url 'ccdb-browse' %}">Search the Database</a>
+                    <div class="row justify-content-center text-center">
+                        <div class="col-md-8">
+                            <a href="https://www.sshrc-crsh.gc.ca" target="_blank">
+                                <img class="img-fluid p-2"
+                                     src="{% static 'footer/sshrc-logo.png' %}"
+                                     alt="Social Sciences and Humanities Research Council Logo"
+                                     title="Social Sciences and Humanities Research Council of Canada" />
+                            </a>
                         </div>
-                        <p id="about-section" class="pt-5">
-                            The goal of the Canadian Chant Database is to catalogue–and eventually inventory–all manuscripts and manuscript fragments containing plainchant derived from the medieval European tradition in libraries, archives, institutions, and private ownership in Canada. Printed chant books are limited to those sources that were published specifically for use in Canada.
-                        </p>
-                    </div>
-                </div>
-                <div id="acknowledgements-section" class="row text-center mt-5">
-                    <p>
-                        Support for the database has been provided by the <a href="https://www.sshrc-crsh.gc.ca/home-accueil-eng.aspx"
-    target="_blank">Social Sciences and Humanities Research Council of Canada</a> and the <a href="https://alliancecan.ca/en" target="_blank">Digital Research Alliance of Canada</a>.
-                    </p>
-                </div>
-                <div class="row justify-content-evenly">
-                    <div class="col-xl-4 col-lg-5">
-                        <a href="https://www.sshrc-crsh.gc.ca" target="_blank">
-                            <img class="img-fluid"
-                                 src="{% static "footer/sshrc-logo.png" %}"
-                                 alt="Social Sciences and Humanities Research Council Logo"
-                                 title="Social Sciences and Humanities Research Council of Canada" />
-                        </a>
-                    </div>
-                    <div class="col-xl-4 col-lg-5">
-                        <a href="https://alliancecan.ca/" target="_blank">
-                            <img class="img-fluid"
-                                 src="{% static "footer/drac-logo.png" %}"
-                                 alt="Digital Research Alliance Logo"
-                                 title="Digital Research Alliance" />
-                        </a>
                     </div>
                 </div>
             </div>
             <div class="col-lg-3">
                 <nav class="ccdb-segment-menu sticky-top pt-4">
                     <ul class="list-unstyled">
+                        <li>
+                            <a href="{% url 'canadian-chant-db-source-list' %}">
+                                <img src="{% static 'ccdb-images/CCDB-favicon_transparentbg.png' %}"
+                                     class="ccdb-nav-home-icon"
+                                     alt="" />Home
+                            </a>
+                        </li>
                         <li><a href="#about-section">About the Database</a></li>
                         <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-chant-search' %}">Chant Search</a></li>
                         <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
                         <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
                         <li><a href="#acknowledgements-section">Acknowledgements</a></li>

--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -23,7 +23,7 @@
             </a>
         </div>
         <div class="row py-5 bg-white bg-opacity-75">
-            <div class="col">
+            <div class="col-lg-9">
                 <div class="d-lg-grid ccdb-landing-grid">
                     <div class="ps-4 ccdb-grid-image">
                         <div class="px-5">
@@ -40,56 +40,14 @@
                     </div>
                     <div class="ccdb-grid-summary px-5 pt-5">
                         <div class="text-white d-block text-center">
-                            <a class="btn btn-primary px-5 ccdb-button" href="#search-container">Search the Database</a>
+                            <a class="btn btn-primary px-5 ccdb-button" href="{% url 'ccdb-browse' %}">Search the Database</a>
                         </div>
-                        <p class="pt-5">
+                        <p id="about-section" class="pt-5">
                             The goal of the Canadian Chant Database is to catalogue–and eventually inventory–all manuscripts and manuscript fragments containing plainchant derived from the medieval European tradition in libraries, archives, institutions, and private ownership in Canada. Printed chant books are limited to those sources that were published specifically for use in Canada.
                         </p>
-                        
-                        <h5 class="mt-4 mb-3">Personnel</h5>
-                        <div class="row">
-                            <div class="col-md-6">
-                                <div class="mb-2">
-                                    <strong>Jennifer Bain</strong>
-                                    <div class="small">DACT Project Director</div>
-                                    <div class="small">Dalhousie University, Halifax</div>
-                                </div>
-                                <div class="mb-2">
-                                    <strong>Debra Lacoste</strong>
-                                    <div class="small">DACT Project Manager</div>
-                                    <div class="small">Dalhousie University, Halifax</div>
-                                </div>
-                                <div class="mb-2">
-                                    <strong>Julie Cumming</strong>
-                                    <div class="small">DACT Manuscripts and Printed Chantbooks - McGill University, Team Lead</div>
-                                    <div class="small">McGill University, Montreal</div>
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <div class="mb-2">
-                                    <strong>D. Linda Pearse</strong>
-                                    <div class="small">DACT Encounters in Kahnawà:ke, Team Lead</div>
-                                </div>
-                                <div class="mb-2">
-                                    <strong>Kate Kennedy Steiner</strong>
-                                    <div class="small">DACT Manuscripts and Fragments - Central & Eastern Canada, Team Lead</div>
-                                    <div class="small">Conrad Grebel University College at the University of Waterloo</div>
-                                </div>
-                                <div class="mb-2">
-                                    <strong>David Watt</strong>
-                                    <div class="small">DACT Manuscripts and Fragments - Western Canada</div>
-                                    <div class="small">University of Manitoba</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="ccdb-grid-map text-center">
-                        <iframe src="https://www.google.com/maps/d/embed?mid=1uTSnFP4RHFd7RSBIIZpJ0_i69hIpypo&ehbc=2E312F"
-                                width="1000"
-                                height="600"></iframe>
                     </div>
                 </div>
-                <div class="row text-center mt-5">
+                <div id="acknowledgements-section" class="row text-center mt-5">
                     <p>
                         Support for the database has been provided by the <a href="https://www.sshrc-crsh.gc.ca/home-accueil-eng.aspx"
     target="_blank">Social Sciences and Humanities Research Council of Canada</a> and the <a href="https://alliancecan.ca/en" target="_blank">Digital Research Alliance of Canada</a>.
@@ -114,215 +72,16 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div id="search-container" class="container-lg">
-            <div class="row rounded my-5 ccdb-table-bg">
-                <div class="col">
-                    <div class="row mt-3 mb-1">
-                        <div class="col">
-                            <h5 class="mb-2">Search Chants</h5>
-                            <form method="get"
-                                  action="{% url 'chant-search' %}"
-                                  class="d-flex flex-wrap gap-2 align-items-end">
-                                <input type="hidden" name="segment" value="4066" />
-                                <div class="flex-grow-1">
-                                    <label for="chantKeyword" class="small form-label">
-                                        Keyword search (incipit, full text, or Cantus ID)
-                                    </label>
-                                    <input type="text"
-                                           class="form-control form-control-sm"
-                                           name="keyword"
-                                           id="chantKeyword"
-                                           placeholder="Enter keyword or Cantus ID" />
-                                </div>
-                                <div>
-                                    <label for="chantSearchOp" class="small form-label">Match</label>
-                                    <select name="op"
-                                            id="chantSearchOp"
-                                            class="form-control form-select form-select-sm">
-                                        <option value="starts_with">Starts with</option>
-                                        <option value="contains">Contains</option>
-                                    </select>
-                                </div>
-                                <button type="submit" class="btn btn-dark btn-sm">Search Chants</button>
-                            </form>
-                        </div>
-                    </div>
-                    <hr class="my-3" />
-                    <form method="get" class="ccdb-filter-form mb-3">
-                        <div class="row mt-2">
-                            <div class="col-lg">
-                                <label for="generalSearch" class="small form-label">
-                                    General search (siglum, city, description…)
-                                </label>
-                                <input type="text"
-                                       class="form-control form-control-sm"
-                                       name="general"
-                                       placeholder="Enter any part of a word"
-                                       value="{{ request.GET.general }}"
-                                       id="generalSearch" />
-                            </div>
-                            <div class="col-lg">
-                                <label for="indexingSearch" class="small form-label">
-                                    Indexing notes and contributors
-                                </label>
-                                <input type="text"
-                                       class="form-control form-control-sm"
-                                       name="indexing"
-                                       placeholder="Enter any part of a word/name"
-                                       value="{{ request.GET.indexing }}"
-                                       id="indexingSearch" />
-                            </div>
-                        </div>
-                        <div class="row align-items-center">
-                            <div class="col-lg-6">
-                                <div class="row">
-                                    <div class="col-lg-6">
-                                        <label for="provenanceFilter" class="small form-label">
-                                            Provenance (origin/history)
-                                        </label>
-                                        <select id="provenanceFilter"
-                                                name="provenance"
-                                                class="form-control form-select form-select-sm">
-                                            <option value="">- Any -</option>
-                                            {% for provenance in provenances %}
-                                                <option value="{{ provenance.id }}">{{ provenance.name }}</option>
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                    <div class="col-lg-6">
-                                        <label for="centuryFilter" class="small form-label">Century</label>
-                                        <select id="centuryFilter"
-                                                name="century"
-                                                class="form-control form-select form-select-sm">
-                                            <option value="">- Any -</option>
-                                            {% for century in centuries %}
-                                                <option value="{{ century.id }}">{{ century.name }}</option>
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                    <div class="col-lg-6">
-                                        <label for="prodMethodFilter" class="small form-label">Manuscript/Print</label>
-                                        <select id="prodMethodFilter"
-                                                name="prodMethod"
-                                                class="form-control form-select form-select-sm">
-                                            <option value="">- Any -</option>
-                                            {% for prod_method_value, prod_method_label in production_method_choices %}
-                                                <option value="{{ prod_method_value }}">{{ prod_method_label }}</option>
-                                            {% endfor %}
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-lg-4">
-                                <label for="sourceCompletenessFilter" class="small form-label">
-                                    Complete Source/Fragment
-                                </label>
-                                <div class="input-group" id="sourceCompletenessFilter">
-                                    {% for source_completeness_value, source_completeness_label in source_completeness_choices %}
-                                        <div class="form-check form-check-inline">
-                                            <input type="checkbox"
-                                                   class="form-check-input"
-                                                   id="sourceCompleteness-{{ source_completeness_value }}"
-                                                   name="sourceCompleteness"
-                                                   value="{{ source_completeness_value }}"
-                                                   checked />
-                                            <label class="form-label form-check-label small"
-                                                   for="sourceCompleteness-{{ source_completeness_value }}">
-                                                {{ source_completeness_label }}
-                                            </label>
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            <div class="col-lg-1">
-                                <button type="submit" class="btn btn-dark btn-sm m-1" id="btn-submit">Apply</button>
-                                <a href="/CanadianChantDB/#search-container"
-                                   class="btn btn-dark btn-sm m-1"
-                                   id="btn-reset">Reset</a>
-                            </div>
-                        </div>
-                    </form>
-                    {% if sources %}
-                        {% include "page_count.html" %}
-                        <table class="table table-sm small table-bordered table-responsive ccdb-table">
-                            <thead>
-                                <tr>
-                                    {% sortable_header request "city_institution" "City + Holding Institution" %}
-                                    {% sortable_header request "source" "Cantus Siglum" %}
-                                    <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
-                                    <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
-                                    <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
-                                    <th scope="col" class="text-wrap" style="text-align:center">
-                                        Chants
-                                        <br />
-                                        /&nbsp;Melodies
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for source in sources %}
-                                    <tr>
-                                        <td class="text-wrap" style="text-align:center">
-                                            {% if source.holding_institution %}
-                                                <a href="{% url 'institution-detail' source.holding_institution.id %}"
-                                                   target="_blank">
-                                                    <b>
-                                                        {% if source.holding_institution.city %}
-                                                            {{ source.holding_institution.city }},
-                                                        {% endif %}
-                                                        {{ source.holding_institution.name }}
-                                                    </b>
-                                                </a>
-                                            {% endif %}
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <a href="{% url 'source-detail' source.id %}" target="_blank">
-                                                <b>{{ source.short_heading|truncatechars_html:100 }}</b>
-                                            </a>
-                                            {% if source.source_completeness == 2 %}
-                                                <br class="m-1" />
-                                                <span class="small">Fragment</span>
-                                            {% endif %}
-                                        </td>
-                                        <td class="text-wrap"
-                                            style="text-align:center"
-                                            title="{{ source.summary|default:""|safe|truncatechars_html:500 }}">
-                                            {% if source.name %}
-                                                <b>"{{ source.name|safe }}"</b>
-                                                <br />
-                                            {% endif %}
-                                            {{ source.summary|default:""|safe|truncatechars_html:120 }}
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            {% if source.century %}
-                                                {% join_absolute_url_links source.century.all 'name' '/' True %}
-                                                <br />
-                                            {% endif %}
-                                            {% if source.provenance %}
-                                                <a href="{% url 'provenance-detail' source.provenance.id %}"
-                                                   target="_blank">{{ source.provenance.name }}</a>
-                                            {% endif %}
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            {% if source.image_link %}
-                                                <a href="{{ source.image_link }}" target="_blank">Images</a>
-                                            {% endif %}
-                                        </td>
-                                        <td class="text-wrap" style="text-align:center">
-                                            <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                            {% if source.number_of_melodies and source.id !=  680970 %}
-                                                <br />
-                                                / {{ source.number_of_melodies }}
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    {% endif %}
-                </div>
+            <div class="col-lg-3">
+                <nav class="ccdb-segment-menu sticky-top pt-4">
+                    <ul class="list-unstyled">
+                        <li><a href="#about-section">About the Database</a></li>
+                        <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
+                        <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
+                        <li><a href="#acknowledgements-section">Acknowledgements</a></li>
+                    </ul>
+                </nav>
             </div>
         </div>
     </div>

--- a/django/cantusdb_project/main_app/templates/source_lists/ccdb_browse.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/ccdb_browse.html
@@ -1,0 +1,242 @@
+{% extends "base.html" %}
+{% load helper_tags %}
+{% load static %}
+{% block title %}<title>Browse Sources – Canadian Chant Database</title>{% endblock %}
+{% block favicon %}<link rel="icon" href="{% static "ccdb-images/CCDB-favicon.png" %}" />{% endblock %}
+{% block scripts %}
+    <script src="{% static 'js/source_list.js' %}"></script>
+    <link href="{% static 'css/ccdb_style.css' %}" rel="stylesheet" media="screen" />
+{% endblock %}
+{% block header %}
+    {% include "header/sticky_header.html" %}
+{% endblock %}
+{% block heading %}{% endblock %}
+{% block content %}
+    <div class="container-fluid ccdb-info">
+        {% include "ccdb_subpage_header.html" %}
+        <div class="row py-4 bg-white bg-opacity-75">
+            <div class="col-lg-9">
+                <div id="search-container" class="container-lg">
+                    <div class="row rounded my-3 ccdb-table-bg">
+                        <div class="col">
+                            <div class="row mt-3 mb-1">
+                                <div class="col">
+                                    <h5 class="mb-2">Search Chants</h5>
+                                    <form method="get"
+                                          action="{% url 'chant-search' %}"
+                                          class="d-flex flex-wrap gap-2 align-items-end">
+                                        <input type="hidden" name="segment" value="4066" />
+                                        <div class="flex-grow-1">
+                                            <label for="chantKeyword" class="small form-label">
+                                                Keyword search (incipit, full text, or Cantus ID)
+                                            </label>
+                                            <input type="text"
+                                                   class="form-control form-control-sm"
+                                                   name="keyword"
+                                                   id="chantKeyword"
+                                                   placeholder="Enter keyword or Cantus ID" />
+                                        </div>
+                                        <div>
+                                            <label for="chantSearchOp" class="small form-label">Match</label>
+                                            <select name="op"
+                                                    id="chantSearchOp"
+                                                    class="form-control form-select form-select-sm">
+                                                <option value="starts_with">Starts with</option>
+                                                <option value="contains">Contains</option>
+                                            </select>
+                                        </div>
+                                        <button type="submit" class="btn btn-dark btn-sm">Search Chants</button>
+                                    </form>
+                                </div>
+                            </div>
+                            <hr class="my-3" />
+                            <form method="get" class="ccdb-filter-form mb-3">
+                                <div class="row mt-2">
+                                    <div class="col-lg">
+                                        <label for="generalSearch" class="small form-label">
+                                            General search (siglum, city, description…)
+                                        </label>
+                                        <input type="text"
+                                               class="form-control form-control-sm"
+                                               name="general"
+                                               placeholder="Enter any part of a word"
+                                               value="{{ request.GET.general }}"
+                                               id="generalSearch" />
+                                    </div>
+                                    <div class="col-lg">
+                                        <label for="indexingSearch" class="small form-label">
+                                            Indexing notes and contributors
+                                        </label>
+                                        <input type="text"
+                                               class="form-control form-control-sm"
+                                               name="indexing"
+                                               placeholder="Enter any part of a word/name"
+                                               value="{{ request.GET.indexing }}"
+                                               id="indexingSearch" />
+                                    </div>
+                                </div>
+                                <div class="row align-items-center">
+                                    <div class="col-lg-6">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <label for="provenanceFilter" class="small form-label">
+                                                    Provenance (origin/history)
+                                                </label>
+                                                <select id="provenanceFilter"
+                                                        name="provenance"
+                                                        class="form-control form-select form-select-sm">
+                                                    <option value="">- Any -</option>
+                                                    {% for provenance in provenances %}
+                                                        <option value="{{ provenance.id }}">{{ provenance.name }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <label for="centuryFilter" class="small form-label">Century</label>
+                                                <select id="centuryFilter"
+                                                        name="century"
+                                                        class="form-control form-select form-select-sm">
+                                                    <option value="">- Any -</option>
+                                                    {% for century in centuries %}
+                                                        <option value="{{ century.id }}">{{ century.name }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <label for="prodMethodFilter" class="small form-label">Manuscript/Print</label>
+                                                <select id="prodMethodFilter"
+                                                        name="prodMethod"
+                                                        class="form-control form-select form-select-sm">
+                                                    <option value="">- Any -</option>
+                                                    {% for prod_method_value, prod_method_label in production_method_choices %}
+                                                        <option value="{{ prod_method_value }}">{{ prod_method_label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <label for="sourceCompletenessFilter" class="small form-label">
+                                            Complete Source/Fragment
+                                        </label>
+                                        <div class="input-group" id="sourceCompletenessFilter">
+                                            {% for source_completeness_value, source_completeness_label in source_completeness_choices %}
+                                                <div class="form-check form-check-inline">
+                                                    <input type="checkbox"
+                                                           class="form-check-input"
+                                                           id="sourceCompleteness-{{ source_completeness_value }}"
+                                                           name="sourceCompleteness"
+                                                           value="{{ source_completeness_value }}"
+                                                           checked />
+                                                    <label class="form-label form-check-label small"
+                                                           for="sourceCompleteness-{{ source_completeness_value }}">
+                                                        {{ source_completeness_label }}
+                                                    </label>
+                                                </div>
+                                            {% endfor %}
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-1">
+                                        <button type="submit" class="btn btn-dark btn-sm m-1" id="btn-submit">Apply</button>
+                                        <a href="{% url 'ccdb-browse' %}"
+                                           class="btn btn-dark btn-sm m-1"
+                                           id="btn-reset">Reset</a>
+                                    </div>
+                                </div>
+                            </form>
+                            {% if sources %}
+                                {% include "page_count.html" %}
+                                <table class="table table-sm small table-bordered table-responsive ccdb-table">
+                                    <thead>
+                                        <tr>
+                                            {% sortable_header request "city_institution" "City + Holding Institution" %}
+                                            {% sortable_header request "source" "Cantus Siglum" %}
+                                            <th scope="col" class="text-wrap" style="text-align:center">Summary</th>
+                                            <th scope="col" class="text-wrap" style="text-align:center">Date/Origin</th>
+                                            <th scope="col" class="text-wrap" style="text-align:center">Image Link</th>
+                                            <th scope="col" class="text-wrap" style="text-align:center">
+                                                Chants
+                                                <br />
+                                                /&nbsp;Melodies
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for source in sources %}
+                                            <tr>
+                                                <td class="text-wrap" style="text-align:center">
+                                                    {% if source.holding_institution %}
+                                                        <a href="{% url 'institution-detail' source.holding_institution.id %}"
+                                                           target="_blank">
+                                                            <b>
+                                                                {% if source.holding_institution.city %}
+                                                                    {{ source.holding_institution.city }},
+                                                                {% endif %}
+                                                                {{ source.holding_institution.name }}
+                                                            </b>
+                                                        </a>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-wrap" style="text-align:center">
+                                                    <a href="{% url 'source-detail' source.id %}" target="_blank">
+                                                        <b>{{ source.short_heading|truncatechars_html:100 }}</b>
+                                                    </a>
+                                                    {% if source.source_completeness == 2 %}
+                                                        <br class="m-1" />
+                                                        <span class="small">Fragment</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-wrap"
+                                                    style="text-align:center"
+                                                    title="{{ source.summary|default:""|safe|truncatechars_html:500 }}">
+                                                    {% if source.name %}
+                                                        <b>"{{ source.name|safe }}"</b>
+                                                        <br />
+                                                    {% endif %}
+                                                    {{ source.summary|default:""|safe|truncatechars_html:120 }}
+                                                </td>
+                                                <td class="text-wrap" style="text-align:center">
+                                                    {% if source.century %}
+                                                        {% join_absolute_url_links source.century.all 'name' '/' True %}
+                                                        <br />
+                                                    {% endif %}
+                                                    {% if source.provenance %}
+                                                        <a href="{% url 'provenance-detail' source.provenance.id %}"
+                                                           target="_blank">{{ source.provenance.name }}</a>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-wrap" style="text-align:center">
+                                                    {% if source.image_link %}
+                                                        <a href="{{ source.image_link }}" target="_blank">Images</a>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-wrap" style="text-align:center">
+                                                    <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
+                                                    {% if source.number_of_melodies and source.id != 680970 %}
+                                                        <br />
+                                                        / {{ source.number_of_melodies }}
+                                                    {% endif %}
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-3">
+                <nav class="ccdb-segment-menu sticky-top pt-4">
+                    <ul class="list-unstyled">
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
+                        <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
+                        <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
+                        <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/django/cantusdb_project/main_app/templates/source_lists/ccdb_browse.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/ccdb_browse.html
@@ -229,8 +229,16 @@
             <div class="col-lg-3">
                 <nav class="ccdb-segment-menu sticky-top pt-4">
                     <ul class="list-unstyled">
+                        <li>
+                            <a href="{% url 'canadian-chant-db-source-list' %}">
+                                <img src="{% static 'ccdb-images/CCDB-favicon_transparentbg.png' %}"
+                                     class="ccdb-nav-home-icon"
+                                     alt="" />Home
+                            </a>
+                        </li>
                         <li><a href="{% url 'canadian-chant-db-source-list' %}#about-section">About the Database</a></li>
                         <li><a href="{% url 'ccdb-browse' %}">Browse the Sources</a></li>
+                        <li><a href="{% url 'ccdb-chant-search' %}">Chant Search</a></li>
                         <li><a href="{% url 'ccdb-map' %}">Map of Sources</a></li>
                         <li><a href="{% url 'ccdb-team' %}">Project Team</a></li>
                         <li><a href="{% url 'canadian-chant-db-source-list' %}#acknowledgements-section">Acknowledgements</a></li>

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -87,7 +87,9 @@ from main_app.views.source import (
     SourceDeleteView,
     SourceInventoryView,
     SourceAddImageLinksView,
+    CcdbBrowseView,
 )
+from main_app.views.ccdb import CcdbTeamView, CcdbMapView
 from main_app.views.user import (
     CustomLogoutView,
     IndexerListView,
@@ -310,6 +312,22 @@ urlpatterns = [
         SourceListView.as_view(),
         name="canadian-chant-db-source-list",
         kwargs={"segment_id": 4066},
+    ),
+    path(
+        "CanadianChantDB/browse/",
+        CcdbBrowseView.as_view(),
+        name="ccdb-browse",
+        kwargs={"segment_id": 4066},
+    ),
+    path(
+        "CanadianChantDB/team/",
+        CcdbTeamView.as_view(),
+        name="ccdb-team",
+    ),
+    path(
+        "CanadianChantDB/map/",
+        CcdbMapView.as_view(),
+        name="ccdb-map",
     ),
     path(
         "Cantorales/",

--- a/django/cantusdb_project/main_app/urls.py
+++ b/django/cantusdb_project/main_app/urls.py
@@ -89,7 +89,7 @@ from main_app.views.source import (
     SourceAddImageLinksView,
     CcdbBrowseView,
 )
-from main_app.views.ccdb import CcdbTeamView, CcdbMapView
+from main_app.views.ccdb import CcdbChantSearchView, CcdbLandingView, CcdbMapView, CcdbTeamView
 from main_app.views.user import (
     CustomLogoutView,
     IndexerListView,
@@ -309,7 +309,7 @@ urlpatterns = [
     ),
     path(
         "CanadianChantDB/",
-        SourceListView.as_view(),
+        CcdbLandingView.as_view(),
         name="canadian-chant-db-source-list",
         kwargs={"segment_id": 4066},
     ),
@@ -328,6 +328,11 @@ urlpatterns = [
         "CanadianChantDB/map/",
         CcdbMapView.as_view(),
         name="ccdb-map",
+    ),
+    path(
+        "CanadianChantDB/chant-search/",
+        CcdbChantSearchView.as_view(),
+        name="ccdb-chant-search",
     ),
     path(
         "Cantorales/",

--- a/django/cantusdb_project/main_app/views/ccdb.py
+++ b/django/cantusdb_project/main_app/views/ccdb.py
@@ -1,0 +1,13 @@
+from django.views.generic import TemplateView
+
+
+class CcdbTeamView(TemplateView):
+    """Project Team page for the Canadian Chant Database."""
+
+    template_name = "ccdb_team.html"
+
+
+class CcdbMapView(TemplateView):
+    """Map of Sources page for the Canadian Chant Database."""
+
+    template_name = "ccdb_map.html"

--- a/django/cantusdb_project/main_app/views/ccdb.py
+++ b/django/cantusdb_project/main_app/views/ccdb.py
@@ -1,13 +1,135 @@
+from typing import Any
+
+from django.db.models import Q, QuerySet
 from django.views.generic import TemplateView
 
+from main_app.views.chant import ChantSearchView
+from main_app.views.source import SourceListView
 
-class CcdbTeamView(TemplateView):
+
+class CcdbMixin:
+    """
+    Adds ccdb_site=True to template context for all CCDB views.
+    This allows the shared navbar to swap the Chant Search link to the
+    CCDB-specific chant search page when browsing the Canadian Chant Database.
+    """
+
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)  # type: ignore[misc]
+        context["ccdb_site"] = True
+        return context
+
+
+class CcdbLandingView(CcdbMixin, SourceListView):
+    """Landing page for the Canadian Chant Database."""
+
+    pass
+
+
+class CcdbTeamView(CcdbMixin, TemplateView):
     """Project Team page for the Canadian Chant Database."""
 
     template_name = "ccdb_team.html"
 
 
-class CcdbMapView(TemplateView):
+class CcdbMapView(CcdbMixin, TemplateView):
     """Map of Sources page for the Canadian Chant Database."""
 
     template_name = "ccdb_map.html"
+
+
+AVAILABLE_SEGMENTS = [
+    (4066, "Canadian Chant Database"),
+    (4063, "Cantus Database"),
+    (4064, "Sequence Database"),
+    (4067, "Cantorales in the Americas and Beyond"),
+]
+
+_DEFAULT_SEGMENT_ID = 4066
+
+
+class CcdbChantSearchView(CcdbMixin, ChantSearchView):
+    """
+    Chant search page scoped to the Canadian Chant Database (segment 4066) by default.
+    Users may expand the search to additional database segments via the 'db' GET param.
+    Because ChantSearchView unions Chant and Sequence querysets before returning — and
+    Django forbids filtering a unioned queryset — multi-segment support works by calling
+    the parent's get_queryset() once per selected segment and unioning the results.
+    """
+
+    template_name = "ccdb_chant_search.html"
+
+    def _get_selected_segment_ids(self) -> list[int]:
+        """Return the segment IDs selected via 'db' GET params. Defaults to [4066]."""
+        raw = self.request.GET.getlist("db")
+        ids = [int(v) for v in raw if str(v).isdigit()]
+        return ids if ids else [_DEFAULT_SEGMENT_ID]
+
+    def get_queryset(self) -> QuerySet:
+        # If no search params, return empty queryset immediately (same as parent behaviour)
+        if not self.request.GET:
+            from main_app.models import Chant
+
+            return Chant.objects.none()
+
+        # Compute segment IDs before any GET manipulation so they survive the copy
+        self._segment_ids = self._get_selected_segment_ids()
+
+        # Make GET mutable
+        self.request.GET = self.request.GET.copy()
+
+        # Fast path: single segment — inject and delegate directly to parent
+        if len(self._segment_ids) == 1:
+            self.request.GET["segment"] = str(self._segment_ids[0])
+            return super().get_queryset()
+
+        # Multi-segment: call the parent once per segment, then union the results.
+        # We cannot filter after .union(), so this is the only correct approach.
+        base_get = self.request.GET.copy()
+        base_get.pop("segment", None)
+
+        querysets = []
+        for seg_id in self._segment_ids:
+            self.request.GET = base_get.copy()
+            self.request.GET["segment"] = str(seg_id)
+            querysets.append(super().get_queryset())
+
+        # Restore GET (minus segment) so get_context_data reads clean params
+        self.request.GET = base_get
+
+        combined = querysets[0]
+        for qs in querysets[1:]:
+            combined = combined.union(qs, all=True)
+        return combined
+
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)
+        from main_app.models import Source
+
+        # Use segment IDs cached by get_queryset; fall back to default on initial load
+        segment_ids = getattr(self, "_segment_ids", [_DEFAULT_SEGMENT_ID])
+        keyword = self.request.GET.get("keyword", "").strip()
+
+        if keyword:
+            source_qs = (
+                Source.objects.filter(segment_m2m__id__in=segment_ids)
+                .filter(
+                    Q(shelfmark__unaccent__icontains=keyword)
+                    | Q(holding_institution__siglum__unaccent__icontains=keyword)
+                    | Q(description__unaccent__icontains=keyword)
+                    | Q(summary__unaccent__icontains=keyword)
+                    | Q(holding_institution__name__unaccent__icontains=keyword)
+                    | Q(holding_institution__city__unaccent__icontains=keyword)
+                    | Q(name__unaccent__icontains=keyword)
+                )
+                .distinct()
+                .order_by("holding_institution__siglum", "shelfmark")
+            )
+        else:
+            source_qs = Source.objects.none()
+
+        context["ccdb_sources"] = source_qs
+        context["ccdb_source_count"] = source_qs.count()
+        context["selected_dbs"] = [str(i) for i in segment_ids]
+        context["available_segments"] = AVAILABLE_SEGMENTS
+        return context

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -520,6 +520,13 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
         )
 
 
+class CcdbBrowseView(SourceListView):
+    """Browse/search view for the Canadian Chant Database sources page."""
+
+    def get_template_names(self) -> list[str]:
+        return ["source_lists/ccdb_browse.html"]
+
+
 class SourceCreateView(UserPassesTestMixin, CreateView):  # type: ignore[type-arg]
     model = Source
     template_name = "source_create.html"

--- a/django/cantusdb_project/static/css/ccdb_style.css
+++ b/django/cantusdb_project/static/css/ccdb_style.css
@@ -22,6 +22,17 @@ body {
     position: relative;
 }
 
+.ccdb-banner-credit {
+    position: absolute;
+    bottom: 0.4rem;
+    left: 0.6rem;
+    font-size: 0.65rem;
+    color: rgba(255, 255, 255, 0.8);
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+    z-index: 5;
+    pointer-events: none;
+}
+
 .ccdb-hero-banner a {
     display: block;
     width: 75%;
@@ -95,6 +106,31 @@ main a {
     filter: brightness(0) invert(1);
 }
 
+.ccdb-search-input:focus {
+    border-color: #cc3333;
+    box-shadow: 0 0 0 0.2rem rgba(204, 51, 51, 0.25);
+}
+
+.ccdb-supporters {
+    border-top: 2px solid #cc3333;
+    border-bottom: 2px solid #cc3333;
+    padding: 1rem 0;
+}
+
+.ccdb-supporters .ccdb-small-logo {
+    max-height: 60px;
+    width: auto;
+}
+
+.ccdb-nav-home-icon {
+    height: 1em;
+    width: auto;
+    vertical-align: middle;
+    margin-right: 2px;
+    position: relative;
+    top: -1px;
+}
+
 .ccdb-segment-menu {
     border-left: 3px solid #cc3333;
     padding-left: 1rem;
@@ -125,6 +161,34 @@ form.ccdb-filter-form select {
     background-color: var(--bs-gray-100);
 }
 
+/* Databases multi-select dropdown — styled to match form-select-sm siblings */
+.ccdb-db-dropdown-btn {
+    background-color: var(--bs-gray-100);
+    border: 1px solid #dee2e6;
+    border-radius: 0.25rem;
+    padding: 0.25rem 2.25rem 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    width: 100%;
+    text-align: left;
+    /* Reuse the same dropdown arrow as Bootstrap's form-select */
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.75rem center;
+    background-size: 16px 12px;
+    cursor: pointer;
+}
+
+.ccdb-db-dropdown-btn:focus {
+    border-color: #cc3333;
+    box-shadow: 0 0 0 0.2rem rgba(204, 51, 51, 0.25);
+    outline: none;
+}
+
+.ccdb-db-dropdown-btn.show {
+    border-color: #cc3333;
+}
+
 table.ccdb-table th,
 table.ccdb-table td {
     background-color: var(--bs-gray-100);
@@ -136,4 +200,30 @@ table.ccdb-table a {
     &:hover {
         color: #992626;
     }
+}
+
+.ccdb-tabs .nav-link {
+    color: #cc3333;
+    border-color: transparent;
+}
+
+.ccdb-tabs .nav-link:hover:not(.active) {
+    color: #992626;
+    border-color: #dee2e6 #dee2e6 transparent;
+}
+
+.ccdb-tabs .nav-link.active {
+    color: white;
+    background-color: #cc3333;
+    border-color: #cc3333;
+}
+
+.ccdb-tabs .nav-link .badge {
+    background-color: rgba(255, 255, 255, 0.3);
+    color: inherit;
+    font-size: 0.75em;
+}
+
+.ccdb-tabs .nav-link.active .badge {
+    background-color: rgba(255, 255, 255, 0.35);
 }

--- a/django/cantusdb_project/static/css/ccdb_style.css
+++ b/django/cantusdb_project/static/css/ccdb_style.css
@@ -81,6 +81,41 @@ main a {
     background-color: #cc3333eb;
 }
 
+.ccdb-subpage-header {
+    background-color: #cc3333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.25rem;
+}
+
+.ccdb-subpage-logo {
+    max-height: 50px;
+    width: auto;
+    filter: brightness(0) invert(1);
+}
+
+.ccdb-segment-menu {
+    border-left: 3px solid #cc3333;
+    padding-left: 1rem;
+    top: 80px;
+}
+
+.ccdb-segment-menu ul li {
+    margin-bottom: 0.75rem;
+}
+
+.ccdb-segment-menu a {
+    color: #cc3333;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.ccdb-segment-menu a:hover {
+    color: #992626;
+    text-decoration: underline;
+}
+
 .ccdb-table-bg {
     background-color: var(--bs-gray-400)
 }

--- a/django/cantusdb_project/templates/header/navbar_links.html
+++ b/django/cantusdb_project/templates/header/navbar_links.html
@@ -74,7 +74,7 @@
            aria-haspopup="true"
            aria-expanded="false">CHANTS</a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownLinkChants">
-            <a class="dropdown-item" href="{% url 'chant-search' %}">Chant Search</a>
+            <a class="dropdown-item" href="{% if ccdb_site %}{% url 'ccdb-chant-search' %}{% else %}{% url 'chant-search' %}{% endif %}">Chant Search</a>
             <a class="dropdown-item" href="{% url 'melody-search' %}">Search by melody</a>
             <a class="dropdown-item" href="{% url 'sequence-list' %}">Clavis Sequentiarum (Sequence Database by Calvin
             Bower)</a>

--- a/docker-compose-dev-containers.yml
+++ b/docker-compose-dev-containers.yml
@@ -20,7 +20,8 @@ services:
       - 3000:3000 # this mapping allows the VSCode Dev Containers extension to work
     restart: always
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     working_dir: /code/cantusdb_project/django/cantusdb_project
     command: [ "python", "manage.py", "runserver_plus", "0:8000" ]
 
@@ -52,6 +53,11 @@ services:
       - 5432:5432
     restart: always
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cantusdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   redis:
     build:


### PR DESCRIPTION
Introduces a dedicated chant search page for the Canadian Chant Database
(/CanadianChantDB/chant-search/) that scopes results to segment 4066 by
default while allowing users to expand their search to other Cantus
segments (Cantus DB, Sequence DB, Cantorales) via a checkbox dropdown.

Key additions and changes:

- New CcdbChantSearchView (ccdb.py): extends ChantSearchView with
  segment-scoped queryset logic; handles multi-segment searches by
  calling the parent's get_queryset() once per segment and unioning
  results (required because Django forbids .filter() after .union())

- New ccdb_chant_search.html: full CCDB-styled chant search page with
  tabbed results — 'Chants (N)' and 'Sources (N)' — allowing users to
  switch between result types without leaving the page; source tab runs
  a parallel keyword search across 7 source fields; empty source tab
  includes a tip that sources return from keyword searches

- Databases dropdown filter: Bootstrap checkbox dropdown letting users
  include additional segments in their search; defaults to CCDB only;
  button label reflects the number of selected databases

- Navbar Chant Search link now conditionally points to the CCDB chant
  search page when browsing CCDB pages (via ccdb_site context flag)

- Landing page search bar now submits keywords to ccdb-chant-search
  instead of the source browse page

- Home link with favicon icon added to the segment sidebar nav on all
  CCDB sub-pages

- Photo credit 'Salzinnes Antiphonal' overlaid on the hero banner

- CcdbMixin and CcdbLandingView wired into urls.py so that ccdb_site=True
  context flows to all CCDB pages including the landing page