### PR TITLE
Add tests for password reset and pagination

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views/test_auth.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_auth.py
@@ -2,8 +2,12 @@
 Tests for views in views/auth.py
 """
 
-from django.test import TestCase
+from django.contrib.auth.tokens import default_token_generator
+from django.core import mail
+from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 from django.contrib.auth import get_user_model
 
 
@@ -40,3 +44,60 @@ class ChangePasswordViewTest(TestCase):
         self.assertEqual(
             response_2.status_code, 200
         )  # if login failed, status code will be 302
+
+
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+class PasswordResetViewsTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create(email="reset@test.com")
+        self.user.set_password("oldpass")
+        self.user.save()
+
+    def test_reset_password_form_renders(self):
+        response = self.client.get(reverse("reset_password"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "registration/reset_password.html")
+
+    def test_reset_password_sends_email(self):
+        response = self.client.post(
+            reverse("reset_password"), {"email": "reset@test.com"}
+        )
+        self.assertRedirects(response, "/reset-password-sent/")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("reset", mail.outbox[0].subject.lower())
+        self.assertIn("reset@test.com", mail.outbox[0].to)
+
+    def test_reset_password_confirm_completes(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = default_token_generator.make_token(self.user)
+
+        # Django redirects to …/set-password/ on valid token; follow to land there
+        confirm_response = self.client.get(
+            reverse("reset_password_confirm", kwargs={"uidb64": uid, "token": token}),
+            follow=True,
+        )
+        self.assertEqual(confirm_response.status_code, 200)
+
+        set_password_url = confirm_response.wsgi_request.path
+        post_response = self.client.post(
+            set_password_url,
+            {"new_password1": "newpass123!", "new_password2": "newpass123!"},
+        )
+        self.assertRedirects(post_response, "/reset-password-complete/")
+
+        self.assertTrue(
+            self.client.login(email="reset@test.com", password="newpass123!")
+        )
+        self.assertFalse(self.client.login(email="reset@test.com", password="oldpass"))
+
+    def test_reset_password_invalid_token(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        response = self.client.get(
+            reverse(
+                "reset_password_confirm",
+                kwargs={"uidb64": uid, "token": "invalid-token"},
+            ),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context.get("validlink", False))

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -27,7 +27,7 @@ from main_app.tests.make_fakes import (
 from main_app.tests.test_functions import mock_requests_get
 from main_app.tests.mixins import CustomAccessTestMixin
 from main_app.models import Chant, Source, Feast, Service
-from main_app.views.chant import get_feast_selector_options
+from main_app.views.chant import get_feast_selector_options, ChantSearchView, ChantSearchMSView
 
 
 # Create a Faker instance with locale set to Latin
@@ -2061,6 +2061,34 @@ class ChantSearchViewTest(CustomAccessTestMixin, TestCase):
             response, f'<a href="{image_link}" target="_blank">Image</a>', html=True
         )
 
+    def test_pagination(self):
+        paginate_by = ChantSearchView.paginate_by
+        full_pages = 2
+        source = make_fake_source(published=True)
+        for _ in range(paginate_by * full_pages):
+            make_fake_chant(source=source)
+
+        for page_num in range(1, full_pages + 1):
+            response = self.client.get(reverse("chant-search"), {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["chants"]), paginate_by)
+
+        overflow = random.randint(1, paginate_by - 1)
+        for _ in range(overflow):
+            make_fake_chant(source=source)
+
+        response = self.client.get(reverse("chant-search"), {"page": full_pages + 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["chants"]), overflow)
+
+        response = self.client.get(reverse("chant-search"), {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        for invalid_page in [-1, 0, "lst", full_pages + 2]:
+            response = self.client.get(reverse("chant-search"), {"page": invalid_page})
+            self.assertEqual(response.status_code, 404)
+
 
 class ChantSearchMSViewTest(ChantPermissionsTestCase):
     def test_url_and_templates(self):
@@ -3121,6 +3149,35 @@ class ChantSearchMSViewTest(ChantPermissionsTestCase):
         html = str(response.content)
         self.assertIn(image_link, html)
         self.assertIn(f'<a href="{image_link}" target="_blank">Image</a>', html)
+
+    def test_pagination(self):
+        paginate_by = ChantSearchMSView.paginate_by
+        full_pages = 2
+        source = make_fake_source(published=True)
+        for _ in range(paginate_by * full_pages):
+            make_fake_chant(source=source)
+
+        url = reverse("chant-search-ms", args=[source.id])
+        for page_num in range(1, full_pages + 1):
+            response = self.client.get(url, {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["chants"]), paginate_by)
+
+        overflow = random.randint(1, paginate_by - 1)
+        for _ in range(overflow):
+            make_fake_chant(source=source)
+
+        response = self.client.get(url, {"page": full_pages + 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["chants"]), overflow)
+
+        response = self.client.get(url, {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        for invalid_page in [-1, 0, "lst", full_pages + 2]:
+            response = self.client.get(url, {"page": invalid_page})
+            self.assertEqual(response.status_code, 404)
 
 
 @patch("requests.get", mock_requests_get)

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -779,6 +779,7 @@ class ChantSearchViewTest(CustomAccessTestMixin, TestCase):
             manuscript_full_text_std_spelling=faker.sentence(),
         )
         # use the beginning part of the full text as the search term
+        random.seed(0)
         search_term = chant.manuscript_full_text_std_spelling[
             0 : random.randint(1, len(chant.manuscript_full_text_std_spelling))
         ]
@@ -2074,6 +2075,7 @@ class ChantSearchViewTest(CustomAccessTestMixin, TestCase):
             self.assertTrue(response.context["is_paginated"])
             self.assertEqual(len(response.context["chants"]), paginate_by)
 
+        random.seed(0)
         overflow = random.randint(1, paginate_by - 1)
         for _ in range(overflow):
             make_fake_chant(source=source)
@@ -3164,6 +3166,7 @@ class ChantSearchMSViewTest(ChantPermissionsTestCase):
             self.assertTrue(response.context["is_paginated"])
             self.assertEqual(len(response.context["chants"]), paginate_by)
 
+        random.seed(0)
         overflow = random.randint(1, paginate_by - 1)
         for _ in range(overflow):
             make_fake_chant(source=source)
@@ -3291,6 +3294,7 @@ class ChantCreateViewTest(CustomAccessTestMixin, TestCase):
         # post a chant with the same folio and seq
         url = reverse("chant-create", args=[source.id])
         fake_text = "this is also a fake but valid text"
+        random.seed(0)
         response = self.client.post(
             url,
             data={

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -2086,6 +2086,7 @@ class ChantSearchViewTest(CustomAccessTestMixin, TestCase):
 
         response = self.client.get(reverse("chant-search"), {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["chants"]), overflow)
 
         for invalid_page in [-1, 0, "lst", full_pages + 2]:
             response = self.client.get(reverse("chant-search"), {"page": invalid_page})
@@ -3177,6 +3178,7 @@ class ChantSearchMSViewTest(ChantPermissionsTestCase):
 
         response = self.client.get(url, {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["chants"]), overflow)
 
         for invalid_page in [-1, 0, "lst", full_pages + 2]:
             response = self.client.get(url, {"page": invalid_page})

--- a/django/cantusdb_project/main_app/tests/test_views/test_feast.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_feast.py
@@ -134,6 +134,7 @@ class FeastListViewTest(TestCase):
         # test the "last" syntax
         response = self.client.get(reverse("feast-list"), {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["feasts"]), new_feast_count - feast_count)
 
         # Test some invalid values for pages
         response = self.client.get(reverse("feast-list"), {"page": -1})

--- a/django/cantusdb_project/main_app/tests/test_views/test_feast.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_feast.py
@@ -119,6 +119,7 @@ class FeastListViewTest(TestCase):
             self.assertEqual(len(response.context["feasts"]), PAGINATE_BY)
 
         # test a little more than 2 full pages of feasts
+        random.seed(0)
         new_feast_count = feast_count + random.randint(1, PAGINATE_BY - 1)
         for i in range(new_feast_count - feast_count):
             make_fake_feast()

--- a/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
@@ -120,6 +120,7 @@ class ProofreadingOverviewViewTest(TestCase):
             self.assertTrue(response.context["is_paginated"])
             self.assertEqual(len(response.context["sources"]), paginate_by)
 
+        random.seed(0)
         overflow = random.randint(1, paginate_by - 1)
         for _ in range(overflow):
             make_fake_chant(source=make_fake_source(segment=[self.cantus_segment]))

--- a/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
@@ -1,3 +1,5 @@
+import random
+
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -6,6 +8,7 @@ from main_app.tests.make_fakes import (
     make_fake_chant,
     make_fake_segment,
 )
+from main_app.views.proofreading import ProofreadView
 from users.models import Group
 
 
@@ -106,21 +109,31 @@ class ProofreadingOverviewViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_pagination(self):
-        for i in range(60):
-            source = make_fake_source(
-                title=f"Source {i}", segment=[self.cantus_segment]
-            )
-            make_fake_chant(source=source)
+        paginate_by = ProofreadView.paginate_by
+        full_pages = 2
+        for _ in range(paginate_by * full_pages):
+            make_fake_chant(source=make_fake_source(segment=[self.cantus_segment]))
 
-        response = self.client.get(self.url, {"page": 1})
+        for page_num in range(1, full_pages + 1):
+            response = self.client.get(self.url, {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["sources"]), paginate_by)
+
+        overflow = random.randint(1, paginate_by - 1)
+        for _ in range(overflow):
+            make_fake_chant(source=make_fake_source(segment=[self.cantus_segment]))
+
+        response = self.client.get(self.url, {"page": full_pages + 1})
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("page_obj" in response.context)
-        self.assertEqual(len(response.context["sources"]), 50)
+        self.assertEqual(len(response.context["sources"]), overflow)
 
-        response2 = self.client.get(self.url, {"page": 2})
-        self.assertEqual(response2.status_code, 200)
-        self.assertTrue("page_obj" in response2.context)
-        self.assertEqual(len(response2.context["sources"]), 10)
+        response = self.client.get(self.url, {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        for invalid_page in [-1, 0, "lst", full_pages + 2]:
+            response = self.client.get(self.url, {"page": invalid_page})
+            self.assertEqual(response.status_code, 404)
 
     def test_proofreading_stats_display(self):
         source = make_fake_source(segment=[self.cantus_segment], title="Stats Source")

--- a/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
@@ -131,6 +131,7 @@ class ProofreadingOverviewViewTest(TestCase):
 
         response = self.client.get(self.url, {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["sources"]), overflow)
 
         for invalid_page in [-1, 0, "lst", full_pages + 2]:
             response = self.client.get(self.url, {"page": invalid_page})

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -2,6 +2,8 @@
 Test views in views/source.py
 """
 
+import random
+
 from faker import Faker
 from typing import Dict
 
@@ -28,6 +30,7 @@ from main_app.tests.make_fakes import (
     make_fake_user,
 )
 from main_app.tests.mixins import HTMLContentsTestMixin, CustomAccessTestMixin
+from main_app.views.source import SourceListView
 from users.models import User as UserAnnotation
 
 # Create a Faker instance with locale set to Latin
@@ -1441,6 +1444,33 @@ class SourceListViewTest(CustomAccessTestMixin, TestCase):
             self.assertEqual(
                 list(reversed(expected_source_order)), list(response_sources_reverse)
             )
+
+    def test_pagination(self):
+        paginate_by = SourceListView.paginate_by
+        full_pages = 2
+        for _ in range(paginate_by * full_pages):
+            make_fake_source(published=True)
+
+        for page_num in range(1, full_pages + 1):
+            response = self.client.get(reverse("source-list"), {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["sources"]), paginate_by)
+
+        overflow = random.randint(1, paginate_by - 1)
+        for _ in range(overflow):
+            make_fake_source(published=True)
+
+        response = self.client.get(reverse("source-list"), {"page": full_pages + 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["sources"]), overflow)
+
+        response = self.client.get(reverse("source-list"), {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        for invalid_page in [-1, 0, "lst", full_pages + 2]:
+            response = self.client.get(reverse("source-list"), {"page": invalid_page})
+            self.assertEqual(response.status_code, 404)
 
 
 class SourceAddImageLinksViewTest(CustomAccessTestMixin, TestCase):

--- a/django/cantusdb_project/main_app/tests/test_views/test_source.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_source.py
@@ -1457,6 +1457,7 @@ class SourceListViewTest(CustomAccessTestMixin, TestCase):
             self.assertTrue(response.context["is_paginated"])
             self.assertEqual(len(response.context["sources"]), paginate_by)
 
+        random.seed(0)
         overflow = random.randint(1, paginate_by - 1)
         for _ in range(overflow):
             make_fake_source(published=True)
@@ -1467,6 +1468,7 @@ class SourceListViewTest(CustomAccessTestMixin, TestCase):
 
         response = self.client.get(reverse("source-list"), {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["sources"]), overflow)
 
         for invalid_page in [-1, 0, "lst", full_pages + 2]:
             response = self.client.get(reverse("source-list"), {"page": invalid_page})

--- a/django/cantusdb_project/main_app/tests/test_views/test_user.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_user.py
@@ -84,6 +84,7 @@ class IndexerListViewTestCase(CustomAccessTestMixin, TestCase):
             self.assertTrue(response.context["is_paginated"])
             self.assertEqual(len(response.context["indexers"]), paginate_by)
 
+        random.seed(0)
         overflow = random.randint(1, paginate_by - 1)
         for _ in range(overflow):
             make_fake_source(published=True)
@@ -115,6 +116,7 @@ class UserSourceListViewTest(TestCase):
             self.assertTrue(response.context["is_paginated"])
             self.assertEqual(len(response.context["sources"]), paginate_by)
 
+        random.seed(0)
         overflow = random.randint(1, paginate_by - 1)
         for _ in range(overflow):
             make_fake_source(published=True, current_editors=[user])

--- a/django/cantusdb_project/main_app/tests/test_views/test_user.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_user.py
@@ -95,6 +95,7 @@ class IndexerListViewTestCase(CustomAccessTestMixin, TestCase):
 
         response = self.client.get(reverse("indexer-list"), {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["indexers"]), overflow)
 
         for invalid_page in [-1, 0, "lst", full_pages + 2]:
             response = self.client.get(reverse("indexer-list"), {"page": invalid_page})
@@ -127,6 +128,7 @@ class UserSourceListViewTest(TestCase):
 
         response = self.client.get(reverse("my-sources"), {"page": "last"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["sources"]), overflow)
 
         for invalid_page in [-1, 0, "lst", full_pages + 2]:
             response = self.client.get(reverse("my-sources"), {"page": invalid_page})

--- a/django/cantusdb_project/main_app/tests/test_views/test_user.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_user.py
@@ -103,6 +103,11 @@ class IndexerListViewTestCase(CustomAccessTestMixin, TestCase):
 
 
 class UserSourceListViewTest(TestCase):
+    # No setUpTestData: data is user-specific and created per test.
+    def test_unauthenticated_access(self) -> None:
+        response = self.client.get(reverse("my-sources"))
+        self.assertRedirects(response, f"/login/?next={reverse('my-sources')}")
+
     def test_pagination(self) -> None:
         paginate_by = UserSourceListView.paginate_by
         full_pages = 2

--- a/django/cantusdb_project/main_app/tests/test_views/test_user.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_user.py
@@ -1,8 +1,11 @@
+import random
+
 from django.test import TestCase
 from django.urls import reverse
 
 from main_app.tests.mixins import CustomAccessTestMixin
 from main_app.tests.make_fakes import make_fake_user, make_fake_source
+from main_app.views.user import IndexerListView, UserSourceListView
 from users.models import User as UserType
 
 
@@ -66,3 +69,63 @@ class IndexerListViewTestCase(CustomAccessTestMixin, TestCase):
         response = self.client.get(reverse("indexer-list"))
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual([self.user_with_source], response.context["indexers"])
+
+    def test_pagination(self) -> None:
+        paginate_by = IndexerListView.paginate_by
+        full_pages = 2
+        # setUpTestData already creates 1 visible indexer (user_with_source),
+        # so create paginate_by * full_pages - 1 sources to reach exactly 2 full pages.
+        for _ in range(paginate_by * full_pages - 1):
+            make_fake_source(published=True)
+
+        for page_num in range(1, full_pages + 1):
+            response = self.client.get(reverse("indexer-list"), {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["indexers"]), paginate_by)
+
+        overflow = random.randint(1, paginate_by - 1)
+        for _ in range(overflow):
+            make_fake_source(published=True)
+
+        response = self.client.get(reverse("indexer-list"), {"page": full_pages + 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["indexers"]), overflow)
+
+        response = self.client.get(reverse("indexer-list"), {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        for invalid_page in [-1, 0, "lst", full_pages + 2]:
+            response = self.client.get(reverse("indexer-list"), {"page": invalid_page})
+            self.assertEqual(response.status_code, 404)
+
+
+class UserSourceListViewTest(TestCase):
+    def test_pagination(self) -> None:
+        paginate_by = UserSourceListView.paginate_by
+        full_pages = 2
+        user = make_fake_user()
+        self.client.force_login(user)
+        for _ in range(paginate_by * full_pages):
+            make_fake_source(published=True, current_editors=[user])
+
+        for page_num in range(1, full_pages + 1):
+            response = self.client.get(reverse("my-sources"), {"page": page_num})
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context["is_paginated"])
+            self.assertEqual(len(response.context["sources"]), paginate_by)
+
+        overflow = random.randint(1, paginate_by - 1)
+        for _ in range(overflow):
+            make_fake_source(published=True, current_editors=[user])
+
+        response = self.client.get(reverse("my-sources"), {"page": full_pages + 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["sources"]), overflow)
+
+        response = self.client.get(reverse("my-sources"), {"page": "last"})
+        self.assertEqual(response.status_code, 200)
+
+        for invalid_page in [-1, 0, "lst", full_pages + 2]:
+            response = self.client.get(reverse("my-sources"), {"page": invalid_page})
+            self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
- Added password reset tests for display, email sending, complete reset flow, and invalid token handling
- Added pagination tests for 5 view classes: testing full pages, overflow, last page, and error cases

resolves #321 and #732 