### PR TITLE
Feat/copy kaiatonsera chants to master

### DIFF
--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -1,3 +1,4 @@
+import argparse
 import re
 
 from django.core.management.base import BaseCommand, CommandError
@@ -8,47 +9,26 @@ import reversion  # type: ignore[import-untyped]
 from main_app.models import Chant, Source
 
 MASTER_SOURCE_ID = 1000289
-FOLIO_RE = re.compile(r"^K\d{3,4}[A-Za-z]?$")
+FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
 
 
 class Command(BaseCommand):
     help = "Copy ~710 chants from student-work sources into the Kaiatonsera master source (issue #2038)."
 
-    def add_arguments(self, parser) -> None:
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--dry-run",
             action="store_true",
             help="Print per-group counts and sanity checks without writing any data.",
         )
-        proofread_group = parser.add_mutually_exclusive_group()
-        proofread_group.add_argument(
-            "--reset-proofread-flags",
-            action="store_true",
-            help="Reset all four proofread booleans to False on every copy.",
-        )
-        proofread_group.add_argument(
-            "--keep-proofread-flags",
-            action="store_true",
-            help="Copy proofread booleans verbatim from the originals.",
-        )
 
     def handle(self, *args, **options) -> None:
         dry_run: bool = options["dry_run"]
-        reset_proofread: bool = options["reset_proofread_flags"]
-
-        # Proofread-flag behavior is unresolved (see issue #2038 — pending Debra).
-        # Block the live run until the caller makes an explicit choice.
-        if not dry_run and not reset_proofread and not options["keep_proofread_flags"]:
-            raise CommandError(
-                "Live run requires an explicit proofread-flag decision.\n"
-                "Pass --reset-proofread-flags or --keep-proofread-flags.\n"
-                "Confirm with Debra before running live (issue #2038)."
-            )
 
         try:
             master_source = Source.objects.get(id=MASTER_SOURCE_ID)
-        except Source.DoesNotExist:
-            raise CommandError(f"Master source {MASTER_SOURCE_ID} not found.")
+        except Source.DoesNotExist as e:
+            raise CommandError(f"Master source {MASTER_SOURCE_ID} not found.") from e
 
         groups = [
             (
@@ -58,7 +38,6 @@ class Command(BaseCommand):
                     folio__gte="K005",
                     folio__lt="K029",
                 ).order_by("folio", "c_sequence"),
-                200,
             ),
             (
                 "Group 2: source 1000208, K039–K053 (~155)",
@@ -67,7 +46,6 @@ class Command(BaseCommand):
                     folio__gte="K039",
                     folio__lt="K054",
                 ).order_by("folio", "c_sequence"),
-                155,
             ),
             (
                 "Group 3: source 1000260, K053(seq≥5)–K067 (~140)",
@@ -77,7 +55,6 @@ class Command(BaseCommand):
                     | Q(folio__gt="K053", folio__lt="K068")
                 )
                 .order_by("folio", "c_sequence"),
-                140,
             ),
             (
                 "Group 4: source 1000260, K082–K090 (~80)",
@@ -86,7 +63,6 @@ class Command(BaseCommand):
                     folio__gte="K082",
                     folio__lt="K091",
                 ).order_by("folio", "c_sequence"),
-                80,
             ),
             (
                 "Group 5: source 1000208, K090(seq≥7)–K108 (~135)",
@@ -96,20 +72,22 @@ class Command(BaseCommand):
                     | Q(folio__gt="K090", folio__lt="K109")
                 )
                 .order_by("folio", "c_sequence"),
-                135,
             ),
         ]
 
         before_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        # master_source.siglum is None as of writing, matching the 19 existing
+        # master-source chants — copying it through preserves that consistency.
         self.stdout.write(
             self.style.NOTICE(
-                f"Master source {MASTER_SOURCE_ID} | siglum: {master_source.siglum}"
+                f"Master source {MASTER_SOURCE_ID} | siglum: {master_source.siglum!r}"
                 f" | current chant count: {before_count}"
             )
         )
 
         total_to_copy = 0
-        for label, qs, estimate in groups:
+        total_bad_folios = 0
+        for label, qs in groups:
             count = qs.count()
             total_to_copy += count
             first = qs.first()
@@ -119,8 +97,9 @@ class Command(BaseCommand):
                 for c in qs.iterator(chunk_size=500)
                 if c.folio and not FOLIO_RE.match(c.folio)
             ]
+            total_bad_folios += len(bad_folios)
             self.stdout.write(f"\n{label}")
-            self.stdout.write(f"  Count: {count} (estimate ~{estimate})")
+            self.stdout.write(f"  Count: {count}")
             if first:
                 self.stdout.write(
                     f"  First: folio={first.folio!r}, c_sequence={first.c_sequence}"
@@ -144,29 +123,32 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("\nDry run complete. No data written."))
             return
 
-        created_ids: list[int] = []
+        if total_bad_folios:
+            raise CommandError(
+                f"Refusing to copy: {total_bad_folios} folio(s) do not match "
+                f"{FOLIO_RE.pattern}. Re-run with --dry-run to inspect the offenders, "
+                "then fix the source data or adjust the filter."
+            )
+
         with transaction.atomic(), reversion.create_revision():
             reversion.set_comment("copy_chants_to_master_source: issue #2038")
-            for label, qs, _ in groups:
+            for label, qs in groups:
                 group_count = 0
                 for chant in qs.iterator(chunk_size=500):
+                    proofread_by_pks = list(
+                        chant.proofread_by.values_list("pk", flat=True)
+                    )
                     chant.pk = None
                     chant.source = master_source
                     chant.siglum = master_source.siglum
                     chant.folio = chant.folio[1:] if chant.folio else chant.folio
+                    # OneToOne to self with a uniqueness constraint; cleared so
+                    # populate_next_chant_fields can rebuild the chain on the master.
                     chant.next_chant = None
-                    if reset_proofread:
-                        chant.manuscript_full_text_std_proofread = False
-                        chant.manuscript_full_text_proofread = False
-                        chant.volpiano_proofread = False
-                        chant.other_fields_proofread = False
                     chant.save()
-                    created_ids.append(chant.pk)
+                    if proofread_by_pks:
+                        chant.proofread_by.set(proofread_by_pks)
                     group_count += 1
-                    if group_count % 100 == 0:
-                        self.stdout.write(
-                            self.style.NOTICE(f"  {label}: {group_count} saved...")
-                        )
                 self.stdout.write(
                     self.style.SUCCESS(f"  {label}: done ({group_count} chants)")
                 )
@@ -177,7 +159,4 @@ class Command(BaseCommand):
                 f"\nDone. Master source chant count: {before_count} → {after_count}"
                 f" (+{after_count - before_count})"
             )
-        )
-        self.stdout.write(
-            f"Created IDs ({len(created_ids)} total): {created_ids}"
         )

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -1,0 +1,183 @@
+import re
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Q
+import reversion  # type: ignore[import-untyped]
+
+from main_app.models import Chant, Source
+
+MASTER_SOURCE_ID = 1000289
+FOLIO_RE = re.compile(r"^K\d{3,4}[A-Za-z]?$")
+
+
+class Command(BaseCommand):
+    help = "Copy ~710 chants from student-work sources into the Kaiatonsera master source (issue #2038)."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print per-group counts and sanity checks without writing any data.",
+        )
+        proofread_group = parser.add_mutually_exclusive_group()
+        proofread_group.add_argument(
+            "--reset-proofread-flags",
+            action="store_true",
+            help="Reset all four proofread booleans to False on every copy.",
+        )
+        proofread_group.add_argument(
+            "--keep-proofread-flags",
+            action="store_true",
+            help="Copy proofread booleans verbatim from the originals.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        dry_run: bool = options["dry_run"]
+        reset_proofread: bool = options["reset_proofread_flags"]
+
+        # Proofread-flag behavior is unresolved (see issue #2038 — pending Debra).
+        # Block the live run until the caller makes an explicit choice.
+        if not dry_run and not reset_proofread and not options["keep_proofread_flags"]:
+            raise CommandError(
+                "Live run requires an explicit proofread-flag decision.\n"
+                "Pass --reset-proofread-flags or --keep-proofread-flags.\n"
+                "Confirm with Debra before running live (issue #2038)."
+            )
+
+        try:
+            master_source = Source.objects.get(id=MASTER_SOURCE_ID)
+        except Source.DoesNotExist:
+            raise CommandError(f"Master source {MASTER_SOURCE_ID} not found.")
+
+        groups = [
+            (
+                "Group 1: source 1000260, K005–K028 (~200)",
+                Chant.objects.filter(
+                    source_id=1000260,
+                    folio__gte="K005",
+                    folio__lt="K029",
+                ).order_by("folio", "c_sequence"),
+                200,
+            ),
+            (
+                "Group 2: source 1000208, K039–K053 (~155)",
+                Chant.objects.filter(
+                    source_id=1000208,
+                    folio__gte="K039",
+                    folio__lt="K054",
+                ).order_by("folio", "c_sequence"),
+                155,
+            ),
+            (
+                "Group 3: source 1000260, K053(seq≥5)–K067 (~140)",
+                Chant.objects.filter(source_id=1000260)
+                .filter(
+                    Q(folio="K053", c_sequence__gte=5)
+                    | Q(folio__gt="K053", folio__lt="K068")
+                )
+                .order_by("folio", "c_sequence"),
+                140,
+            ),
+            (
+                "Group 4: source 1000260, K082–K090 (~80)",
+                Chant.objects.filter(
+                    source_id=1000260,
+                    folio__gte="K082",
+                    folio__lt="K091",
+                ).order_by("folio", "c_sequence"),
+                80,
+            ),
+            (
+                "Group 5: source 1000208, K090(seq≥7)–K108 (~135)",
+                Chant.objects.filter(source_id=1000208)
+                .filter(
+                    Q(folio="K090", c_sequence__gte=7)
+                    | Q(folio__gt="K090", folio__lt="K109")
+                )
+                .order_by("folio", "c_sequence"),
+                135,
+            ),
+        ]
+
+        before_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        self.stdout.write(
+            self.style.NOTICE(
+                f"Master source {MASTER_SOURCE_ID} | siglum: {master_source.siglum}"
+                f" | current chant count: {before_count}"
+            )
+        )
+
+        total_to_copy = 0
+        for label, qs, estimate in groups:
+            count = qs.count()
+            total_to_copy += count
+            first = qs.first()
+            last = qs.last()
+            bad_folios = [
+                c.folio
+                for c in qs.iterator(chunk_size=500)
+                if c.folio and not FOLIO_RE.match(c.folio)
+            ]
+            self.stdout.write(f"\n{label}")
+            self.stdout.write(f"  Count: {count} (estimate ~{estimate})")
+            if first:
+                self.stdout.write(
+                    f"  First: folio={first.folio!r}, c_sequence={first.c_sequence}"
+                )
+            if last:
+                self.stdout.write(
+                    f"  Last:  folio={last.folio!r}, c_sequence={last.c_sequence}"
+                )
+            if bad_folios:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  WARNING: {len(bad_folios)} folio(s) fail regex: {bad_folios[:20]}"
+                    )
+                )
+            else:
+                self.stdout.write("  Folio format: OK")
+
+        self.stdout.write(f"\nTotal to copy: {total_to_copy}")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS("\nDry run complete. No data written."))
+            return
+
+        created_ids: list[int] = []
+        with transaction.atomic(), reversion.create_revision():
+            reversion.set_comment("copy_chants_to_master_source: issue #2038")
+            for label, qs, _ in groups:
+                group_count = 0
+                for chant in qs.iterator(chunk_size=500):
+                    chant.pk = None
+                    chant.source = master_source
+                    chant.siglum = master_source.siglum
+                    chant.folio = chant.folio[1:] if chant.folio else chant.folio
+                    chant.next_chant = None
+                    if reset_proofread:
+                        chant.manuscript_full_text_std_proofread = False
+                        chant.manuscript_full_text_proofread = False
+                        chant.volpiano_proofread = False
+                        chant.other_fields_proofread = False
+                    chant.save()
+                    created_ids.append(chant.pk)
+                    group_count += 1
+                    if group_count % 100 == 0:
+                        self.stdout.write(
+                            self.style.NOTICE(f"  {label}: {group_count} saved...")
+                        )
+                self.stdout.write(
+                    self.style.SUCCESS(f"  {label}: done ({group_count} chants)")
+                )
+
+        after_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nDone. Master source chant count: {before_count} → {after_count}"
+                f" (+{after_count - before_count})"
+            )
+        )
+        self.stdout.write(
+            f"Created IDs ({len(created_ids)} total): {created_ids}"
+        )

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -12,7 +12,20 @@ MASTER_SOURCE_ID = 1000289
 # Pre-copy chant count on the master source. Used as an idempotency guard:
 # a non-matching count means the command likely already ran and re-running would create duplicates.
 EXPECTED_MASTER_BASELINE = 19
+# Total rows the five folio ranges should yield. Drift here means the source sources have
+# changed since #2038 was scoped; the operator should investigate before copying blindly.
+EXPECTED_TOTAL = 705
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
+# Used to detect semantic folio collisions where master and the source disagree
+# on zero-padding (e.g. '89' vs '089' are the same physical page).
+LEADING_ZEROS_RE = re.compile(r"(?<!\d)0+(?=\d)")
+
+
+def _normalize_folio(folio: str | None) -> str | None:
+    """Strip leading zeros from each numeric segment so '089' and '89' compare equal."""
+    if not folio:
+        return folio
+    return LEADING_ZEROS_RE.sub("", folio)
 
 
 class Command(BaseCommand):
@@ -24,9 +37,18 @@ class Command(BaseCommand):
             action="store_true",
             help="Print per-group counts and sanity checks without writing any data.",
         )
+        parser.add_argument(
+            "--allow-drift",
+            action="store_true",
+            help=(
+                "Proceed even if total_to_copy != EXPECTED_TOTAL. "
+                "Only set this after verifying the dry-run output."
+            ),
+        )
 
     def handle(self, *args, **options) -> None:
         dry_run: bool = options["dry_run"]
+        allow_drift: bool = options["allow_drift"]
 
         try:
             master_source = Source.objects.get(id=MASTER_SOURCE_ID)
@@ -94,8 +116,8 @@ class Command(BaseCommand):
             first = qs.first()
             last = qs.last()
             bad_folios = [
-                c.folio
-                for c in qs.iterator(chunk_size=500)
+                (c.id, c.folio)
+                for c in qs.only("id", "folio").iterator(chunk_size=500)
                 if c.folio and not FOLIO_RE.match(c.folio)
             ]
             total_bad_folios += len(bad_folios)
@@ -110,15 +132,54 @@ class Command(BaseCommand):
                     f"  Last:  folio={last.folio!r}, c_sequence={last.c_sequence}"
                 )
             if bad_folios:
+                preview = ", ".join(f"#{cid}={folio!r}" for cid, folio in bad_folios[:20])
                 self.stdout.write(
                     self.style.WARNING(
-                        f"  WARNING: {len(bad_folios)} folio(s) fail regex: {bad_folios[:20]}"
+                        f"  WARNING: {len(bad_folios)} folio(s) fail regex: {preview}"
                     )
                 )
             else:
                 self.stdout.write("  Folio format: OK")
 
         self.stdout.write(f"\nTotal to copy: {total_to_copy}")
+
+        # Key on the normalized folio so '89' and '089' (same physical page,
+        # different zero-padding conventions) compare as equal.
+        existing_master_slots: dict[tuple[str | None, int | None], tuple[int, str | None]] = {
+            (_normalize_folio(folio), c_seq): (cid, folio)
+            for cid, folio, c_seq in Chant.objects.filter(
+                source_id=MASTER_SOURCE_ID
+            ).values_list("id", "folio", "c_sequence")
+        }
+        collisions: list[tuple[int, str | None, int, str | None, int | None]] = []
+        for _, qs in groups:
+            for src_id, src_folio, c_seq in qs.values_list("id", "folio", "c_sequence"):
+                new_folio = src_folio[1:] if src_folio else src_folio
+                match = existing_master_slots.get((_normalize_folio(new_folio), c_seq))
+                if match is not None:
+                    master_cid, master_folio = match
+                    collisions.append((master_cid, master_folio, src_id, new_folio, c_seq))
+
+        if collisions:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"\nCOLLISION: {len(collisions)} (folio, c_sequence) slot(s) "
+                    f"on master {MASTER_SOURCE_ID} are already occupied:"
+                )
+            )
+            for master_id, master_folio, src_id, src_folio_stripped, c_seq in collisions[:20]:
+                marker = "" if master_folio == src_folio_stripped else "  [folio normalized]"
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"  master #{master_id} (folio={master_folio!r}) "
+                        f"<-> src #{src_id} (folio={src_folio_stripped!r}) "
+                        f"@ c_sequence={c_seq}{marker}"
+                    )
+                )
+            if len(collisions) > 20:
+                self.stdout.write(
+                    self.style.ERROR(f"  ... and {len(collisions) - 20} more")
+                )
 
         if dry_run:
             self.stdout.write(self.style.SUCCESS("\nDry run complete. No data written."))
@@ -130,6 +191,23 @@ class Command(BaseCommand):
                 f"baseline is {EXPECTED_MASTER_BASELINE}. This command is one-shot; "
                 "re-running it would create duplicates. If the current state is "
                 f"intentional, update EXPECTED_MASTER_BASELINE in {__name__}."
+            )
+
+        if collisions:
+            raise CommandError(
+                f"Refusing to copy: {len(collisions)} (folio, c_sequence) slot(s) "
+                f"already occupied on master {MASTER_SOURCE_ID}. Two chants cannot "
+                "share the same page address. Re-run with --dry-run to see the full "
+                "list, then resolve manually (delete the existing rows, narrow the "
+                "source ranges, or coordinate with whoever added them)."
+            )
+
+        if total_to_copy != EXPECTED_TOTAL and not allow_drift:
+            raise CommandError(
+                f"Refusing to copy: total_to_copy={total_to_copy} but EXPECTED_TOTAL="
+                f"{EXPECTED_TOTAL}. The source sources may have drifted since #2038 "
+                "was scoped. Re-run with --dry-run to inspect; pass --allow-drift "
+                "to proceed once you've confirmed the new count is correct."
             )
 
         if total_bad_folios:
@@ -147,9 +225,6 @@ class Command(BaseCommand):
                     proofread_by_pks = [u.pk for u in chant.proofread_by.all()]
                     chant.pk = None
                     chant.source = master_source
-                    # Master's siglum is None; clobbering keeps new copies
-                    # consistent with the existing master-source chants.
-                    chant.siglum = master_source.siglum
                     chant.folio = chant.folio[1:] if chant.folio else chant.folio
                     chant.next_chant = None
                     chant.save()

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -302,7 +302,7 @@ class Command(BaseCommand):
             raise CommandError(
                 f"Refusing to copy: {len(cross_collisions)} (folio, c_sequence) slot(s) "
                 "would be occupied by multiple copies. The source folio ranges "
-                "overlap, and two copies cannot share the same page address on master."
+                "overlap, and two copies cannot share the same page address on master. "
                 "Re-run with --dry-run to see the full list, then narrow the source "
                 "ranges or coordinate with the data owner before re-running."
             )

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -9,11 +9,14 @@ import reversion  # type: ignore[import-untyped]
 from main_app.models import Chant, Source
 
 MASTER_SOURCE_ID = 1000289
+# Pre-copy chant count on the master source. Used as an idempotency guard:
+# a non-matching count means the command likely already ran and re-running would create duplicates.
+EXPECTED_MASTER_BASELINE = 19
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
 
 
 class Command(BaseCommand):
-    help = "Copy ~710 chants from student-work sources into the Kaiatonsera master source (issue #2038)."
+    help = "Copy 705 chants from student-work sources into the Kaiatonsera master source (issue #2038)."
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -76,8 +79,6 @@ class Command(BaseCommand):
         ]
 
         before_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
-        # master_source.siglum is None as of writing, matching the 19 existing
-        # master-source chants — copying it through preserves that consistency.
         self.stdout.write(
             self.style.NOTICE(
                 f"Master source {MASTER_SOURCE_ID} | siglum: {master_source.siglum!r}"
@@ -123,6 +124,14 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("\nDry run complete. No data written."))
             return
 
+        if before_count != EXPECTED_MASTER_BASELINE:
+            raise CommandError(
+                f"Master source has {before_count} chants but the expected pre-copy "
+                f"baseline is {EXPECTED_MASTER_BASELINE}. This command is one-shot; "
+                "re-running it would create duplicates. If the current state is "
+                f"intentional, update EXPECTED_MASTER_BASELINE in {__name__}."
+            )
+
         if total_bad_folios:
             raise CommandError(
                 f"Refusing to copy: {total_bad_folios} folio(s) do not match "
@@ -134,16 +143,14 @@ class Command(BaseCommand):
             reversion.set_comment("copy_chants_to_master_source: issue #2038")
             for label, qs in groups:
                 group_count = 0
-                for chant in qs.iterator(chunk_size=500):
-                    proofread_by_pks = list(
-                        chant.proofread_by.values_list("pk", flat=True)
-                    )
+                for chant in qs.prefetch_related("proofread_by"):
+                    proofread_by_pks = [u.pk for u in chant.proofread_by.all()]
                     chant.pk = None
                     chant.source = master_source
+                    # Master's siglum is None; clobbering keeps new copies
+                    # consistent with the existing master-source chants.
                     chant.siglum = master_source.siglum
                     chant.folio = chant.folio[1:] if chant.folio else chant.folio
-                    # OneToOne to self with a uniqueness constraint; cleared so
-                    # populate_next_chant_fields can rebuild the chain on the master.
                     chant.next_chant = None
                     chant.save()
                     if proofread_by_pks:

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -18,9 +18,6 @@ import reversion  # type: ignore[import-untyped]
 from main_app.models import Chant, Source
 
 MASTER_SOURCE_ID = 1000289
-# Total rows the five folio ranges should yield. Drift here may mean the source
-# sources have changed since #2038 was scoped
-EXPECTED_TOTAL = 709
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
 
 # (id, folio, c_sequence) tuples materialized from each group's queryset.
@@ -33,8 +30,10 @@ CrossCollision = tuple[str | None, int | None, list[int]]
 
 class Command(BaseCommand):
     help = (
-        f"Copy {EXPECTED_TOTAL} chants from student-work sources into the "
-        "Kaiatonsera master source (issue #2038)."
+        "Copy chants from student-work sources into the Kaiatonsera master "
+        "source (issue #2038). Pass --expected-total to declare the number "
+        "of rows you expect to copy; the command refuses to run if the "
+        "actual total differs."
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
@@ -44,17 +43,24 @@ class Command(BaseCommand):
             help="Print per-group counts and sanity checks without writing any data.",
         )
         parser.add_argument(
-            "--allow-drift",
-            action="store_true",
+            "--expected-total",
+            type=int,
+            default=None,
             help=(
-                "Proceed even if total_to_copy != EXPECTED_TOTAL. "
-                "Only set this after verifying the dry-run output."
+                "Required for non-dry-run invocations. The command refuses "
+                "to copy if the actual row count differs from this value. "
+                "Run with --dry-run first to discover the current count."
             ),
         )
 
     def handle(self, *args, **options) -> None:
         dry_run: bool = options["dry_run"]
-        allow_drift: bool = options["allow_drift"]
+        expected_total: int | None = options["expected_total"]
+        if not dry_run and expected_total is None:
+            raise CommandError(
+                "--expected-total is required for non-dry-run invocations. "
+                "Run with --dry-run first to discover the current count."
+            )
 
         master_source = self._get_master_source()
         groups = self._build_groups()
@@ -77,7 +83,7 @@ class Command(BaseCommand):
             cross_collisions=cross_collisions,
             total_to_copy=total_to_copy,
             total_bad_folios=total_bad_folios,
-            allow_drift=allow_drift,
+            expected_total=expected_total,
         )
 
         before_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
@@ -280,7 +286,7 @@ class Command(BaseCommand):
         cross_collisions: list[CrossCollision],
         total_to_copy: int,
         total_bad_folios: int,
-        allow_drift: bool,
+        expected_total: int | None,
     ) -> None:
         if collisions:
             raise CommandError(
@@ -298,13 +304,12 @@ class Command(BaseCommand):
                 "Re-run with --dry-run to see the full list, then narrow the source "
                 "ranges or coordinate with the data owner before re-running."
             )
-        if total_to_copy != EXPECTED_TOTAL and not allow_drift:
+        if expected_total is not None and total_to_copy != expected_total:
             raise CommandError(
-                f"Refusing to copy: total_to_copy={total_to_copy} but EXPECTED_TOTAL="
-                f"{EXPECTED_TOTAL}. The source sources may have drifted since #2038 "
-                "was scoped. Re-run with --dry-run to inspect, then either pass "
-                "--allow-drift for this one-time run, or bump EXPECTED_TOTAL in code "
-                f"to {total_to_copy} if the new count is the new normal."
+                f"Refusing to copy: total_to_copy={total_to_copy} but "
+                f"--expected-total={expected_total}. Re-run with --dry-run "
+                "to inspect, then either correct your --expected-total or "
+                "fix the source data."
             )
         if total_bad_folios:
             raise CommandError(
@@ -334,10 +339,6 @@ class Command(BaseCommand):
                 chant.next_chant = None
                 chant.save()
                 if proofread_by_pks:
-                    # add() rather than set(): set() consults the prefetch
-                    # cache, which still points at the original chant's pk,
-                    # so it decides the M2M is already in place and inserts
-                    # nothing into the new row's through table.
                     chant.proofread_by.add(*proofread_by_pks)
                 copies[orig_id] = chant
                 original_next[orig_id] = orig_next_id

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -11,10 +11,10 @@ from main_app.models import Chant, Source
 MASTER_SOURCE_ID = 1000289
 # Pre-copy chant count on the master source. Used as an idempotency guard:
 # a non-matching count means the command likely already ran and re-running would create duplicates.
-EXPECTED_MASTER_BASELINE = 19
+EXPECTED_MASTER_BASELINE = 22
 # Total rows the five folio ranges should yield. Drift here means the source sources have
 # changed since #2038 was scoped; the operator should investigate before copying blindly.
-EXPECTED_TOTAL = 705
+EXPECTED_TOTAL = 709
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
 # Used to detect semantic folio collisions where master and the source disagree
 # on zero-padding (e.g. '89' vs '089' are the same physical page).
@@ -29,7 +29,7 @@ def _normalize_folio(folio: str | None) -> str | None:
 
 
 class Command(BaseCommand):
-    help = "Copy 705 chants from student-work sources into the Kaiatonsera master source (issue #2038)."
+    help = f"Copy {EXPECTED_TOTAL} chants from student-work sources into the Kaiatonsera master source (issue #2038)."
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -334,7 +334,11 @@ class Command(BaseCommand):
                 chant.next_chant = None
                 chant.save()
                 if proofread_by_pks:
-                    chant.proofread_by.set(proofread_by_pks)
+                    # add() rather than set(): set() consults the prefetch
+                    # cache, which still points at the original chant's pk,
+                    # so it decides the M2M is already in place and inserts
+                    # nothing into the new row's through table.
+                    chant.proofread_by.add(*proofread_by_pks)
                 copies[orig_id] = chant
                 original_next[orig_id] = orig_next_id
                 group_count += 1

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -1,22 +1,41 @@
+"""Copy chants from student-work sources into the Kaiatonsera master source.
+
+One-shot command for issue #2038. `--dry-run` previews counts and sanity
+checks; the real run is guarded against drift, malformed folios, and slot
+collisions before any write.
+"""
+
 import argparse
 import re
+from collections.abc import Callable, Sequence
+from typing import Any
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 import reversion  # type: ignore[import-untyped]
 
 from main_app.models import Chant, Source
 
 MASTER_SOURCE_ID = 1000289
-# Total rows the five folio ranges should yield. Drift here means the source sources have
-# changed since #2038 was scoped; the operator should investigate before copying blindly.
+# Total rows the five folio ranges should yield. Drift here may mean the source
+# sources have changed since #2038 was scoped
 EXPECTED_TOTAL = 709
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
 
+# (id, folio, c_sequence) tuples materialized from each group's queryset.
+ScannedRow = tuple[int, str | None, int | None]
+LabeledGroup = tuple[str, QuerySet[Chant]]
+LabeledRows = tuple[str, list[ScannedRow]]
+MasterCollision = tuple[int, int, str | None, int | None]
+CrossCollision = tuple[str | None, int | None, list[int]]
+
 
 class Command(BaseCommand):
-    help = f"Copy {EXPECTED_TOTAL} chants from student-work sources into the Kaiatonsera master source (issue #2038)."
+    help = (
+        f"Copy {EXPECTED_TOTAL} chants from student-work sources into the "
+        "Kaiatonsera master source (issue #2038)."
+    )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -37,14 +56,55 @@ class Command(BaseCommand):
         dry_run: bool = options["dry_run"]
         allow_drift: bool = options["allow_drift"]
 
+        master_source = self._get_master_source()
+        groups = self._build_groups()
+        self._print_master_summary(master_source)
+
+        group_rows, total_to_copy, total_bad_folios = self._scan_groups(groups)
+        self.stdout.write(f"\nTotal to copy: {total_to_copy}")
+
+        collisions, cross_collisions = self._detect_collisions(group_rows)
+        self._print_collisions(collisions, cross_collisions, dry_run=dry_run)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS("\nDry run complete. No data written.")
+            )
+            return
+
+        self._enforce_guards(
+            collisions=collisions,
+            cross_collisions=cross_collisions,
+            total_to_copy=total_to_copy,
+            total_bad_folios=total_bad_folios,
+            allow_drift=allow_drift,
+        )
+
+        before_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        with transaction.atomic(), reversion.create_revision():
+            reversion.set_comment("copy_chants_to_master_source: issue #2038")
+            self._copy_groups(groups, master_source)
+        after_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nDone. Master source chant count: {before_count} → {after_count}"
+            )
+        )
+
+    # -------------------- setup --------------------
+
+    def _get_master_source(self) -> Source:
         try:
-            master_source = Source.objects.get(id=MASTER_SOURCE_ID)
+            return Source.objects.get(id=MASTER_SOURCE_ID)
         except Source.DoesNotExist as e:
             raise CommandError(f"Master source {MASTER_SOURCE_ID} not found.") from e
 
-        groups = [
+    def _build_groups(self) -> list[LabeledGroup]:
+        # Five (source, folio range) groups specified by Debra in issue #2038.
+        return [
             (
-                "Group 1: source 1000260, K005–K028 (~200)",
+                "Group 1: source 1000260, K005–K028",
                 Chant.objects.filter(
                     source_id=1000260,
                     folio__gte="K005",
@@ -52,7 +112,7 @@ class Command(BaseCommand):
                 ).order_by("folio", "c_sequence"),
             ),
             (
-                "Group 2: source 1000208, K039–K053 (~155)",
+                "Group 2: source 1000208, K039–K053",
                 Chant.objects.filter(
                     source_id=1000208,
                     folio__gte="K039",
@@ -60,7 +120,7 @@ class Command(BaseCommand):
                 ).order_by("folio", "c_sequence"),
             ),
             (
-                "Group 3: source 1000260, K053(seq≥5)–K067 (~140)",
+                "Group 3: source 1000260, K053(seq≥5)–K067",
                 Chant.objects.filter(source_id=1000260)
                 .filter(
                     Q(folio="K053", c_sequence__gte=5)
@@ -69,7 +129,7 @@ class Command(BaseCommand):
                 .order_by("folio", "c_sequence"),
             ),
             (
-                "Group 4: source 1000260, K082–K090 (~80)",
+                "Group 4: source 1000260, K082–K090",
                 Chant.objects.filter(
                     source_id=1000260,
                     folio__gte="K082",
@@ -77,7 +137,7 @@ class Command(BaseCommand):
                 ).order_by("folio", "c_sequence"),
             ),
             (
-                "Group 5: source 1000208, K090(seq≥7)–K108 (~135)",
+                "Group 5: source 1000208, K090(seq≥7)–K108",
                 Chant.objects.filter(source_id=1000208)
                 .filter(
                     Q(folio="K090", c_sequence__gte=7)
@@ -87,6 +147,7 @@ class Command(BaseCommand):
             ),
         ]
 
+    def _print_master_summary(self, master_source: Source) -> None:
         before_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
         self.stdout.write(
             self.style.NOTICE(
@@ -95,77 +156,132 @@ class Command(BaseCommand):
             )
         )
 
+    # -------------------- scan --------------------
+
+    def _scan_groups(
+        self, groups: list[LabeledGroup]
+    ) -> tuple[list[LabeledRows], int, int]:
+        # Materialize each group's (id, folio, c_sequence) rows once so the
+        # count, sample rows, bad-folio scan, and collision scan all reuse it.
+        group_rows: list[LabeledRows] = []
         total_to_copy = 0
         total_bad_folios = 0
-        # Materialize each group's (id, folio, c_sequence) rows once so the
-        # count / first / last / bad-folio scan / collision scan all reuse it.
-        group_rows: list[tuple[str, list[tuple[int, str | None, int | None]]]] = []
         for label, qs in groups:
-            rows = list(qs.values_list("id", "folio", "c_sequence"))
-            group_rows.append((label, rows))
-            count = len(rows)
-            total_to_copy += count
+            rows: list[ScannedRow] = list(qs.values_list("id", "folio", "c_sequence"))
             bad_folios = [
-                (cid, folio) for cid, folio, _ in rows
+                (cid, folio)
+                for cid, folio, _ in rows
                 if folio and not FOLIO_RE.match(folio)
             ]
+            group_rows.append((label, rows))
+            total_to_copy += len(rows)
             total_bad_folios += len(bad_folios)
-            self.stdout.write(f"\n{label}")
-            self.stdout.write(f"  Count: {count}")
-            if rows:
-                _, first_folio, first_seq = rows[0]
-                _, last_folio, last_seq = rows[-1]
-                self.stdout.write(f"  First: folio={first_folio!r}, c_sequence={first_seq}")
-                self.stdout.write(f"  Last:  folio={last_folio!r}, c_sequence={last_seq}")
-            if bad_folios:
-                preview = ", ".join(f"#{cid}={folio!r}" for cid, folio in bad_folios[:20])
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"  WARNING: {len(bad_folios)} folio(s) fail regex: {preview}"
-                    )
+            self._print_group_summary(label, rows, bad_folios)
+        return group_rows, total_to_copy, total_bad_folios
+
+    def _print_group_summary(
+        self,
+        label: str,
+        rows: list[ScannedRow],
+        bad_folios: list[tuple[int, str]],
+    ) -> None:
+        self.stdout.write(f"\n{label}")
+        self.stdout.write(f"  Count: {len(rows)}")
+        if rows:
+            _, first_folio, first_seq = rows[0]
+            _, last_folio, last_seq = rows[-1]
+            self.stdout.write(f"  First: folio={first_folio!r}, c_sequence={first_seq}")
+            self.stdout.write(f"  Last:  folio={last_folio!r}, c_sequence={last_seq}")
+        if bad_folios:
+            preview = ", ".join(f"#{cid}={folio!r}" for cid, folio in bad_folios[:20])
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  WARNING: {len(bad_folios)} folio(s) fail regex: {preview}"
                 )
-            else:
-                self.stdout.write("  Folio format: OK")
+            )
+        else:
+            self.stdout.write("  Folio format: OK")
 
-        self.stdout.write(f"\nTotal to copy: {total_to_copy}")
+    # -------------------- collisions --------------------
 
+    def _detect_collisions(
+        self, group_rows: list[LabeledRows]
+    ) -> tuple[list[MasterCollision], list[CrossCollision]]:
         existing_master_slots: dict[tuple[str | None, int | None], int] = {
             (folio, c_seq): cid
             for cid, folio, c_seq in Chant.objects.filter(
                 source_id=MASTER_SOURCE_ID
             ).values_list("id", "folio", "c_sequence")
         }
-        collisions: list[tuple[int, int, str | None, int | None]] = []
+        # collisions: a copy would land on a slot already taken by an existing master row.
+        # cross_collisions: two copies want the same slot.
+        collisions: list[MasterCollision] = []
+        copy_slots: dict[tuple[str | None, int | None], list[int]] = {}
         for _, rows in group_rows:
             for src_id, src_folio, c_seq in rows:
                 new_folio = src_folio[1:] if src_folio else src_folio
                 master_id = existing_master_slots.get((new_folio, c_seq))
                 if master_id is not None:
                     collisions.append((master_id, src_id, new_folio, c_seq))
+                copy_slots.setdefault((new_folio, c_seq), []).append(src_id)
+        cross_collisions: list[CrossCollision] = [
+            (folio, c_seq, ids)
+            for (folio, c_seq), ids in copy_slots.items()
+            if len(ids) > 1
+        ]
+        return collisions, cross_collisions
+
+    def _print_collisions(
+        self,
+        collisions: list[MasterCollision],
+        cross_collisions: list[CrossCollision],
+        *,
+        dry_run: bool,
+    ) -> None:
+        def _emit(
+            header: str,
+            rows: Sequence[Any],
+            format_row: Callable[[Any], str],
+        ) -> None:
+            self.stdout.write(self.style.ERROR(header))
+            preview = rows if dry_run else rows[:20]
+            for row in preview:
+                self.stdout.write(self.style.ERROR(format_row(row)))
+            if not dry_run and len(rows) > 20:
+                self.stdout.write(self.style.ERROR(f"  ... and {len(rows) - 20} more"))
 
         if collisions:
-            self.stdout.write(
-                self.style.ERROR(
-                    f"\nCOLLISION: {len(collisions)} (folio, c_sequence) slot(s) "
-                    f"on master {MASTER_SOURCE_ID} are already occupied:"
-                )
+            _emit(
+                f"\nCOLLISION: {len(collisions)} (folio, c_sequence) slot(s) "
+                f"on master {MASTER_SOURCE_ID} are already occupied:",
+                collisions,
+                lambda r: (
+                    f"  master #{r[0]} <-> src #{r[1]} "
+                    f"@ folio={r[2]!r}, c_sequence={r[3]}"
+                ),
             )
-            for master_id, src_id, folio, c_seq in collisions[:20]:
-                self.stdout.write(
-                    self.style.ERROR(
-                        f"  master #{master_id} <-> src #{src_id} "
-                        f"@ folio={folio!r}, c_sequence={c_seq}"
-                    )
-                )
-            if len(collisions) > 20:
-                self.stdout.write(
-                    self.style.ERROR(f"  ... and {len(collisions) - 20} more")
-                )
+        if cross_collisions:
+            _emit(
+                f"\nCROSS-COPY COLLISION: {len(cross_collisions)} (folio, c_sequence) "
+                "slot(s) would be occupied by multiple copies:",
+                cross_collisions,
+                lambda r: (
+                    f"  src chants [{', '.join(f'#{cid}' for cid in r[2])}] "
+                    f"-> folio={r[0]!r}, c_sequence={r[1]}"
+                ),
+            )
 
-        if dry_run:
-            self.stdout.write(self.style.SUCCESS("\nDry run complete. No data written."))
-            return
+    # -------------------- guards --------------------
 
+    def _enforce_guards(
+        self,
+        *,
+        collisions: list[MasterCollision],
+        cross_collisions: list[CrossCollision],
+        total_to_copy: int,
+        total_bad_folios: int,
+        allow_drift: bool,
+    ) -> None:
         if collisions:
             raise CommandError(
                 f"Refusing to copy: {len(collisions)} (folio, c_sequence) slot(s) "
@@ -174,15 +290,22 @@ class Command(BaseCommand):
                 "list, then resolve manually (delete the existing rows, narrow the "
                 "source ranges, or coordinate with whoever added them)."
             )
-
+        if cross_collisions:
+            raise CommandError(
+                f"Refusing to copy: {len(cross_collisions)} (folio, c_sequence) slot(s) "
+                "would be occupied by multiple copies. The source folio ranges "
+                "overlap, and two copies cannot share the same page address on master."
+                "Re-run with --dry-run to see the full list, then narrow the source "
+                "ranges or coordinate with the data owner before re-running."
+            )
         if total_to_copy != EXPECTED_TOTAL and not allow_drift:
             raise CommandError(
                 f"Refusing to copy: total_to_copy={total_to_copy} but EXPECTED_TOTAL="
                 f"{EXPECTED_TOTAL}. The source sources may have drifted since #2038 "
-                "was scoped. Re-run with --dry-run to inspect; pass --allow-drift "
-                "to proceed once you've confirmed the new count is correct."
+                "was scoped. Re-run with --dry-run to inspect, then either pass "
+                "--allow-drift for this one-time run, or bump EXPECTED_TOTAL in code "
+                f"to {total_to_copy} if the new count is the new normal."
             )
-
         if total_bad_folios:
             raise CommandError(
                 f"Refusing to copy: {total_bad_folios} folio(s) do not match "
@@ -190,59 +313,50 @@ class Command(BaseCommand):
                 "then fix the source data or adjust the filter."
             )
 
-        with transaction.atomic(), reversion.create_revision():
-            reversion.set_comment("copy_chants_to_master_source: issue #2038")
-            # Two passes so each copy's next_chant can point at the copy of its
-            # original's successor. The OneToOneField forbids two rows sharing a
-            # target, not "copying a pointer" — distinct PKs may target distinct
-            # PKs without conflict.
-            copies: dict[int, Chant] = {}
-            original_next: dict[int, int | None] = {}
+    # -------------------- copy --------------------
 
-            for label, qs in groups:
-                group_count = 0
-                for chant in qs.prefetch_related("proofread_by"):
-                    orig_id = chant.id
-                    orig_next_id = chant.next_chant_id
-                    proofread_by_pks = [u.pk for u in chant.proofread_by.all()]
-                    chant.pk = None
-                    chant.source = master_source
-                    chant.folio = chant.folio[1:] if chant.folio else chant.folio
-                    chant.next_chant = None
-                    chant.save()
-                    if proofread_by_pks:
-                        chant.proofread_by.set(proofread_by_pks)
-                    copies[orig_id] = chant
-                    original_next[orig_id] = orig_next_id
-                    group_count += 1
-                self.stdout.write(
-                    self.style.SUCCESS(f"  {label}: done ({group_count} chants)")
-                )
-
-            # Rebind next_chant on each copy to the copy of its original's
-            # successor; at group boundaries the successor is outside the
-            # copy range and next_chant stays None. Use save(update_fields=...)
-            # rather than QuerySet.update() so django-reversion captures the
-            # rebound state — .update() bypasses signals and would leave the
-            # revision frozen at pass-1's next_chant=None.
-            # Why this matters: views/chant.py reads chant.next_chant directly
-            # via select_related for feast-boundary detection. Chant.get_next_chant
-            # itself recomputes from folio + c_sequence and ignores the FK.
-            rebound = 0
-            for orig_id, copy in copies.items():
-                succ = original_next[orig_id]
-                if succ is not None and succ in copies:
-                    copy.next_chant = copies[succ]
-                    copy.save(update_fields=["next_chant"])
-                    rebound += 1
+    def _copy_groups(self, groups: list[LabeledGroup], master_source: Source) -> None:
+        # Pass 1: insert copies with next_chant=None, remembering each original's
+        # successor id for pass 2. The OneToOneField on next_chant forbids two rows
+        # sharing a target, not copying a pointer — distinct PKs may target distinct
+        # PKs without conflict.
+        copies: dict[int, Chant] = {}
+        original_next: dict[int, int | None] = {}
+        for label, qs in groups:
+            group_count = 0
+            for chant in qs.prefetch_related("proofread_by"):
+                orig_id = chant.id
+                orig_next_id = chant.next_chant_id
+                proofread_by_pks = [u.pk for u in chant.proofread_by.all()]
+                chant.pk = None
+                chant.source = master_source
+                chant.folio = chant.folio[1:] if chant.folio else chant.folio
+                chant.next_chant = None
+                chant.save()
+                if proofread_by_pks:
+                    chant.proofread_by.set(proofread_by_pks)
+                copies[orig_id] = chant
+                original_next[orig_id] = orig_next_id
+                group_count += 1
             self.stdout.write(
-                self.style.SUCCESS(f"Rebound next_chant on {rebound} copies.")
+                self.style.SUCCESS(f"  {label}: done ({group_count} chants)")
             )
 
-        after_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        # Pass 2: rebind next_chant to the copy of each original's successor. At
+        # group boundaries the successor is outside the copy range and next_chant
+        # stays None. save(update_fields=...) is required so django-reversion
+        # captures the rebind — QuerySet.update bypasses signals and would leave
+        # the revision frozen at pass-1's next_chant=None.
+        # views/chant.py reads chant.next_chant directly via select_related for
+        # feast-boundary detection; Chant.get_next_chant itself recomputes from
+        # folio + c_sequence and ignores the FK.
+        rebound = 0
+        for orig_id, copy in copies.items():
+            succ = original_next[orig_id]
+            if succ is not None and succ in copies:
+                copy.next_chant = copies[succ]
+                copy.save(update_fields=["next_chant"])
+                rebound += 1
         self.stdout.write(
-            self.style.SUCCESS(
-                f"\nDone. Master source chant count: {before_count} → {after_count}"
-                f" (+{after_count - before_count})"
-            )
+            self.style.SUCCESS(f"Rebound next_chant on {rebound} copies.")
         )

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -9,23 +9,10 @@ import reversion  # type: ignore[import-untyped]
 from main_app.models import Chant, Source
 
 MASTER_SOURCE_ID = 1000289
-# Pre-copy chant count on the master source. Used as an idempotency guard:
-# a non-matching count means the command likely already ran and re-running would create duplicates.
-EXPECTED_MASTER_BASELINE = 22
 # Total rows the five folio ranges should yield. Drift here means the source sources have
 # changed since #2038 was scoped; the operator should investigate before copying blindly.
 EXPECTED_TOTAL = 709
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
-# Used to detect semantic folio collisions where master and the source disagree
-# on zero-padding (e.g. '89' vs '089' are the same physical page).
-LEADING_ZEROS_RE = re.compile(r"(?<!\d)0+(?=\d)")
-
-
-def _normalize_folio(folio: str | None) -> str | None:
-    """Strip leading zeros from each numeric segment so '089' and '89' compare equal."""
-    if not folio:
-        return folio
-    return LEADING_ZEROS_RE.sub("", folio)
 
 
 class Command(BaseCommand):
@@ -110,27 +97,26 @@ class Command(BaseCommand):
 
         total_to_copy = 0
         total_bad_folios = 0
+        # Materialize each group's (id, folio, c_sequence) rows once so the
+        # count / first / last / bad-folio scan / collision scan all reuse it.
+        group_rows: list[tuple[str, list[tuple[int, str | None, int | None]]]] = []
         for label, qs in groups:
-            count = qs.count()
+            rows = list(qs.values_list("id", "folio", "c_sequence"))
+            group_rows.append((label, rows))
+            count = len(rows)
             total_to_copy += count
-            first = qs.first()
-            last = qs.last()
             bad_folios = [
-                (c.id, c.folio)
-                for c in qs.only("id", "folio").iterator(chunk_size=500)
-                if c.folio and not FOLIO_RE.match(c.folio)
+                (cid, folio) for cid, folio, _ in rows
+                if folio and not FOLIO_RE.match(folio)
             ]
             total_bad_folios += len(bad_folios)
             self.stdout.write(f"\n{label}")
             self.stdout.write(f"  Count: {count}")
-            if first:
-                self.stdout.write(
-                    f"  First: folio={first.folio!r}, c_sequence={first.c_sequence}"
-                )
-            if last:
-                self.stdout.write(
-                    f"  Last:  folio={last.folio!r}, c_sequence={last.c_sequence}"
-                )
+            if rows:
+                _, first_folio, first_seq = rows[0]
+                _, last_folio, last_seq = rows[-1]
+                self.stdout.write(f"  First: folio={first_folio!r}, c_sequence={first_seq}")
+                self.stdout.write(f"  Last:  folio={last_folio!r}, c_sequence={last_seq}")
             if bad_folios:
                 preview = ", ".join(f"#{cid}={folio!r}" for cid, folio in bad_folios[:20])
                 self.stdout.write(
@@ -143,22 +129,19 @@ class Command(BaseCommand):
 
         self.stdout.write(f"\nTotal to copy: {total_to_copy}")
 
-        # Key on the normalized folio so '89' and '089' (same physical page,
-        # different zero-padding conventions) compare as equal.
-        existing_master_slots: dict[tuple[str | None, int | None], tuple[int, str | None]] = {
-            (_normalize_folio(folio), c_seq): (cid, folio)
+        existing_master_slots: dict[tuple[str | None, int | None], int] = {
+            (folio, c_seq): cid
             for cid, folio, c_seq in Chant.objects.filter(
                 source_id=MASTER_SOURCE_ID
             ).values_list("id", "folio", "c_sequence")
         }
-        collisions: list[tuple[int, str | None, int, str | None, int | None]] = []
-        for _, qs in groups:
-            for src_id, src_folio, c_seq in qs.values_list("id", "folio", "c_sequence"):
+        collisions: list[tuple[int, int, str | None, int | None]] = []
+        for _, rows in group_rows:
+            for src_id, src_folio, c_seq in rows:
                 new_folio = src_folio[1:] if src_folio else src_folio
-                match = existing_master_slots.get((_normalize_folio(new_folio), c_seq))
-                if match is not None:
-                    master_cid, master_folio = match
-                    collisions.append((master_cid, master_folio, src_id, new_folio, c_seq))
+                master_id = existing_master_slots.get((new_folio, c_seq))
+                if master_id is not None:
+                    collisions.append((master_id, src_id, new_folio, c_seq))
 
         if collisions:
             self.stdout.write(
@@ -167,13 +150,11 @@ class Command(BaseCommand):
                     f"on master {MASTER_SOURCE_ID} are already occupied:"
                 )
             )
-            for master_id, master_folio, src_id, src_folio_stripped, c_seq in collisions[:20]:
-                marker = "" if master_folio == src_folio_stripped else "  [folio normalized]"
+            for master_id, src_id, folio, c_seq in collisions[:20]:
                 self.stdout.write(
                     self.style.ERROR(
-                        f"  master #{master_id} (folio={master_folio!r}) "
-                        f"<-> src #{src_id} (folio={src_folio_stripped!r}) "
-                        f"@ c_sequence={c_seq}{marker}"
+                        f"  master #{master_id} <-> src #{src_id} "
+                        f"@ folio={folio!r}, c_sequence={c_seq}"
                     )
                 )
             if len(collisions) > 20:
@@ -184,14 +165,6 @@ class Command(BaseCommand):
         if dry_run:
             self.stdout.write(self.style.SUCCESS("\nDry run complete. No data written."))
             return
-
-        if before_count != EXPECTED_MASTER_BASELINE:
-            raise CommandError(
-                f"Master source has {before_count} chants but the expected pre-copy "
-                f"baseline is {EXPECTED_MASTER_BASELINE}. This command is one-shot; "
-                "re-running it would create duplicates. If the current state is "
-                f"intentional, update EXPECTED_MASTER_BASELINE in {__name__}."
-            )
 
         if collisions:
             raise CommandError(
@@ -223,7 +196,7 @@ class Command(BaseCommand):
             # original's successor. The OneToOneField forbids two rows sharing a
             # target, not "copying a pointer" — distinct PKs may target distinct
             # PKs without conflict.
-            original_to_copy: dict[int, int] = {}
+            copies: dict[int, Chant] = {}
             original_next: dict[int, int | None] = {}
 
             for label, qs in groups:
@@ -239,25 +212,28 @@ class Command(BaseCommand):
                     chant.save()
                     if proofread_by_pks:
                         chant.proofread_by.set(proofread_by_pks)
-                    original_to_copy[orig_id] = chant.pk
+                    copies[orig_id] = chant
                     original_next[orig_id] = orig_next_id
                     group_count += 1
                 self.stdout.write(
                     self.style.SUCCESS(f"  {label}: done ({group_count} chants)")
                 )
 
-            # Rebind next_chant on each copy to point at the copy of its
-            # original's successor. At group boundaries the successor is outside
-            # the copy range and the copy's next_chant stays None — display
-            # falls back to Chant.get_next_chant, which recomputes lazily from
-            # folio + c_sequence and ignores the persisted FK.
+            # Rebind next_chant on each copy to the copy of its original's
+            # successor; at group boundaries the successor is outside the
+            # copy range and next_chant stays None. Use save(update_fields=...)
+            # rather than QuerySet.update() so django-reversion captures the
+            # rebound state — .update() bypasses signals and would leave the
+            # revision frozen at pass-1's next_chant=None.
+            # Why this matters: views/chant.py reads chant.next_chant directly
+            # via select_related for feast-boundary detection. Chant.get_next_chant
+            # itself recomputes from folio + c_sequence and ignores the FK.
             rebound = 0
-            for orig_id, copy_id in original_to_copy.items():
+            for orig_id, copy in copies.items():
                 succ = original_next[orig_id]
-                if succ is not None and succ in original_to_copy:
-                    Chant.objects.filter(pk=copy_id).update(
-                        next_chant_id=original_to_copy[succ]
-                    )
+                if succ is not None and succ in copies:
+                    copy.next_chant = copies[succ]
+                    copy.save(update_fields=["next_chant"])
                     rebound += 1
             self.stdout.write(
                 self.style.SUCCESS(f"Rebound next_chant on {rebound} copies.")

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -219,9 +219,18 @@ class Command(BaseCommand):
 
         with transaction.atomic(), reversion.create_revision():
             reversion.set_comment("copy_chants_to_master_source: issue #2038")
+            # Two passes so each copy's next_chant can point at the copy of its
+            # original's successor. The OneToOneField forbids two rows sharing a
+            # target, not "copying a pointer" — distinct PKs may target distinct
+            # PKs without conflict.
+            original_to_copy: dict[int, int] = {}
+            original_next: dict[int, int | None] = {}
+
             for label, qs in groups:
                 group_count = 0
                 for chant in qs.prefetch_related("proofread_by"):
+                    orig_id = chant.id
+                    orig_next_id = chant.next_chant_id
                     proofread_by_pks = [u.pk for u in chant.proofread_by.all()]
                     chant.pk = None
                     chant.source = master_source
@@ -230,10 +239,29 @@ class Command(BaseCommand):
                     chant.save()
                     if proofread_by_pks:
                         chant.proofread_by.set(proofread_by_pks)
+                    original_to_copy[orig_id] = chant.pk
+                    original_next[orig_id] = orig_next_id
                     group_count += 1
                 self.stdout.write(
                     self.style.SUCCESS(f"  {label}: done ({group_count} chants)")
                 )
+
+            # Rebind next_chant on each copy to point at the copy of its
+            # original's successor. At group boundaries the successor is outside
+            # the copy range and the copy's next_chant stays None — display
+            # falls back to Chant.get_next_chant, which recomputes lazily from
+            # folio + c_sequence and ignores the persisted FK.
+            rebound = 0
+            for orig_id, copy_id in original_to_copy.items():
+                succ = original_next[orig_id]
+                if succ is not None and succ in original_to_copy:
+                    Chant.objects.filter(pk=copy_id).update(
+                        next_chant_id=original_to_copy[succ]
+                    )
+                    rebound += 1
+            self.stdout.write(
+                self.style.SUCCESS(f"Rebound next_chant on {rebound} copies.")
+            )
 
         after_count = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
         self.stdout.write(

--- a/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/management/commands/copy_chants_to_master_source.py
@@ -18,6 +18,8 @@ import reversion  # type: ignore[import-untyped]
 from main_app.models import Chant, Source
 
 MASTER_SOURCE_ID = 1000289
+STUDENT_SOURCE_260 = 1000260
+STUDENT_SOURCE_208 = 1000208
 FOLIO_RE = re.compile(r"^K\d{3}[A-Za-z]?$")
 
 # (id, folio, c_sequence) tuples materialized from each group's queryset.
@@ -112,7 +114,7 @@ class Command(BaseCommand):
             (
                 "Group 1: source 1000260, K005–K028",
                 Chant.objects.filter(
-                    source_id=1000260,
+                    source_id=STUDENT_SOURCE_260,
                     folio__gte="K005",
                     folio__lt="K029",
                 ).order_by("folio", "c_sequence"),
@@ -120,14 +122,14 @@ class Command(BaseCommand):
             (
                 "Group 2: source 1000208, K039–K053",
                 Chant.objects.filter(
-                    source_id=1000208,
+                    source_id=STUDENT_SOURCE_208,
                     folio__gte="K039",
                     folio__lt="K054",
                 ).order_by("folio", "c_sequence"),
             ),
             (
                 "Group 3: source 1000260, K053(seq≥5)–K067",
-                Chant.objects.filter(source_id=1000260)
+                Chant.objects.filter(source_id=STUDENT_SOURCE_260)
                 .filter(
                     Q(folio="K053", c_sequence__gte=5)
                     | Q(folio__gt="K053", folio__lt="K068")
@@ -137,14 +139,14 @@ class Command(BaseCommand):
             (
                 "Group 4: source 1000260, K082–K090",
                 Chant.objects.filter(
-                    source_id=1000260,
+                    source_id=STUDENT_SOURCE_260,
                     folio__gte="K082",
                     folio__lt="K091",
                 ).order_by("folio", "c_sequence"),
             ),
             (
                 "Group 5: source 1000208, K090(seq≥7)–K108",
-                Chant.objects.filter(source_id=1000208)
+                Chant.objects.filter(source_id=STUDENT_SOURCE_208)
                 .filter(
                     Q(folio="K090", c_sequence__gte=7)
                     | Q(folio__gt="K090", folio__lt="K109")

--- a/django/cantusdb_project/main_app/tests/test_copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/tests/test_copy_chants_to_master_source.py
@@ -198,10 +198,11 @@ class CopyChantToMasterSourceTest(TestCase):
             call_command(COMMAND, expected_total=total, stdout=out)
 
         self.assertEqual(Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before)
-        # Offending slot must appear in the pre-guard output under the
-        # COLLISION header — substring "005" alone is too loose.
+        # The collision listing uses the stripped folio, so "folio='005'" only
+        # appears in the COLLISION line. The per-group summary prints the
+        # original "folio='K005'", which would match a looser "005" assertion.
         self.assertIn("COLLISION", out.getvalue())
-        self.assertIn("005", out.getvalue())
+        self.assertIn("folio='005'", out.getvalue())
 
     def test_cross_copy_collision_blocks(self) -> None:
         # Groups 2 and 3 overlap at K053 seq 5:

--- a/django/cantusdb_project/main_app/tests/test_copy_chants_to_master_source.py
+++ b/django/cantusdb_project/main_app/tests/test_copy_chants_to_master_source.py
@@ -1,0 +1,271 @@
+"""Tests for the copy_chants_to_master_source management command.
+
+The command copies chants from two student-work sources (1000260, 1000208)
+into the Kaiatonsera master source (1000289), stripping the leading 'K' from
+each folio. Five (source, folio range) groups are defined in the command; see
+_build_groups in the command file for the canonical definitions.
+"""
+
+import io
+from dataclasses import dataclass
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from main_app.management.commands.copy_chants_to_master_source import (
+    MASTER_SOURCE_ID,
+    STUDENT_SOURCE_208,
+    STUDENT_SOURCE_260,
+)
+from main_app.models import Chant, Source
+from main_app.tests.make_fakes import (
+    make_fake_chant,
+    make_fake_feast,
+    make_fake_genre,
+    make_fake_service,
+    make_fake_source,
+    make_fake_user,
+)
+from users.models import User
+
+COMMAND = "copy_chants_to_master_source"
+
+
+@dataclass
+class Fixture:
+    chant_a: Chant
+    chant_b: Chant
+    proofread_user: User
+    total: int
+
+
+class CopyChantToMasterSourceTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.feast = make_fake_feast()
+        cls.genre = make_fake_genre()
+        cls.service = make_fake_service()
+        cls.master = make_fake_source(id=MASTER_SOURCE_ID)
+        cls.src_260 = make_fake_source(id=STUDENT_SOURCE_260)
+        cls.src_208 = make_fake_source(id=STUDENT_SOURCE_208)
+
+    def _shared(self) -> dict:
+        return dict(feast=self.feast, genre=self.genre, service=self.service)
+
+    def _run(self, **kwargs) -> io.StringIO:
+        out = io.StringIO()
+        call_command(COMMAND, stdout=out, **kwargs)
+        return out
+
+    def _build_full_fixture(self) -> Fixture:
+        """Build the full multi-group fixture used by the happy-path tests.
+
+        Group 1 contains a two-chant next_chant chain with proofread_by on the
+        tail. Groups 2–5 each get one boundary-pinned exemplar. The total chant
+        count is derived from the created list, so adding or removing a chant
+        here doesn't require updating a hardcoded number elsewhere.
+        """
+        shared = self._shared()
+        created: list[Chant] = []
+
+        # Group 1 (src_260, K005–K028). chant_b is built before chant_a because
+        # chant_a.next_chant=chant_b needs the target row to exist first.
+        chant_b = make_fake_chant(
+            source=self.src_260, folio="K005", c_sequence=2, **shared
+        )
+        created.append(chant_b)
+        proofread_user = make_fake_user()
+        chant_b.proofread_by.add(proofread_user)
+
+        chant_a = make_fake_chant(
+            source=self.src_260,
+            folio="K005",
+            c_sequence=1,
+            next_chant=chant_b,
+            **shared,
+        )
+        created.append(chant_a)
+        created.append(
+            make_fake_chant(source=self.src_260, folio="K010", c_sequence=1, **shared)
+        )
+
+        # Group 2 (src_208, K039–K053)
+        created.append(
+            make_fake_chant(source=self.src_208, folio="K039", c_sequence=1, **shared)
+        )
+        # Group 3 (src_260, K053 seq≥5–K067)
+        created.append(
+            make_fake_chant(source=self.src_260, folio="K053", c_sequence=5, **shared)
+        )
+        # Group 4 (src_260, K082–K090)
+        created.append(
+            make_fake_chant(source=self.src_260, folio="K082", c_sequence=1, **shared)
+        )
+        # Group 5 (src_208, K090 seq≥7–K108)
+        created.append(
+            make_fake_chant(source=self.src_208, folio="K090", c_sequence=7, **shared)
+        )
+
+        return Fixture(
+            chant_a=chant_a,
+            chant_b=chant_b,
+            proofread_user=proofread_user,
+            total=len(created),
+        )
+
+    def _build_one_per_group(self) -> int:
+        """Minimal fixture: one boundary chant per group. Returns chant count."""
+        shared = self._shared()
+        chants = [
+            make_fake_chant(source=self.src_260, folio="K005", c_sequence=1, **shared),
+            make_fake_chant(source=self.src_208, folio="K039", c_sequence=1, **shared),
+            make_fake_chant(source=self.src_260, folio="K053", c_sequence=5, **shared),
+            make_fake_chant(source=self.src_260, folio="K082", c_sequence=1, **shared),
+            make_fake_chant(source=self.src_208, folio="K090", c_sequence=7, **shared),
+        ]
+        return len(chants)
+
+    # ---------------- happy path and existing guard coverage ----------------
+
+    def test_happy_path_copies_and_transforms(self) -> None:
+        fix = self._build_full_fixture()
+        before = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+
+        self._run(expected_total=fix.total)
+
+        orig_b_pk = fix.chant_b.pk
+        fix.chant_a.refresh_from_db()
+        fix.chant_b.refresh_from_db()
+        self.assertEqual(fix.chant_a.source_id, STUDENT_SOURCE_260)
+        self.assertEqual(fix.chant_a.folio, "K005")
+        self.assertEqual(fix.chant_a.next_chant_id, fix.chant_b.pk)
+
+        self.assertEqual(
+            Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before + fix.total
+        )
+
+        copy_b = Chant.objects.get(source_id=MASTER_SOURCE_ID, folio="005", c_sequence=2)
+        self.assertNotEqual(copy_b.pk, orig_b_pk)
+        self.assertEqual(copy_b.source_id, MASTER_SOURCE_ID)
+        self.assertEqual(copy_b.folio, "005")
+        # Guards against the prefetch-cache regression fixed in commit c31732a0:
+        # .set() reads the prefetch cache and skips the insert — must be .add().
+        self.assertIn(fix.proofread_user, copy_b.proofread_by.all())
+
+        # next_chant must rebind to the copy of chant_b, not the original donor row.
+        copy_a = Chant.objects.get(source_id=MASTER_SOURCE_ID, folio="005", c_sequence=1)
+        self.assertEqual(copy_a.next_chant_id, copy_b.pk)
+
+        # copy_b is the tail of the chain — its next_chant stays None.
+        self.assertIsNone(copy_b.next_chant_id)
+
+    def test_dry_run_writes_nothing(self) -> None:
+        self._build_full_fixture()
+        before = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+
+        # --dry-run must not require --expected-total.
+        self._run(dry_run=True)
+
+        self.assertEqual(Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before)
+
+    def test_expected_total_mismatch_blocks(self) -> None:
+        fix = self._build_full_fixture()
+        before = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+
+        with self.assertRaises(CommandError):
+            self._run(expected_total=fix.total + 1)
+        self.assertEqual(Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before)
+
+        with self.assertRaisesRegex(CommandError, "--expected-total is required"):
+            self._run()
+
+        self._run(expected_total=fix.total)
+        self.assertEqual(
+            Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before + fix.total
+        )
+
+    def test_master_collision_blocks(self) -> None:
+        shared = self._shared()
+        # Pre-seed the master slot that Group 1's K005/1 chant would map to.
+        make_fake_chant(source=self.master, folio="005", c_sequence=1, **shared)
+        total = self._build_one_per_group()
+
+        before = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        out = io.StringIO()
+        with self.assertRaises(CommandError):
+            call_command(COMMAND, expected_total=total, stdout=out)
+
+        self.assertEqual(Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before)
+        # Offending slot must appear in the pre-guard output under the
+        # COLLISION header — substring "005" alone is too loose.
+        self.assertIn("COLLISION", out.getvalue())
+        self.assertIn("005", out.getvalue())
+
+    def test_cross_copy_collision_blocks(self) -> None:
+        # Groups 2 and 3 overlap at K053 seq 5:
+        #   Group 2 (src_208): folio >= K039, < K054 — includes K053
+        #   Group 3 (src_260): folio = K053, c_seq >= 5
+        # Both strip K → master slot (053, 5).
+        shared = self._shared()
+        created = [
+            make_fake_chant(source=self.src_208, folio="K053", c_sequence=5, **shared),
+            make_fake_chant(source=self.src_260, folio="K053", c_sequence=5, **shared),
+            make_fake_chant(source=self.src_260, folio="K005", c_sequence=1, **shared),
+            make_fake_chant(source=self.src_260, folio="K082", c_sequence=1, **shared),
+            make_fake_chant(source=self.src_208, folio="K090", c_sequence=7, **shared),
+        ]
+        total = len(created)
+
+        before = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        with self.assertRaises(CommandError):
+            self._run(expected_total=total)
+        self.assertEqual(Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before)
+
+    # ---------------- guards not covered by the original tests ----------------
+
+    def test_bad_folio_blocks(self) -> None:
+        # "K00Z" lies in Group 1's range (K005 <= K00Z < K029) but fails the
+        # ^K\d{3}[A-Za-z]?$ regex (only two digits after K). Expected_total
+        # matches so the bad-folio guard is the one that fires.
+        shared = self._shared()
+        make_fake_chant(source=self.src_260, folio="K00Z", c_sequence=1, **shared)
+
+        before = Chant.objects.filter(source_id=MASTER_SOURCE_ID).count()
+        with self.assertRaisesRegex(CommandError, r"do not match"):
+            self._run(expected_total=1)
+        self.assertEqual(Chant.objects.filter(source_id=MASTER_SOURCE_ID).count(), before)
+
+    def test_master_source_not_found_blocks(self) -> None:
+        # Drop the master source; the lookup at the top of handle() should fail
+        # before any writes happen. --expected-total is passed only to satisfy
+        # the earlier required-flag check.
+        Source.objects.filter(id=MASTER_SOURCE_ID).delete()
+
+        with self.assertRaisesRegex(CommandError, "Master source"):
+            self._run(expected_total=0)
+
+    def test_next_chant_at_group_boundary_stays_none(self) -> None:
+        # Chant Y lives on src_260 at folio "K003", outside Group 1's range
+        # (K005–K028). Chant X is inside Group 1 and points to Y. After copy,
+        # X_copy.next_chant must be None because Y was never copied.
+        shared = self._shared()
+        chant_y = make_fake_chant(
+            source=self.src_260, folio="K003", c_sequence=1, **shared
+        )
+        chant_x = make_fake_chant(
+            source=self.src_260,
+            folio="K005",
+            c_sequence=1,
+            next_chant=chant_y,
+            **shared,
+        )
+
+        self._run(expected_total=1)
+
+        copy_x = Chant.objects.get(source_id=MASTER_SOURCE_ID, folio="005", c_sequence=1)
+        self.assertIsNone(copy_x.next_chant_id)
+        # Original X still points at Y; the original chain is untouched.
+        chant_x.refresh_from_db()
+        self.assertEqual(chant_x.next_chant_id, chant_y.pk)


### PR DESCRIPTION
## Summary

Adds a one-shot management command `copy_chants_to_master_source` that copies 709 chants from two student-work sources (`1000260`, `1000208`) into the Kaiatonsera master source (`1000289`) so this summer's Mount Allison lab students can proofread them alongside the existing master-source records.

Closes #2038.

## What it copies

Per Debra's request in the issue, five folio ranges across two sources:

| Group | Source  | Folios                          | Count |
| ----- | ------- | ------------------------------- | ----- |
| 1     | 1000260 | K005–K028                       | 200   |
| 2     | 1000208 | K039–K053                       | 155   |
| 3     | 1000260 | K053 (seq ≥ 5) – K067           | 140   |
| 4     | 1000260 | K082–K090                       | 80    |
| 5     | 1000208 | K090 (seq ≥ 7) – K108           | 134   |
| **Total** |     |                                 | **709** |

Originals on the source sources are **not** deleted (issue requirement).

## Per-chant transformations

For each copied chant:
- New PK (so the original row is left untouched).
- `source` rebound to `1000289`.
- `folio` has its leading `K` stripped (`K053` → `053`) — answers question A from the issue.
- `next_chant` is rebound in a second pass to the copy of the original's successor when that successor is also in the copy range; at group boundaries it stays `None`. (The chant detail view reads `chant.next_chant` directly via `select_related` for feast-boundary detection; `Chant.get_next_chant` itself recomputes from folio + c_sequence and ignores the FK.)
- `proofread_by` M2M is preserved.