### PR TITLE
feat: extend source general search to cover all metadata fields

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import get_user_model
 
-from main_app.models import Source, Chant, Differentia
+from main_app.models import Source, Chant, Differentia, SourceIdentifier
 from main_app.tests.make_fakes import (
     make_fake_source,
     make_fake_segment,
@@ -1326,6 +1326,39 @@ class SourceListViewTest(CustomAccessTestMixin, TestCase):
             reverse("source-list"), {"general": f'"{source.name}"'}
         )
         self.assertIn(source, response.context["sources"])
+
+    def test_search_by_provenance_and_trailing_punctuation(self) -> None:
+        provenance = make_fake_provenance()
+        provenance.name = "Kremsmünster"
+        provenance.save()
+        source = make_fake_source(
+            provenance=provenance,
+            published=True,
+            shelfmark="title",
+        )
+
+        for term in ["Kremsmünster", "Kremsmünster,"]:
+            with self.subTest(term=term):
+                response = self.client.get(reverse("source-list"), {"general": term})
+                self.assertIn(source, response.context["sources"])
+
+    def test_search_by_identifier_with_colon_and_trailing_punctuation(self) -> None:
+        source = make_fake_source(
+            published=True,
+            shelfmark="title",
+            dact_id="D:06e4d",
+            fragmentarium_id="F:01a2b",
+        )
+        SourceIdentifier.objects.create(
+            source=source,
+            identifier="ID:123",
+            type=SourceIdentifier.OTHER,
+        )
+
+        for term in ["D:06e4d", "D:06e4d,", "F:01a2b", "ID:123", "ID:123,"]:
+            with self.subTest(term=term):
+                response = self.client.get(reverse("source-list"), {"general": term})
+                self.assertIn(source, response.context["sources"])
 
     def test_ordering(self) -> None:
         """

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -402,11 +402,6 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
             holding_institution_city_q = Q()
             description_q = Q()
             name_q = Q()
-            # it seems that old cantus don't look into title and provenance
-            # for the general search terms
-            # cantus.uwaterloo.ca/source/123901 this source cannot be found by searching
-            # its provenance 'Kremsmünster' in the general search field
-            # provenance_q = Q()
             summary_q = Q()
             provenance_q = Q()
             fragmentarium_id_q = Q()

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -384,15 +384,15 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
             q_obj_filter &= Q(production_method=production_method)
 
         if general_str := self.request.GET.get("general"):
-            # Strip spaces at the beginning and end
-            general_str = general_str.strip()
+            # Strip leading/trailing spaces and collapse internal whitespace
+            general_str = " ".join(general_str.split())
 
             # Use regex to extract quoted and unquoted terms
             quoted_terms = re.findall(
                 r'"(.*?)"', general_str
             )  # Extract terms in quotes
             unquoted_terms = re.findall(
-                r"\b[\w,-.]+\b", re.sub(r'"(.*?)"', "", general_str)
+                r"\b[\w,-.:]+", re.sub(r'"(.*?)"', "", general_str)
             )
 
             # We need a Q Object for each field we're gonna look into
@@ -408,6 +408,10 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
             # its provenance 'Kremsmünster' in the general search field
             # provenance_q = Q()
             summary_q = Q()
+            provenance_q = Q()
+            fragmentarium_id_q = Q()
+            dact_id_q = Q()
+            identifiers_q = Q()
 
             # Add unquoted terms to the Q object with partial matching (icontains)
             for term in unquoted_terms:
@@ -422,6 +426,10 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 description_q |= Q(description__unaccent__icontains=term)
                 summary_q |= Q(summary__unaccent__icontains=term)
                 name_q |= Q(name__unaccent__icontains=term)
+                provenance_q |= Q(provenance__name__unaccent__icontains=term)
+                fragmentarium_id_q |= Q(fragmentarium_id__icontains=term)
+                dact_id_q |= Q(dact_id__icontains=term)
+                identifiers_q |= Q(identifiers__identifier__unaccent__icontains=term)
 
             # Add quoted terms to the Q object with exact matching (iexact)
             for term in quoted_terms:
@@ -436,6 +444,10 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 description_q |= Q(description__unaccent__icontains=term)
                 summary_q |= Q(summary__unaccent__icontains=term)
                 name_q |= Q(name__unaccent__icontains=term)
+                provenance_q |= Q(provenance__name__unaccent__icontains=term)
+                fragmentarium_id_q |= Q(fragmentarium_id__icontains=term)
+                dact_id_q |= Q(dact_id__icontains=term)
+                identifiers_q |= Q(identifiers__identifier__unaccent__icontains=term)
 
             # Combine all Q objects with OR
             general_search_q = (
@@ -446,6 +458,10 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 | holding_institution_q
                 | holding_institution_city_q
                 | name_q
+                | provenance_q
+                | fragmentarium_id_q
+                | dact_id_q
+                | identifiers_q
             )
 
             # Apply the general search Q object to the filter

--- a/django/cantusdb_project/main_app/views/source.py
+++ b/django/cantusdb_project/main_app/views/source.py
@@ -392,7 +392,7 @@ class SourceListView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 r'"(.*?)"', general_str
             )  # Extract terms in quotes
             unquoted_terms = re.findall(
-                r"\b[\w,-.:]+", re.sub(r'"(.*?)"', "", general_str)
+                r"\b[\w,-.:]+\b", re.sub(r'"(.*?)"', "", general_str)
             )
 
             # We need a Q Object for each field we're gonna look into


### PR DESCRIPTION
- Add `fragmentarium_id` and `dact_id` fields to general search Q objects
- Add `identifiers__identifier` lookup to cover all `SourceIdentifier` types (olim/former shelfmarks, alternative names, etc.)
- Add `provenance__name` to general search, which was omitted in the old Cantus
- Collapse internal whitespace (as mentioned by Ich in the April 25th meeting)
- Include colon in unquoted term Regex so IDs are kept as a single token instead of being splitted by `:`


resolves #2014, resolves #1979, resolves #1988, resolves #1695