### PR TITLE
fix: re-enable volpiano display for MS 73 (source 680970) in templates

### DIFF
--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -154,8 +154,8 @@
                                 <p>
                                     {{ chant.manuscript_full_text_std_spelling|default:"" }}
                                     <br />
-                                    <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                    {% if chant.volpiano and chant.source.id != 680970 %}
+                                    <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                    {% if chant.volpiano %}
                                         <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
                                     {% endif %}
                                 </p>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -242,8 +242,8 @@
                 {{ chant.manuscript_full_text }}
             </dd>
         {% endif %}
-        <!-- See #1635. Temporarily disable volpiano display for this source. -->
-        {% if chant.volpiano and chant.source.id != 680970 %}
+        <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+        {% if chant.volpiano %}
             <dt>Volpiano</dt>
             <dd>
                 <p class="font-volpiano-lg">{{ chant.volpiano }}</p>
@@ -255,8 +255,8 @@
                 {{ chant.indexing_notes }}
             </dd>
         {% endif %}
-        <!-- See #1635. Temporarily disable volpiano display for this source. -->
-        {% if chant.volpiano and chant.source.id != 680970 %}
+        <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+        {% if chant.volpiano %}
             <div class="row">
                 <div class="col">
                     <dt>Melody with text</dt>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -159,8 +159,7 @@
             </thead>
             <tbody>
                 {% for chant in chants %}
-                    <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                    {% if chant.source.id != 680970 or melodies != "true" %}
+                    <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
                         <tr>
                             {% if not source %}
                                 <td class="text-wrap" style="text-align:left">
@@ -218,8 +217,8 @@
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                {% if chant.volpiano and chant.source.id !=  680970 %}
+                                <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                {% if chant.volpiano %}
                                     <span title="Chant record has Volpiano melody">♫</span>
                                 {% endif %}
                             </td>
@@ -229,7 +228,6 @@
                                 {% endif %}
                             </td>
                         </tr>
-                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>

--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -311,8 +311,8 @@
                                         </td>
                                         <td class="text-wrap" style="text-align:center">
                                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                            {% if source.number_of_melodies and source.id !=  680970 %}
+                                            <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                            {% if source.number_of_melodies %}
                                                 <br />
                                                 / {{ source.number_of_melodies }}
                                             {% endif %}

--- a/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
@@ -287,8 +287,8 @@
                                         </td>
                                         <td class="text-wrap" style="text-align:center">
                                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                            {% if source.number_of_melodies and source.id !=  680970 %}
+                                            <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                            {% if source.number_of_melodies %}
                                                 <br />
                                                 / {{ source.number_of_melodies }}
                                             {% endif %}

--- a/django/cantusdb_project/main_app/templates/source_lists/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/source_list.html
@@ -191,8 +191,8 @@
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                            {% if source.number_of_melodies and source.id !=  680970 %}
+                            <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                            {% if source.number_of_melodies %}
                                 <br />
                                 / {{ source.number_of_melodies }}
                             {% endif %}


### PR DESCRIPTION
## Summary

- Re-enables volpiano melody display for source 680970 (MS 73) across all affected templates
- Display was temporarily disabled in #1635; this resolves #1893
- Each changed location retains a comment referencing both issues for traceability

## Files changed

- `browse_chants.html` — volpiano notation in chant rows
- `chant_detail.html` — volpiano notation field and "Melody with text" section (2 spots)
- `chant_search.html` — row-suppression wrapper removed; volpiano indicator restored
- `source_lists/source_list.html`, `cantorales.html`, `canadian_chant_db.html` — melody count display

## Test plan

- [ ] Browse chants for MS 73 (source 680970) while logged out — confirm volpiano notation renders
- [ ] Open a chant detail page for a chant in MS 73 with volpiano — confirm notation and "Melody with text" both appear
- [ ] Source list page — confirm melody count shows for MS 73
- [ ] Run `python manage.py test main_app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)