### PR TITLE
docs: add CLAUDE.md and ignore personal Claude Code config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ api_cache/
 
 .python-version
 runtests.sh
+
+# Personal Claude Code files
+CLAUDE.local.md
+.claude*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Cantus Database
+
+Django app for the Cantus Database — a digital catalogue of medieval Latin chant manuscripts. Built and maintained by DDMAL at McGill.
+
+## Stack
+
+Django + Postgres + Redis/Celery, managed with Poetry. `django-reversion` tracks model history; `volpiano-display-utilities` is a custom DDMAL dependency installed from git. See `pyproject.toml` for versions.
+
+## Local development
+
+Docker Compose is the only supported local setup — bare `manage.py runserver` is not used.
+
+```bash
+docker compose up
+```
+
+## Tests
+
+Tests run inside the dev `django` container. Make sure the dev stack is up (`docker compose up -d`), then:
+
+```bash
+docker compose exec -T django python manage.py test main_app.tests
+```
+
+Run a single module or class to keep the loop tight:
+
+```bash
+docker compose exec -T django python manage.py test main_app.tests.test_functions
+```
+
+Uses Django's built-in test runner, **not pytest**. Exec'ing into the existing dev container is faster than spinning up a clean-room run.
+
+## Verifying changes
+
+Beyond running tests:
+
+- `docker compose exec -T django python manage.py check` — fast sanity check after settings, model, or URL changes.
+- `docker compose exec -T django python manage.py makemigrations --dry-run` — confirms whether a migration is needed after model changes.
+- UI/template changes can't be verified from the terminal — say so explicitly rather than claiming success.
+
+## Lint, format, types
+
+**No pre-commit hook is configured** — run `black`, `mypy`, `pylint`, and `djlint` yourself before pushing.
+
+## Branches and PRs
+
+Three long-lived branches: `production`, `staging`, and `develop`. PR against `develop`.
+
+Branch names: `feat/<topic>` or `fix/<topic>`.
+
+Commit messages: Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`).
+
+## Architecture
+
+- `users/` defines a custom `Group` and `GroupMembership` — **distinct from `django.contrib.auth.Group`, which is unregistered.** Don't confuse the two.
+- `RevisionMiddleware` from `django-reversion` is active, so most model writes are tracked automatically.
+
+## User permissions
+
+Five access tiers, enforced via `main_app/permissions.py` (`CustomAccessMixin`, `get_sources_visible_to_user`):
+
+- **Anonymous** — sees only `published=True` sources.
+- **Logged-in user (no group)** — published sources plus any sources they're explicitly assigned to via `Source.current_editors`. Can edit those assigned sources.
+- **`editor` group** — broad edit privileges across the site.
+- **`global viewer` group** — can see *all* sources, published or not.
+- **Superuser** — bypasses every permission check.
+
+Group memberships have **expiration dates** (`GroupMembership.expiration`); `user_group_valid()` treats an expired membership as no membership.
+
+Old groups `contributor` and `project manager` are deprecated. Only `editor` and `global viewer` are active. Some documentation refers to a "Debra" — this means superuser, after Debra Lacoste, the project manager. There is no `Debra` role in code.
+
+## Migrations
+
+- Migrations auto-run on container build.
+- Data migrations using `RunPython` should define `reverse_code` where applicable.
+
+## Project quirks
+
+- **Single `published` field controls visibility.** OldCantus had separate `published` and `visible`; that was intentionally collapsed. `published=True` → everyone sees it; `published=False` → only logged-in users. Do not reintroduce a `visible` field.
+- **CSV/JSON exports diverge from OldCantus.** Some endpoints (`/json-node`, `/json-activity`) behave differently or aren't implemented. Verify the OldCantus shape before claiming parity — README has the diff.
+
+## More context
+
+- Project wiki (API docs, history): <https://github.com/DDMAL/CantusDB/wiki>
+- Deployment / infrastructure (Ansible playbooks): <https://github.com/DDMAL/ansible.cantus-db>
+- `README.md` covers the OldCantus → CantusDB transition and known test-data quirks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,43 +2,29 @@
 
 Django app for the Cantus Database — a digital catalogue of medieval Latin chant manuscripts. Built and maintained by DDMAL at McGill.
 
-## Stack
+## Development workflow
 
-Django + Postgres + Redis/Celery, managed with Poetry. `volpiano-display-utilities` is a custom DDMAL dependency installed from git, not PyPI. See `pyproject.toml` for versions.
+`volpiano-display-utilities` is a custom DDMAL dependency installed from git, not PyPI.
 
-## Local development
-
-Docker Compose is the only supported local setup — bare `manage.py runserver` is not used. First-time setup (env file, compose file layout, Dev Containers option) is in the wiki.
+Docker Compose is the only supported local setup — bare `manage.py runserver` is not used. With the dev stack up (`docker compose up -d`), run from the host. Prefer `exec` into the running container over `run`:
 
 ```bash
-docker compose up
-```
-
-## Tests
-
-Tests run inside the dev `django` container. Make sure the dev stack is up (`docker compose up -d`), then:
-
-```bash
+# Tests (Django's built-in runner, not pytest)
 docker compose exec -T django python manage.py test main_app.tests
-```
 
-Run a single module or class to keep the loop tight:
-
-```bash
+# Single module/class to keep the loop tight
 docker compose exec -T django python manage.py test main_app.tests.test_functions
+
+# Fast sanity check after settings, model, or URL changes
+docker compose exec -T django python manage.py check
+
+# Confirm a migration is needed after model changes
+docker compose exec -T django python manage.py makemigrations --dry-run
 ```
 
-Uses Django's built-in test runner, **not pytest**. Exec'ing into the existing dev container is faster than spinning up a clean-room run.
+**Migrations do not auto-run.** Apply them manually: `docker compose exec -T django python manage.py migrate`. Data migrations using `RunPython` should define `reverse_code` where applicable.
 
-## Verifying changes
-
-Beyond running tests:
-
-- `docker compose exec -T django python manage.py check` — fast sanity check after settings, model, or URL changes.
-- `docker compose exec -T django python manage.py makemigrations --dry-run` — confirms whether a migration is needed after model changes.
-- UI/template changes can't be verified from the terminal — say so explicitly rather than claiming success.
-
-## Lint, format, types
+UI/template changes can't be verified from the terminal — say so explicitly rather than claiming success.
 
 **No pre-commit hook is configured** — run `black`, `mypy`, `pylint`, and `djlint` yourself before pushing.
 
@@ -52,16 +38,15 @@ Commit messages: Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `c
 
 **Keep PRs small and focused.** Sprawling diffs are hard to review and slow the project down.
 
-- One concern per PR. If you spot an unrelated bug, smell, or cleanup, surface it — don't bundle it in.
 - Watch for scope creep. If you find yourself refactoring surrounding code, touching many files, or pulling in unplanned schema/migration work, pause and warn the user before continuing.
 - New dependencies need explicit sign-off — don't add them silently.
 
-## Architecture
+## Architecture and permissions
+
+**Models, migrations, and `main_app/permissions.py` are the highest-risk areas.** Use plan mode and confirm the approach before editing.
 
 - `users/` defines a custom `Group` and `GroupMembership` — **distinct from `django.contrib.auth.Group`, which is unregistered.** Don't confuse the two.
 - `RevisionMiddleware` from `django-reversion` is active, so most model writes are tracked automatically.
-
-## User permissions
 
 Five access tiers, enforced via `main_app/permissions.py` (`CustomAccessMixin`, `get_sources_visible_to_user`):
 
@@ -73,20 +58,17 @@ Five access tiers, enforced via `main_app/permissions.py` (`CustomAccessMixin`, 
 
 Group memberships have **expiration dates** (`GroupMembership.expiration`); `user_group_valid()` treats an expired membership as no membership.
 
-Old groups `contributor` and `project manager` are deprecated. Only `editor` and `global viewer` are active. Some documentation refers to a "Debra" — this means superuser, after Debra Lacoste, the project manager. There is no `Debra` role in code.
+Old groups `contributor` and `project manager` are deprecated. Only `editor` and `global viewer` are active.
 
-## Migrations
+## Gotchas
 
-- Migrations do **not** auto-run. Apply them manually: `docker compose exec -T django python manage.py migrate`.
-- Data migrations using `RunPython` should define `reverse_code` where applicable.
-
-## Project quirks
-
-- **Single `published` field controls visibility.** OldCantus had separate `published` and `visible`; that was intentionally collapsed. Do not reintroduce a `visible` field. See *User permissions* for what `published` actually gates — it's not a simple "anonymous vs. logged-in" split.
+- **Single `published` field controls visibility.** OldCantus had separate `published` and `visible`; that was intentionally collapsed. Do not reintroduce a `visible` field. See *Architecture and permissions* for what `published` actually gates — it's not a simple "anonymous vs. logged-in" split.
 - **CSV/JSON exports diverge from OldCantus.** Some endpoints (`/json-node`, `/json-activity`) behave differently or aren't implemented. Verify the OldCantus shape before claiming parity — README has the diff.
 
-## More context
+## References
 
-- Project wiki (API docs, history, local-dev setup): <https://github.com/DDMAL/CantusDB/wiki>
+The wiki is often the fastest source for API shape, OldCantus → CantusDB diffs, and historical decisions — check it before assuming code is the only source of truth. It can lag behind the codebase, so verify against current code before acting on anything load-bearing.
+
+- Wiki: <https://github.com/DDMAL/CantusDB/wiki>
 - Deployment / infrastructure (Ansible playbooks): <https://github.com/DDMAL/ansible.cantus-db>
 - `README.md` covers the OldCantus → CantusDB transition and known test-data quirks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ Django app for the Cantus Database — a digital catalogue of medieval Latin cha
 
 ## Stack
 
-Django + Postgres + Redis/Celery, managed with Poetry. `django-reversion` tracks model history; `volpiano-display-utilities` is a custom DDMAL dependency installed from git. See `pyproject.toml` for versions.
+Django + Postgres + Redis/Celery, managed with Poetry. `volpiano-display-utilities` is a custom DDMAL dependency installed from git, not PyPI. See `pyproject.toml` for versions.
 
 ## Local development
 
-Docker Compose is the only supported local setup — bare `manage.py runserver` is not used.
+Docker Compose is the only supported local setup — bare `manage.py runserver` is not used. First-time setup (env file, compose file layout, Dev Containers option) is in the wiki.
 
 ```bash
 docker compose up
@@ -50,6 +50,12 @@ Branch names: `feat/<topic>` or `fix/<topic>`.
 
 Commit messages: Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`).
 
+**Keep PRs small and focused.** Sprawling diffs are hard to review and slow the project down.
+
+- One concern per PR. If you spot an unrelated bug, smell, or cleanup, surface it — don't bundle it in.
+- Watch for scope creep. If you find yourself refactoring surrounding code, touching many files, or pulling in unplanned schema/migration work, pause and warn the user before continuing.
+- New dependencies need explicit sign-off — don't add them silently.
+
 ## Architecture
 
 - `users/` defines a custom `Group` and `GroupMembership` — **distinct from `django.contrib.auth.Group`, which is unregistered.** Don't confuse the two.
@@ -71,16 +77,16 @@ Old groups `contributor` and `project manager` are deprecated. Only `editor` and
 
 ## Migrations
 
-- Migrations auto-run on container build.
+- Migrations do **not** auto-run. Apply them manually: `docker compose exec -T django python manage.py migrate`.
 - Data migrations using `RunPython` should define `reverse_code` where applicable.
 
 ## Project quirks
 
-- **Single `published` field controls visibility.** OldCantus had separate `published` and `visible`; that was intentionally collapsed. `published=True` → everyone sees it; `published=False` → only logged-in users. Do not reintroduce a `visible` field.
+- **Single `published` field controls visibility.** OldCantus had separate `published` and `visible`; that was intentionally collapsed. Do not reintroduce a `visible` field. See *User permissions* for what `published` actually gates — it's not a simple "anonymous vs. logged-in" split.
 - **CSV/JSON exports diverge from OldCantus.** Some endpoints (`/json-node`, `/json-activity`) behave differently or aren't implemented. Verify the OldCantus shape before claiming parity — README has the diff.
 
 ## More context
 
-- Project wiki (API docs, history): <https://github.com/DDMAL/CantusDB/wiki>
+- Project wiki (API docs, history, local-dev setup): <https://github.com/DDMAL/CantusDB/wiki>
 - Deployment / infrastructure (Ansible playbooks): <https://github.com/DDMAL/ansible.cantus-db>
 - `README.md` covers the OldCantus → CantusDB transition and known test-data quirks.


### PR DESCRIPTION
I would appreciate everyone's input on this file. I've tried to follow the [Claude Code best practices guide](https://code.claude.com/docs/en/best-practices) as much as possible, but please let me know if there's inaccurate, missing, or unnecessary information, or if certain points are better suited for the personal `CLAUDE.local.md`. 

### Summary

- Adds `CLAUDE.md` at the repo root with team-shared context for Claude Code
- Adds `CLAUDE.local.md` and `.claude*` to `.gitignore` so each developer can keep personal Claude Code preferences
- Content is scoped to things Claude can't reliably infer by reading the code itself (e.g., commands, gotchas, conventions, etc.)

Closes #2029.
