### PR TITLE
fix: disallow /chants/ and /sources/ in robots.txt

### DIFF
--- a/nginx/robots.txt
+++ b/nginx/robots.txt
@@ -5,6 +5,8 @@ Disallow: /chant-search/
 Disallow: /searchms/
 Disallow: /ci-search/
 Disallow: /melody/
+Disallow: /chants/
+Disallow: /sources/
 
 Disallow: /ajax/
 Disallow: /json-sources/


### PR DESCRIPTION
Googlebot was hammering `/chants/` and `/sources/` — the two highest-traffic
endpoints — because they were not listed in `robots.txt`. `/chants/` without a
`source` query parameter was also throwing `BadRequest` errors on every hit.

Added `Disallow: /chants/` and `Disallow: /sources/` to `robots.txt`.
