### PR TITLE
fix: encode spaces in image_link URLs before Django validation

### DIFF
--- a/django/cantusdb_project/main_app/forms.py
+++ b/django/cantusdb_project/main_app/forms.py
@@ -26,6 +26,7 @@ from .models import (
     Century,
     Sequence,
 )
+from .models.url_field import NormalizedURLFormField
 from .widgets import (
     TextInputWidget,
     VolpianoInputWidget,
@@ -1023,7 +1024,7 @@ class ImageLinkForm(forms.Form):
         initial = kwargs.get("initial")
         if initial:
             for folio in initial:
-                self.fields[folio] = forms.CharField(
+                self.fields[folio] = NormalizedURLFormField(
                     widget=HiddenInput(attrs={"class": "img-link-input"}),
                     required=False,
                 )

--- a/django/cantusdb_project/main_app/models/base_chant.py
+++ b/django/cantusdb_project/main_app/models/base_chant.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.contrib.auth import get_user_model
 from django.contrib.postgres.search import SearchVectorField
 
+from main_app.models.url_field import NormalizedURLField
 from main_app.models import BaseModel
 
 
@@ -53,7 +54,7 @@ class BaseChant(BaseModel):
     cantus_id = models.CharField(
         blank=True, null=True, max_length=255, db_index=True, verbose_name="cantus ID"
     )
-    image_link = models.URLField(blank=True, null=True)
+    image_link = NormalizedURLField(blank=True, null=True)
     json_info = models.JSONField(null=True, blank=True)
     marginalia = models.CharField(max_length=63, null=True, blank=True)
     service = models.ForeignKey(

--- a/django/cantusdb_project/main_app/models/source.py
+++ b/django/cantusdb_project/main_app/models/source.py
@@ -3,6 +3,7 @@ from typing import Any
 from django.db import models
 from django.contrib.auth import get_user_model
 
+from main_app.models.url_field import NormalizedURLField
 from main_app.models import BaseModel, Segment
 
 
@@ -157,7 +158,7 @@ class Source(BaseModel):
     liturgical_occasions = models.TextField(blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     selected_bibliography = models.TextField(blank=True, null=True)
-    image_link = models.URLField(
+    image_link = NormalizedURLField(
         blank=True,
         null=True,
         help_text="HTTP link to the image gallery of the source.",

--- a/django/cantusdb_project/main_app/models/url_field.py
+++ b/django/cantusdb_project/main_app/models/url_field.py
@@ -1,0 +1,41 @@
+from typing import Any, Optional
+
+from django import forms
+from django.db import models
+
+
+def _normalize(value: Optional[str]) -> Optional[str]:
+    if isinstance(value, str):
+        return value.strip().replace(" ", "%20")
+    return value
+
+
+class NormalizedURLFormField(forms.URLField):
+    """Form URLField that encodes spaces before Django's URLValidator fires."""
+
+    def to_python(self, value: Any) -> str:
+        return super().to_python(_normalize(value))
+
+
+class NormalizedURLField(models.URLField):
+    """
+    Model URLField that strips whitespace and percent-encodes spaces.
+
+    Normalizes on validation (full_clean) and on save (get_prep_value), so
+    forms, admin, management commands, and direct ORM writes all benefit.
+    """
+
+    def to_python(self, value: Any) -> Optional[str]:
+        return super().to_python(_normalize(value))
+
+    def get_prep_value(self, value: Any) -> Optional[str]:
+        return super().get_prep_value(_normalize(value))
+
+    def formfield(self, **kwargs: Any) -> Optional[forms.Field]:
+        kwargs.setdefault("form_class", NormalizedURLFormField)
+        return super().formfield(**kwargs)
+
+    def deconstruct(self) -> tuple:
+        # Report as plain URLField so makemigrations doesn't see a field change.
+        name, _, args, kwargs = super().deconstruct()
+        return name, "django.db.models.URLField", args, kwargs

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -545,3 +545,34 @@ class NormalizedURLModelFieldTest(TestCase):
 
     def test_formfield_returns_normalizing_form_field(self):
         self.assertIsInstance(self.field.formfield(), NormalizedURLFormField)
+
+
+class ImageLinkSpaceEncodingIntegrationTest(TestCase):
+    """End-to-end coverage: saving a model whose image_link
+    contains spaces must succeed and persist the URL with spaces encoded."""
+
+    def test_chant_with_spaced_image_link_saves(self) -> None:
+        # Mirrors the management-command path from #1868: a direct .save(),
+        # which BaseModel.save() routes through full_clean()/URLValidator.
+        chant = make_fake_chant()
+        chant.image_link = "https://example.com/Folio 92r.jpg"
+        chant.save()
+        chant.refresh_from_db()
+        self.assertEqual(chant.image_link, "https://example.com/Folio%2092r.jpg")
+
+    def test_source_with_spaced_image_link_saves(self) -> None:
+        source = make_fake_source()
+        source.image_link = "https://example.com/image gallery.jpg"
+        source.save()
+        source.refresh_from_db()
+        self.assertEqual(source.image_link, "https://example.com/image%20gallery.jpg")
+
+    def test_save_does_not_raise_on_spaces(self) -> None:
+        # Without the fix this raises ValidationError ("Enter a valid URL"),
+        # which is exactly the failure reported in #1868.
+        chant = make_fake_chant()
+        chant.image_link = "https://example.com/a b c.jpg"
+        try:
+            chant.save()
+        except ValidationError:
+            self.fail("Saving a chant with spaces in image_link should not raise.")

--- a/django/cantusdb_project/main_app/tests/test_functions.py
+++ b/django/cantusdb_project/main_app/tests/test_functions.py
@@ -1,10 +1,11 @@
 from typing import Union, Optional
 from unittest.mock import patch
 
-
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 import requests
 from requests.exceptions import SSLError, Timeout, HTTPError
+from main_app.models.url_field import NormalizedURLField, NormalizedURLFormField
 from main_app.models import (
     Chant,
     Source,
@@ -483,3 +484,64 @@ class CantusIndexFunctionsTest(TestCase):
                 results = get_ci_text_search("HTTPError")
             self.assertRaises(HTTPError)
             self.assertIsNone(results)
+
+
+class NormalizedURLFormFieldTest(TestCase):
+    def setUp(self):
+        self.field = NormalizedURLFormField(required=False)
+
+    def test_spaces_encoded(self):
+        result = self.field.clean(
+            "https://example.com/Folio 92r.jpg"
+        )
+        self.assertEqual(
+            result,
+            "https://example.com/Folio%2092r.jpg",
+        )
+
+    def test_already_encoded_unchanged(self):
+        url = "https://example.com/Folio%2092r.jpg"
+        self.assertEqual(self.field.clean(url), url)
+
+    def test_leading_trailing_whitespace_stripped(self):
+        result = self.field.clean("  https://example.com/image.jpg  ")
+        self.assertEqual(result, "https://example.com/image.jpg")
+
+    def test_spaces_in_query_string_encoded(self):
+        result = self.field.clean("https://example.com/search?q=some query")
+        self.assertEqual(result, "https://example.com/search?q=some%20query")
+
+    def test_invalid_url_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.field.clean("not a url at all")
+
+    def test_empty_string_returns_empty(self):
+        self.assertEqual(self.field.clean(""), "")
+
+
+class NormalizedURLModelFieldTest(TestCase):
+    """Covers code paths that skip forms (admin, management commands, ORM)."""
+
+    def setUp(self):
+        self.field = NormalizedURLField(blank=True, null=True)
+
+    def test_to_python_encodes_spaces(self):
+        self.assertEqual(
+            self.field.to_python("https://example.com/Folio 92r.jpg"),
+            "https://example.com/Folio%2092r.jpg",
+        )
+
+    def test_get_prep_value_encodes_spaces(self):
+        # Exercised on direct .save() even without full_clean().
+        self.assertEqual(
+            self.field.get_prep_value("https://example.com/Folio 92r.jpg"),
+            "https://example.com/Folio%2092r.jpg",
+        )
+
+    def test_deconstruct_reports_as_plain_urlfield(self):
+        # Keeps makemigrations from generating a no-op migration.
+        _, path, _, _ = self.field.deconstruct()
+        self.assertEqual(path, "django.db.models.URLField")
+
+    def test_formfield_returns_normalizing_form_field(self):
+        self.assertIsInstance(self.field.formfield(), NormalizedURLFormField)


### PR DESCRIPTION
- Replace spaces in the link before the validator runs
- Add unit tests for image link functionality


--------
Update: The previous form-level NormalizedURLField only normalized values that passed through the public edit forms. Django admin, management commands, and any direct ORM write still hit URLValidator with raw spaces and
failed.

Introduce NormalizedURLField (models.URLField subclass) used by Source.image_link and BaseChant.image_link. It normalizes in both to_python (full_clean) and get_prep_value (save), so every write path benefits. Its formfield() returns NormalizedURLFormField so ModelForms and admin auto-generated forms normalize user input too.

The field deconstructs back to models.URLField, so no migration is needed and the DB column is unchanged.

--------

resolves #1868