### PR TITLE
fix: order `proofread sources` by institution siglum and shelfmark as in the `browse sources`

### DIFF
--- a/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
+++ b/django/cantusdb_project/main_app/tests/test_views/test_proofreading.py
@@ -5,6 +5,7 @@ from main_app.tests.make_fakes import (
     make_fake_source,
     make_fake_chant,
     make_fake_segment,
+    make_fake_institution,
 )
 from users.models import Group
 
@@ -104,6 +105,78 @@ class ProofreadingOverviewViewTest(TestCase):
     def test_sortable_headers(self):
         response = self.client.get(self.url, {"order": "country"})
         self.assertEqual(response.status_code, 200)
+
+    def test_ordering(self):
+        """
+        Order on the Proofreading Overview should mirror Browse Sources for the
+        shared sort modes: by country (with NULL sigla coalesced to "") and by
+        institution siglum + shelfmark.
+        """
+        sources = []
+        # A source from a private collector (NULL siglum).
+        private_collector = make_fake_institution(is_private_collector=True)
+        sources.append(
+            make_fake_source(
+                holding_institution=private_collector, segment=[self.cantus_segment]
+            )
+        )
+        # A handful of other sources with distinct institutions.
+        inst = None
+        for _ in range(10):
+            inst = make_fake_institution()
+            sources.append(
+                make_fake_source(
+                    holding_institution=inst, segment=[self.cantus_segment]
+                )
+            )
+        # Another institution sharing the last one's country, to exercise
+        # within-country ordering by siglum.
+        sources.append(
+            make_fake_source(
+                holding_institution=make_fake_institution(country=inst.country),
+                segment=[self.cantus_segment],
+            )
+        )
+        # A second source under an existing institution, to exercise shelfmark
+        # as a tiebreaker.
+        sources.append(
+            make_fake_source(holding_institution=inst, segment=[self.cantus_segment])
+        )
+        for s in sources:
+            make_fake_chant(source=s)
+
+        with self.subTest("Order by country"):
+            response = self.client.get(self.url, {"order": "country"})
+            expected = sorted(
+                sources,
+                key=lambda s: (
+                    s.holding_institution.country,
+                    s.holding_institution.siglum or "",
+                    s.shelfmark,
+                ),
+            )
+            self.assertEqual(expected, list(response.context["sources"]))
+
+            response_desc = self.client.get(
+                self.url, {"order": "country", "sort": "desc"}
+            )
+            self.assertEqual(
+                list(reversed(expected)), list(response_desc.context["sources"])
+            )
+
+        with self.subTest("Order by source_siglum"):
+            # source_siglum sorts by institution siglum then shelfmark, without
+            # COALESCE — so NULL sigla (private collectors) land last in asc.
+            response = self.client.get(self.url, {"order": "source_siglum"})
+            expected = sorted(
+                sources,
+                key=lambda s: (
+                    s.holding_institution.siglum is None,
+                    s.holding_institution.siglum or "",
+                    s.shelfmark,
+                ),
+            )
+            self.assertEqual(expected, list(response.context["sources"]))
 
     def test_pagination(self):
         for i in range(60):

--- a/django/cantusdb_project/main_app/views/proofreading.py
+++ b/django/cantusdb_project/main_app/views/proofreading.py
@@ -11,6 +11,7 @@ from django.db.models import (
     When,
     Value,
 )
+from django.db.models.functions import Coalesce
 from django.views.generic import ListView
 from django.views.generic.list import MultipleObjectMixin
 from django.utils import timezone
@@ -217,44 +218,54 @@ class ProofreadView(CustomAccessMixin, ListView, MultipleObjectMixin):
         sort_param = self.request.GET.get("sort", "asc")
         sort_prefix = "-" if sort_param == "desc" else ""
 
+        # Mirror Browse Sources: coalesce NULL holding_institution__siglum to ""
+        # so private collectors sort consistently regardless of DB NULL ordering.
+        siglum_coalesced = Coalesce("holding_institution__siglum", Value(""))
+
+        if order_param == "country":
+            ordering_fields = [
+                f"{sort_prefix}holding_institution__country",
+                siglum_coalesced.desc() if sort_prefix else siglum_coalesced.asc(),
+                f"{sort_prefix}shelfmark",
+            ]
+            return queryset.order_by(*ordering_fields)
+
         # Updated sort_mapping to use annotated fields
         sort_mapping = {
-            "country": [
-                "holding_institution__country",
-                "holding_institution__city",
-                "holding_institution__name",
-                "siglum",
-            ],
             "city_institution": [
                 "holding_institution__city",
                 "holding_institution__name",
-                "siglum",
+                "holding_institution__siglum",
+                "shelfmark",
             ],
-            "source_siglum": ["siglum"],
+            "source_siglum": ["holding_institution__siglum", "shelfmark"],
             "shelfmark": [
                 "shelfmark",
                 "holding_institution__siglum",
             ],
-            "published": ["published", "siglum"],
-            "volpiano": ["num_volpiano_to_proofread", "siglum"],
-            "ms_text": ["num_ms_full_text_to_proofread", "siglum"],
+            "published": ["published", "holding_institution__siglum", "shelfmark"],
+            "volpiano": ["num_volpiano_to_proofread", "holding_institution__siglum", "shelfmark"],
+            "ms_text": ["num_ms_full_text_to_proofread", "holding_institution__siglum", "shelfmark"],
             "ms_text_std": [
                 "num_ms_full_text_std_to_proofread",
-                "siglum",
+                "holding_institution__siglum",
+                "shelfmark",
             ],
-            "other": ["num_other_fields_to_proofread", "siglum"],
+            "other": ["num_other_fields_to_proofread", "holding_institution__siglum", "shelfmark"],
             "needing_proof": [
                 "total_chants_needing_proofread",
-                "siglum",
+                "holding_institution__siglum",
+                "shelfmark",
             ],
             "total_chants": [
                 "number_of_chants",
-                "siglum",
+                "holding_institution__siglum",
+                "shelfmark",
             ],
-            "percent_complete": ["percent_complete", "siglum"],
+            "percent_complete": ["percent_complete", "holding_institution__siglum", "shelfmark"],
         }
 
-        primary_sort_fields = sort_mapping.get(order_param, sort_mapping["country"])
+        primary_sort_fields = sort_mapping.get(order_param, [])
 
         if not isinstance(primary_sort_fields, list):
             primary_sort_fields = [primary_sort_fields]
@@ -265,7 +276,8 @@ class ProofreadView(CustomAccessMixin, ListView, MultipleObjectMixin):
         if not ordering_fields:
             ordering_fields = [
                 f"{sort_prefix}holding_institution__country",
-                f"{sort_prefix}siglum",
+                siglum_coalesced.desc() if sort_prefix else siglum_coalesced.asc(),
+                f"{sort_prefix}shelfmark",
             ]
 
         return queryset.order_by(*ordering_fields)


### PR DESCRIPTION

resolves #1955