### PR TITLE
style: apply black formatting and consolidate duplicate imports

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/import_cantorales.py
+++ b/django/cantusdb_project/main_app/management/commands/import_cantorales.py
@@ -58,11 +58,11 @@ COL_SOURCE_OF_DATA = 27
 
 # Condition → Source.source_completeness
 CONDITION_MAP = {
-    "1": Source.SourceCompletenessChoices.FULL_SOURCE,      # complete
-    "2": Source.SourceCompletenessChoices.FRAGMENTED,       # partial
-    "3": Source.SourceCompletenessChoices.FRAGMENT,         # fragment
-    "4": Source.SourceCompletenessChoices.FRAGMENT,         # binding waste
-    "5": Source.SourceCompletenessChoices.UNKNOWN,          # unknown
+    "1": Source.SourceCompletenessChoices.FULL_SOURCE,  # complete
+    "2": Source.SourceCompletenessChoices.FRAGMENTED,  # partial
+    "3": Source.SourceCompletenessChoices.FRAGMENT,  # fragment
+    "4": Source.SourceCompletenessChoices.FRAGMENT,  # binding waste
+    "5": Source.SourceCompletenessChoices.UNKNOWN,  # unknown
 }
 
 MATERIAL_MAP = {
@@ -367,7 +367,9 @@ class Command(BaseCommand):
         sole_email = {}
         with open(csv_path, newline="", encoding="utf-8-sig") as f:
             reader = csv.reader(f)
-            next(reader); next(reader); next(reader)  # header, REQUIRED, SAMPLE
+            next(reader)
+            next(reader)
+            next(reader)  # header, REQUIRED, SAMPLE
             for row in reader:
                 while len(row) < 33:
                     row.append("")

--- a/django/cantusdb_project/main_app/tests/test_import_cantorales.py
+++ b/django/cantusdb_project/main_app/tests/test_import_cantorales.py
@@ -8,7 +8,11 @@ from django.test import TestCase
 
 from main_app.management.commands.import_cantorales import parse_centuries
 from main_app.models import Source
-from main_app.tests.make_fakes import make_fake_century, make_fake_institution, make_fake_segment
+from main_app.tests.make_fakes import (
+    make_fake_century,
+    make_fake_institution,
+    make_fake_segment,
+)
 
 
 class TestParseCenturies(TestCase):
@@ -22,7 +26,9 @@ class TestParseCenturies(TestCase):
         self.assertEqual(parse_centuries("16, 17"), ["16th century", "17th century"])
 
     def test_dash_range(self):
-        self.assertEqual(parse_centuries("15-17"), ["15th century", "16th century", "17th century"])
+        self.assertEqual(
+            parse_centuries("15-17"), ["15th century", "16th century", "17th century"]
+        )
 
     def test_slash_separated(self):
         self.assertEqual(parse_centuries("16/17"), ["16th century", "17th century"])
@@ -36,23 +42,85 @@ class TestParseCenturies(TestCase):
 
 # Minimal valid CSV content (header + REQUIRED + SAMPLE + 1 data row)
 # Columns are 0-indexed; see COL_* constants in import_cantorales.py
-def _make_csv(rism="US-NYcu", shelfmark="Ms. 1", contributor="Jane Doe",
-              email="jane@example.com"):
-    header = ",".join(["col0", "RISM", "Shelfmark", "City", "Archive",
-                        "Condition", "Leaves", "Material", "SourceType",
-                        "ChantType", "Century", "Date", "Staves", "StaffLines",
-                        "Colophon", "Origins", "Owners", "TextScript",
-                        "Notation", "Binding", "Notes", "Images", "ArchiveLink",
-                        "CantusDBLink", "Contributor", "Email", "DateEntered",
-                        "SourceOfData", "", "", "", "", ""])
+def _make_csv(
+    rism="US-NYcu", shelfmark="Ms. 1", contributor="Jane Doe", email="jane@example.com"
+):
+    header = ",".join(
+        [
+            "col0",
+            "RISM",
+            "Shelfmark",
+            "City",
+            "Archive",
+            "Condition",
+            "Leaves",
+            "Material",
+            "SourceType",
+            "ChantType",
+            "Century",
+            "Date",
+            "Staves",
+            "StaffLines",
+            "Colophon",
+            "Origins",
+            "Owners",
+            "TextScript",
+            "Notation",
+            "Binding",
+            "Notes",
+            "Images",
+            "ArchiveLink",
+            "CantusDBLink",
+            "Contributor",
+            "Email",
+            "DateEntered",
+            "SourceOfData",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
     required = header  # same shape
     sample = header
-    data = ",".join(["", rism, shelfmark, "New York", "Columbia University",
-                      "1", "200", "2", "1", "2", "16", "1600", "5", "4",
-                      "1", "Franciscan", "", "", "", "", "",
-                      "http://example.com/img", "http://example.com/archive",
-                      "", contributor, email, "2024-01-01", "Database",
-                      "", "", "", "", ""])
+    data = ",".join(
+        [
+            "",
+            rism,
+            shelfmark,
+            "New York",
+            "Columbia University",
+            "1",
+            "200",
+            "2",
+            "1",
+            "2",
+            "16",
+            "1600",
+            "5",
+            "4",
+            "1",
+            "Franciscan",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "http://example.com/img",
+            "http://example.com/archive",
+            "",
+            contributor,
+            email,
+            "2024-01-01",
+            "Database",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
     return "\n".join([header, required, sample, data])
 
 
@@ -78,8 +146,10 @@ class TestImportCantoralesCommand(TestCase):
         self.assertEqual(Source.objects.filter(shelfmark="Ms. 1").count(), 1)
         source = Source.objects.get(shelfmark="Ms. 1")
         self.assertTrue(source.published)
-        self.assertIn("Cantorales in the Americas",
-                      source.segment_m2m.values_list("name", flat=True))
+        self.assertIn(
+            "Cantorales in the Americas",
+            source.segment_m2m.values_list("name", flat=True),
+        )
 
     def test_idempotent(self):
         """Running the command twice should not create duplicate sources."""

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -4,9 +4,8 @@ from typing import Any, Optional, Union
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.db.models import Q, Prefetch, Value
+from django.db.models import Q, Prefetch, QuerySet, Value
 from django.db.models.functions import Coalesce
-from django.db.models import QuerySet
 from django.http import (
     HttpResponseRedirect,
     Http404,
@@ -25,6 +24,7 @@ from django.views.generic import (
     FormView,
 )
 from django.views.generic.detail import SingleObjectMixin
+
 from main_app.forms import (
     SourceCreateForm,
     SourceEditForm,
@@ -45,7 +45,6 @@ from main_app.models import (
 )
 from main_app.permissions import CustomAccessMixin
 from main_app.mixins import JSONResponseMixin
-
 from main_app.views.chant import get_feast_selector_options
 from main_app.tasks import save_browse_chants_formset
 


### PR DESCRIPTION
## Summary

Pure formatting changes, no functional modifications:

- **`import_cantorales.py`**: align comment spacing consistently; split three semicolon-chained `next()` calls onto separate lines
- **`test_import_cantorales.py`**: reformat long lines and argument lists to black style
- **`source.py`**: consolidate two `from django.db.models import` lines into one; fix blank lines around third-party/local import groups

This PR is a prerequisite for DDMAL/CantusDB#2001 (CCDB redesign), split out per reviewer request to keep style and functional changes separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)