### PR TITLE
Fix: improve autocomplete search behavior for holding institutions and feasts

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -627,6 +627,14 @@ class SourceEditForm(forms.ModelForm):
     )
 
 
+class ChantSearchForm(forms.Form):
+    feast = forms.ModelChoiceField(
+        queryset=Feast.objects.all(),
+        required=False,
+        widget=autocomplete.ModelSelect2(url="feast-autocomplete"),
+    )
+
+
 class SourceBrowseChantsProofreadForm(forms.Form):
     manuscript_full_text_std_proofread = forms.ChoiceField(
         label="Full text as in Source (standardized spelling) proofread",

--- a/django/cantusdb_project/main_app/templates/chant_search.html
+++ b/django/cantusdb_project/main_app/templates/chant_search.html
@@ -2,7 +2,12 @@
 {% load humanize %}
 {% load helper_tags %}
 {% block title %}<title>Search Chants | Cantus Database</title>{% endblock %}
-{% block scripts %}<script src="/static/js/chant_search.js"></script>{% endblock %}
+{% block scripts %}
+{% load static %}
+<script src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+{{ search_form.media }}
+<script src="/static/js/chant_search.js"></script>
+{% endblock %}
 {% block heading %}<h3>Search Chants</h3>{% endblock %}
 {% block results_count %}
     {% if not query_empty %}{{ block.super }}{% endif %}
@@ -80,14 +85,6 @@
                    value="{{ request.GET.mode }}" />
         </div>
         <div class="form-group col-lg-3 col-sm-6 col-12">
-            <label for="feast" class="small">Feast</label>
-            <input type="text"
-                   class="form-control form-control-sm"
-                   name="feast"
-                   id="feast"
-                   value="{{ request.GET.feast }}" />
-        </div>
-        <div class="form-group col-lg-3 col-sm-6 col-12">
             <label for="position" class="small">Position</label>
             <input type="text"
                    class="form-control form-control-sm"
@@ -103,6 +100,10 @@
                 <option value="">- Any -</option>
                 <option value="true">Chants with melodies</option>
             </select>
+        </div>
+        <div class="form-group col-lg-6 col-sm-12 col-12">
+            <label for="{{ search_form.feast.id_for_label }}" class="small">Feast</label>
+            {{ search_form.feast }}
         </div>
     </div>
     {% if source %}

--- a/django/cantusdb_project/main_app/tests/test_views/test_autocomplete.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_autocomplete.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from main_app.tests.make_fakes import make_fake_century
+from main_app.tests.make_fakes import make_fake_century, make_fake_feast
 
 
 class AutocompleteViewsTest(TestCase):
@@ -31,6 +31,17 @@ class AutocompleteViewsTest(TestCase):
 
         for i in range(10):
             make_fake_century()
+
+        make_fake_feast(
+            name="Adalberti", description="Adalbert of Prague, Bishop and Martyr"
+        )
+        make_fake_feast(
+            name="Ad Mandatum", description="At the Mandatum (Foot-Washing)"
+        )
+        make_fake_feast(
+            name="Dom. Pentecostes",
+            description='Pentecost Sunday (also "Whitsunday")',
+        )
 
     def test_active_users_autocomplete(self):
         response = self.client.get(reverse("active-users-autocomplete"))
@@ -56,6 +67,28 @@ class AutocompleteViewsTest(TestCase):
         data = response.json()
         self.assertEqual(len(data["results"]), 10)
 
+    def test_feast_autocomplete(self):
+        response = self.client.get(reverse("feast-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 3)
+
+        # Searches match feast name
+        response = self.client.get(reverse("feast-autocomplete"), {"q": "Adalberti"})
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+
+        # Searches also match feast description (keyword only in description)
+        response = self.client.get(reverse("feast-autocomplete"), {"q": "Prague"})
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+
+        response = self.client.get(
+            reverse("feast-autocomplete"), {"q": "Whitsunday"}
+        )
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+
     def test_non_authenticated_user(self):
         self.client.logout()
         response = self.client.get(reverse("active-users-autocomplete"))
@@ -72,3 +105,11 @@ class AutocompleteViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["results"]), 0)
+
+        # FeastAutocomplete is intentionally public: the chant search page is
+        # reachable anonymously and uses this endpoint to populate its Select2
+        # feast widget.
+        response = self.client.get(reverse("feast-autocomplete"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 3)

--- a/django/cantusdb_project/main_app/tests/test_views/test_chant.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_chant.py
@@ -744,8 +744,7 @@ class ChantSearchViewTest(CustomAccessTestMixin, TestCase):
         source = make_fake_source(published=True)
         feast = make_fake_feast()
         chant = make_fake_chant(source=source, feast=feast)
-        search_term = get_random_search_term(feast.name)
-        response = self.client.get(reverse("chant-search"), {"feast": search_term})
+        response = self.client.get(reverse("chant-search"), {"feast": feast.id})
         context_chant_id = response.context["chants"][0].id
         self.assertEqual(chant.id, context_chant_id)
 
@@ -1732,7 +1731,7 @@ class ChantSearchViewTest(CustomAccessTestMixin, TestCase):
             "genre": genre.id,
             "cantus_id": cantus_id,
             "mode": mode,
-            "feast": feast.name,
+            "feast": feast.id,
             "position": position,
             "melodies": "true",
         }
@@ -2151,9 +2150,8 @@ class ChantSearchMSViewTest(ChantPermissionsTestCase):
         source = make_fake_source()
         feast = make_fake_feast()
         chant = make_fake_chant(source=source, feast=feast)
-        search_term = get_random_search_term(feast.name)
         response = self.client.get(
-            reverse("chant-search-ms", args=[source.id]), {"feast": search_term}
+            reverse("chant-search-ms", args=[source.id]), {"feast": feast.id}
         )
         context_chant_id = response.context["chants"][0].id
         self.assertEqual(chant.id, context_chant_id)
@@ -2800,7 +2798,7 @@ class ChantSearchMSViewTest(ChantPermissionsTestCase):
             "genre": genre.id,
             "cantus_id": cantus_id,
             "mode": mode,
-            "feast": feast.name,
+            "feast": feast.id,
             "position": position,
             "melodies": "true",
         }

--- a/django/cantusdb_project/main_app/views/autocomplete.py
+++ b/django/cantusdb_project/main_app/views/autocomplete.py
@@ -133,8 +133,8 @@ class HoldingAutocomplete(autocomplete.Select2QuerySetView):
         qs = Institution.objects.all().order_by("name")
         if self.q:
             qs = qs.filter(
-                Q(name__istartswith=self.q)
-                | Q(siglum__istartswith=self.q)
+                Q(name__icontains=self.q)
+                | Q(siglum__icontains=self.q)
                 | Q(city__istartswith=self.q)
                 | Q(country__istartswith=self.q)
             )

--- a/django/cantusdb_project/main_app/views/autocomplete.py
+++ b/django/cantusdb_project/main_app/views/autocomplete.py
@@ -49,12 +49,17 @@ class CenturyAutocomplete(autocomplete.Select2QuerySetView):
 
 
 class FeastAutocomplete(autocomplete.Select2QuerySetView):
+    def get_result_label(self, result):
+        if result.description:
+            return f"{result.name} – {result.description}"
+        return result.name
+
     def get_queryset(self):
-        if not self.request.user.is_authenticated:
-            return Feast.objects.none()
         qs = Feast.objects.all().order_by("name")
         if self.q:
-            qs = qs.filter(name__icontains=self.q)
+            qs = qs.filter(
+                Q(name__icontains=self.q) | Q(description__icontains=self.q)
+            )
         return qs
 
 

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -466,8 +466,9 @@ class ChantSearchView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
         context["services"] = (
             Service.objects.all().order_by("name").values("id", "name")
         )
+        feast_param = self.request.GET.get("feast")
         context["search_form"] = ChantSearchForm(
-            initial={"feast": self.request.GET.get("feast")}
+            initial={"feast": feast_param} if feast_param and feast_param.isdigit() else {}
         )
         context["query_empty"] = False if self.request.GET else True
         context["order"] = self.request.GET.get("order")
@@ -758,6 +759,10 @@ class ChantSearchMSView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
         context["genres"] = Genre.objects.all().order_by("name").values("id", "name")
         context["services"] = (
             Service.objects.all().order_by("name").values("id", "name")
+        )
+        feast_param = self.request.GET.get("feast")
+        context["search_form"] = ChantSearchForm(
+            initial={"feast": feast_param} if feast_param and feast_param.isdigit() else {}
         )
         context["order"] = self.request.GET.get("order")
         context["sort"] = self.request.GET.get("sort")

--- a/django/cantusdb_project/main_app/views/chant.py
+++ b/django/cantusdb_project/main_app/views/chant.py
@@ -33,6 +33,7 @@ from main_app.forms import (
     ChantCreateForm,
     ChantEditForm,
     ChantEditSyllabificationForm,
+    ChantSearchForm,
 )
 from main_app.models import (
     Chant,
@@ -465,6 +466,9 @@ class ChantSearchView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
         context["services"] = (
             Service.objects.all().order_by("name").values("id", "name")
         )
+        context["search_form"] = ChantSearchForm(
+            initial={"feast": self.request.GET.get("feast")}
+        )
         context["query_empty"] = False if self.request.GET else True
         context["order"] = self.request.GET.get("order")
         context["sort"] = self.request.GET.get("sort")
@@ -595,9 +599,9 @@ class ChantSearchView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 if melodies == "true":
                     q_obj_filter &= Q(volpiano__isnull=False)
 
-            if feast := self.request.GET.get("feast"):
-                # This will match any feast whose name contains the feast parameter as a substring
-                q_obj_filter &= Q(feast__name__icontains=feast)
+            if feast_id := self.request.GET.get("feast"):
+                if feast_id.isdigit():
+                    q_obj_filter &= Q(feast_id=feast_id)
 
             # Filter the QuerySet with Q object
             chant_set = Chant.objects.filter(q_obj_filter).select_related(
@@ -831,10 +835,9 @@ class ChantSearchMSView(CustomAccessMixin, ListView):  # type: ignore[type-arg]
                 q_obj_filter &= Q(volpiano__isnull=False)
             if melodies == "false":
                 q_obj_filter &= Q(volpiano__isnull=True)
-        if feast := self.request.GET.get("feast"):
-            # This will match any feast whose name contains the feast parameter
-            # as a substring
-            q_obj_filter &= Q(feast__name__icontains=feast)
+        if feast_id := self.request.GET.get("feast"):
+            if feast_id.isdigit():
+                q_obj_filter &= Q(feast_id=feast_id)
 
         order_value = self.request.GET.get("order")
         sort_get_param: Optional[str] = self.request.GET.get("sort")


### PR DESCRIPTION
- Fixes `HoldingAutocomplete` to use icontains for institution name and siglum fields.
- Replaces the free-text feast input on the chant search page with a Select2 autocomplete.
- Extends search feast to contain description in addition to name.

resolves #1894, resolves #1978, and resolves #2019

Example for #1978 and #2019
<img width="1341" height="534" alt="Example" src="https://github.com/user-attachments/assets/153b79b5-1565-400a-bc23-6a65d443c552" />
