### PR TITLE
Fix CCDB mobile layout: table overflow, sticky header, nav z-index

### DIFF
--- a/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/canadian_chant_db.html
@@ -333,7 +333,8 @@
                     </form>
                     {% if sources %}
                         {% include "page_count.html" %}
-                        <table class="table table-sm small table-bordered table-responsive ccdb-table">
+                        <div class="table-responsive">
+                        <table class="table table-sm small table-bordered ccdb-table">
                             <thead>
                                 <tr>
                                     {% sortable_header request "city_institution" "City + Holding Institution" %}
@@ -409,6 +410,7 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                        </div>
                         {% if is_paginated %}
                             <div class="row mb-2">
                                 <div class="col">{% include "pagination.html" %}</div>

--- a/django/cantusdb_project/main_app/templates/source_lists/ccdb_browse.html
+++ b/django/cantusdb_project/main_app/templates/source_lists/ccdb_browse.html
@@ -146,7 +146,8 @@
                             </form>
                             {% if sources %}
                                 {% include "page_count.html" %}
-                                <table class="table table-sm small table-bordered table-responsive ccdb-table">
+                                <div class="table-responsive">
+                                <table class="table table-sm small table-bordered ccdb-table">
                                     <thead>
                                         <tr>
                                             {% sortable_header request "city_institution" "City + Holding Institution" %}
@@ -221,6 +222,7 @@
                                         {% endfor %}
                                     </tbody>
                                 </table>
+                                </div>
                                 {% if is_paginated %}
                                     <div class="row mb-2">
                                         <div class="col">{% include "pagination.html" %}</div>

--- a/django/cantusdb_project/static/css/ccdb_style.css
+++ b/django/cantusdb_project/static/css/ccdb_style.css
@@ -81,6 +81,7 @@ main a {
 #collapsing-navbar {
     background-color: #cc3333eb;
     color: white;
+    z-index: 100;
 
     .nav-link {
         color: white !important;

--- a/django/cantusdb_project/static/css/sticky_header.css
+++ b/django/cantusdb_project/static/css/sticky_header.css
@@ -21,3 +21,12 @@
 .collapsing-navbar-show {
     transform: translateY(80px);
 }
+
+@media (max-width: 991.98px) {
+    .collapsing-navbar {
+        position: relative;
+        top: 0;
+        height: auto;
+        transform: none !important;
+    }
+}

--- a/django/cantusdb_project/templates/header/sticky_header.html
+++ b/django/cantusdb_project/templates/header/sticky_header.html
@@ -1,5 +1,5 @@
 {% load static %}
-<header id="collapsing-navbar" class="z-1 collapsing-navbar">
+<header id="collapsing-navbar" class="collapsing-navbar">
     <script src="{% static 'js/sticky_header.js' %}"></script>
     <link href="{% static 'css/sticky_header.css' %}" rel="stylesheet" />
     <nav class="navbar navbar-expand-lg">


### PR DESCRIPTION
This is marked as urgent, as Jennifer and Debra will be presenting and using the site with folks at MedRen who will likely be on mobile. They will be presenting on 7 July. 

## Summary

Three targeted mobile/responsive fixes for CCDB pages, each committed independently.

- **Table overflow on mobile** — `table-responsive` was applied directly to `<table>` elements in `canadian_chant_db.html` and `ccdb_browse.html`. Bootstrap 5 requires this class on a wrapper `<div>`; on the element itself it has no effect, leaving tables unconstrained on narrow viewports. Wrapped both tables in `<div class="table-responsive">`.

- **Sticky header mobile behavior** — On viewports < 992px, the sticky header's `position: sticky` and fixed `height: 90px` caused the hamburger-expanded nav to overlay page content with no background (the red background only covers the fixed 90px box). Added a media query to switch the header to `position: relative; height: auto` on mobile, so the expanded nav pushes content down and is fully backed by the red header background.

- **Nav dropdowns obscured by hero logo** — The sticky header had `z-index: 1` (Bootstrap's `z-1` utility, while  has  in the root stacking context. Bootstrap dropdown menus are capped by their ancestor's stacking context, so they rendered behind the hero logo. Raised  to  in  and removed the  class from the template.

## Test plan

- [ ] At 375px viewport width, navigate to  and  — tables should scroll horizontally without breaking page layout
- [ ] At mobile width, tap the hamburger button — nav links should expand in-flow (pushing content down) with full red background
- [ ] On the CCDB homepage, open any top-nav dropdown (ABOUT, SOURCES, etc.) — menu should appear above the hero banner logo, not behind it
- [ ] Verify desktop layout is unchanged (sticky slide behavior still functions at lg+ breakpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)