### PR TITLE
fix: re-enable MS 73 (source 680970) volpiano display in templates and melody search

### DIFF
--- a/django/cantusdb_project/main_app/templates/browse_chants.html
+++ b/django/cantusdb_project/main_app/templates/browse_chants.html
@@ -154,8 +154,8 @@
                                 <p>
                                     {{ chant.manuscript_full_text_std_spelling|default:"" }}
                                     <br />
-                                    <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                    {% if chant.volpiano and chant.source.id != 680970 %}
+                                    <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                    {% if chant.volpiano %}
                                         <span style="font-family: volpiano; font-size:25px">{{ chant.volpiano|default:"" }}</span>
                                     {% endif %}
                                 </p>

--- a/django/cantusdb_project/main_app/templates/chant_detail.html
+++ b/django/cantusdb_project/main_app/templates/chant_detail.html
@@ -242,8 +242,8 @@
                 {{ chant.manuscript_full_text }}
             </dd>
         {% endif %}
-        <!-- See #1635. Temporarily disable volpiano display for this source. -->
-        {% if chant.volpiano and chant.source.id != 680970 %}
+        <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+        {% if chant.volpiano %}
             <dt>Volpiano</dt>
             <dd>
                 <p class="font-volpiano-lg">{{ chant.volpiano }}</p>
@@ -255,8 +255,8 @@
                 {{ chant.indexing_notes }}
             </dd>
         {% endif %}
-        <!-- See #1635. Temporarily disable volpiano display for this source. -->
-        {% if chant.volpiano and chant.source.id != 680970 %}
+        <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+        {% if chant.volpiano %}
             <div class="row">
                 <div class="col">
                     <dt>Melody with text</dt>

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -159,8 +159,7 @@
             </thead>
             <tbody>
                 {% for chant in chants %}
-                    <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                    {% if chant.source.id != 680970 or melodies != "true" %}
+                    <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
                         <tr>
                             {% if not source %}
                                 <td class="text-wrap" style="text-align:left">
@@ -218,8 +217,8 @@
                                 {% endif %}
                             </td>
                             <td class="text-wrap" style="text-align:center">
-                                <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                {% if chant.volpiano and chant.source.id !=  680970 %}
+                                <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                {% if chant.volpiano %}
                                     <span title="Chant record has Volpiano melody">♫</span>
                                 {% endif %}
                             </td>
@@ -229,7 +228,6 @@
                                 {% endif %}
                             </td>
                         </tr>
-                    {% endif %}
                 {% endfor %}
             </tbody>
         </table>

--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -311,8 +311,8 @@
                                         </td>
                                         <td class="text-wrap" style="text-align:center">
                                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                            {% if source.number_of_melodies and source.id !=  680970 %}
+                                            <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                            {% if source.number_of_melodies %}
                                                 <br />
                                                 / {{ source.number_of_melodies }}
                                             {% endif %}

--- a/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/cantorales.html
@@ -287,8 +287,8 @@
                                         </td>
                                         <td class="text-wrap" style="text-align:center">
                                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                                            {% if source.number_of_melodies and source.id !=  680970 %}
+                                            <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                                            {% if source.number_of_melodies %}
                                                 <br />
                                                 / {{ source.number_of_melodies }}
                                             {% endif %}

--- a/django/cantusdb_project/main_app/templates/source_lists/source_list.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/source_list.html
@@ -191,8 +191,8 @@
                         </td>
                         <td class="text-wrap" style="text-align:center">
                             <b>{{ source.number_of_chants|default_if_none:"0" }}</b>
-                            <!-- See #1635. Temporarily disable volpiano display for this source. -->
-                            {% if source.number_of_melodies and source.id !=  680970 %}
+                            <!-- Volpiano display for source 680970 (MS 73) was temporarily disabled in #1635; re-enabled in #1893. -->
+                            {% if source.number_of_melodies %}
                                 <br />
                                 / {{ source.number_of_melodies }}
                             {% endif %}

--- a/django/cantusdb_project/main_app/views/api.py
+++ b/django/cantusdb_project/main_app/views/api.py
@@ -271,21 +271,17 @@ def ajax_melody_search(
         chants = chants.filter(feast__name__icontains=feast_name)
     if mode:
         chants = chants.filter(mode__icontains=mode)
-    # See #1635 re the following source exclusion. Temporarily disable volpiano display for this source.
-    result_values = (
-        chants.exclude(source__id=680970)
-        .order_by("id")
-        .values(
-            "id",
-            "source__holding_institution__siglum",
-            "source__shelfmark",
-            "folio",
-            "incipit",
-            "genre__name",
-            "feast__name",
-            "mode",
-            "volpiano",
-        )
+    # Source 680970 (MS 73) was excluded from melody search in #1635; re-enabled in #1893.
+    result_values = chants.order_by("id").values(
+        "id",
+        "source__holding_institution__siglum",
+        "source__shelfmark",
+        "folio",
+        "incipit",
+        "genre__name",
+        "feast__name",
+        "mode",
+        "volpiano",
     )
     # convert queryset to a list of dicts because QuerySet is not JSON serializable
     # the above constructed queryset will be evaluated here

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -501,9 +501,6 @@ class ChantSearchView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
         if search_position:
             search_parameters.append(f"position={search_position}")
         search_melodies: Optional[str] = self.request.GET.get("melodies")
-        # This was added to context so that we could implement #1635 and can be
-        # removed once that is undone.
-        context["melodies"] = search_melodies
         if search_melodies:
             search_parameters.append(f"melodies={search_melodies}")
         search_bar: Optional[str] = self.request.GET.get("search_bar")
@@ -809,12 +806,7 @@ class ChantSearchMSView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
         # If the "apply" button hasn't been clicked, return empty queryset
         if not self.request.GET:
             return Chant.objects.none()
-        # See #1635 re the following source exclusion. Temporarily disable volpiano display for this source.
-        if (
-            self.request.GET.get("melodies") == "true"
-            and self.kwargs["source_pk"] == 680970
-        ):
-            return Chant.objects.none()
+        # Source 680970 (MS 73) melody search was blocked in #1635; re-enabled in #1893.
 
         # Create a Q object to filter the QuerySet of Chants
         q_obj_filter = Q()


### PR DESCRIPTION
Closes #1893

Re-enables source 680970 (MS 73) which was temporarily disabled in #1635.

This PR combines the fixes from both #2017 and #2018 (per reviewer request):

**Backend (views):**
- Removed `.exclude(source__id=680970)` from the `ajax_melody_search` queryset in `api.py`
- Removed the early-return block in `ChantSearchMSView.get_queryset` that was skipping melody search for source 680970
- Removed the `context["melodies"]` assignment in `ChantSearchView.get_context_data` that was added only to support a template guard

**Frontend (templates):**
- Removed all `chant.source.id != 680970` conditional checks from template `{% if %}` statements in `browse_chants.html`, `chant_detail.html`, and `chant_search.html`
- Removed the row-suppression wrapper in `chant_search.html`
- Restored melody count display in `source_list.html`, `cantorales.html`, and `canadian_chant_db.html`