### PR TITLE
Remove static server-maintenance notice banner

### DIFF
--- a/django/cantusdb_project/templates/base.html
+++ b/django/cantusdb_project/templates/base.html
@@ -55,9 +55,6 @@
         {% block scripts %}{% endblock %}
     </head>
     <body>
-        <div class="alert alert-warning mb-0 rounded-0 text-center" role="alert">
-            <strong>SERVICE NOTICE:</strong> Server maintenance is happening on Friday, June 12. We apologize for any disruption.
-        </div>
         {% block header %}
             {% include "header/base_header.html" %}
         {% endblock %}


### PR DESCRIPTION
Removes the June 12 maintenance notification banner now that the server has been migrated.